### PR TITLE
[backend] add multi-file seed logic

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,6 +3,8 @@ import { PrismaClient } from '@prisma/client';
 import { seedProfiles } from './seeds/profile.ts';
 import { seedActivities } from './seeds/activities.ts';
 import { seedFormeJuridique } from './seeds/formeJuridique.ts';
+import { seedArticles } from './seeds/articles.ts';
+import { seedImmobilisations } from './seeds/immobilisations.ts';
 
 
 // … import des autres seedXxx
@@ -15,8 +17,8 @@ async function main() {
   await seedProfiles();
   await seedFormeJuridique();
   await seedActivities();
-  //await seedArticles();
-  //await seedImmobilisations();
+  await seedArticles();
+  await seedImmobilisations();
   // …
   //await seedDernier();
 }

--- a/backend/prisma/seeds/articles.ts
+++ b/backend/prisma/seeds/articles.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function seedArticles() {
+  const files = [
+    'articles_6.json',
+    'articles_7.json',
+    'articles_16.json',
+    'articles_divers.json',
+  ];
+
+  let all: any[] = [];
+  for (const file of files) {
+    const raw = fs.readFileSync(path.join(__dirname, '../seed_json', file), 'utf-8');
+    const { datas } = JSON.parse(raw);
+    if (Array.isArray(datas)) {
+      all = all.concat(datas);
+    }
+  }
+
+  await prisma.article.deleteMany();
+  for (const item of all) {
+    await prisma.article.create({ data: item as any });
+  }
+  console.log(`✅ Articles seeded (${all.length})`);
+}
+


### PR DESCRIPTION
## Summary
- expand prisma seeding logic to load articles and immobilisations from multiple JSON files
- call the new seeders from `seed.ts`

## Testing
- `pnpm turbo run lint --filter backend` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `pnpm turbo run test --filter backend` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684a8ce9d5e483299f88df2a6988dae7