### PR TITLE
[backend] add health route test

### DIFF
--- a/backend/tests/app.test.ts
+++ b/backend/tests/app.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import app from '../src/app';
+
+describe('GET /health', () => {
+  it('returns ok', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add a basic health endpoint test using Supertest

## Testing
- `pnpm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492a51aba08329b6b7de2d83b9f151