### PR TITLE
[backend] add remaining seed helpers

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -5,6 +5,15 @@ import { seedActivities } from './seeds/activities.ts';
 import { seedFormeJuridique } from './seeds/formeJuridique.ts';
 import { seedArticles } from './seeds/articles.ts';
 import { seedImmobilisations } from './seeds/immobilisations.ts';
+import { seedRoF } from './seeds/rof.ts';
+import { seedSIE } from './seeds/sie.ts';
+import { seedSocietes } from './seeds/societes.ts';
+import { seedAdresses } from './seeds/adresses.ts';
+import { seedClients } from './seeds/clients.ts';
+import { seedFiscalYears } from './seeds/fiscalYears.ts';
+import { seedLogements } from './seeds/logements.ts';
+import { seedEmprunts } from './seeds/emprunts.ts';
+import { seedOperations } from './seeds/operations.ts';
 
 
 // … import des autres seedXxx

--- a/backend/prisma/seeds/adresses.ts
+++ b/backend/prisma/seeds/adresses.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface RawAdresse {
+  NumeroRue: string;
+  Adresse: string;
+  AdresseComplement: string;
+  CodePostal: string;
+  Ville: string;
+  Etat?: { prTexte: string | null; Mnem: string | null };
+  Pays: { prTexte: string; Mnem: string };
+}
+
+export async function seedAdresses() {
+  console.log('▶️ seedAdresses démarré');
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas }: { datas: any[] } = JSON.parse(raw);
+
+  const adrs: RawAdresse[] = datas.map(d => d.Adresse as RawAdresse);
+  const unique = adrs.filter((v, i, a) =>
+    a.findIndex(x =>
+      x.NumeroRue === v.NumeroRue &&
+      x.Adresse === v.Adresse &&
+      x.CodePostal === v.CodePostal &&
+      x.Ville === v.Ville
+    ) === i
+  );
+
+  await prisma.adresse.deleteMany();
+  await prisma.adresse.createMany({
+    data: unique.map(a => ({
+      numeroRue: a.NumeroRue,
+      adresse: a.Adresse,
+      adresseComplement: a.AdresseComplement || null,
+      codePostal: a.CodePostal,
+      ville: a.Ville,
+      etatTexte: a.Etat?.prTexte ?? null,
+      etatMnem: a.Etat?.Mnem ?? null,
+      paysTexte: a.Pays.prTexte,
+      paysMnem: a.Pays.Mnem,
+    })),
+    skipDuplicates: true,
+  });
+  console.log(`✅ Adresses seeded (${unique.length})`);
+}

--- a/backend/prisma/seeds/clients.ts
+++ b/backend/prisma/seeds/clients.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function seedClients() {
+  console.log('▶️ seedClients démarré');
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas }: { datas: any[] } = JSON.parse(raw);
+
+  const count = datas.length;
+
+  await prisma.client.deleteMany();
+  for (let i = 0; i < count; i++) {
+    await prisma.client.create({ data: {} });
+  }
+  console.log(`✅ Clients seeded (${count})`);
+}

--- a/backend/prisma/seeds/emprunts.ts
+++ b/backend/prisma/seeds/emprunts.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function seedEmprunts() {
+  console.log('▶️ seedEmprunts démarré');
+
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../seed_json/emprunt.json'),
+    'utf-8'
+  );
+  const { datas } = JSON.parse(raw);
+
+  const rawFY = fs.readFileSync(
+    path.join(__dirname, '../seed_json/fiscal_years.json'),
+    'utf-8'
+  );
+  const { datas: fyDatas } = JSON.parse(rawFY);
+  const anneeId = fyDatas.length > 0 ? BigInt(fyDatas[0].Oid) : BigInt(0);
+
+  const rawAct = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas: actDatas } = JSON.parse(rawAct);
+  const activityId = actDatas.length > 0 ? BigInt(actDatas[0].Oid) : BigInt(0);
+
+  await prisma.emprunt.deleteMany();
+  for (const item of datas) {
+    await prisma.emprunt.create({
+      data: {
+        id: BigInt(item.Oid),
+        prTexte: item.prTexte,
+        libelle: item.Libelle,
+        logementId: BigInt(item.Logement.Oid),
+        dateEmprunt: item.DateEmprunt ? new Date(item.DateEmprunt) : null,
+        dateEcheance: item.DateEcheance ? new Date(item.DateEcheance) : null,
+        dateConstitution: item.DateConstitution || null,
+        capitalEmprunte: item.CapitalEmprunte?.montant || 0,
+        capitalInitial: item.CapitalInitial?.montant || 0,
+        echeancesDiffere: item.EcheancesDiffere,
+        capitalRestant: item.CapitalRestant?.montant || 0,
+        capitalRestantDate: item.CapitalRestantDate
+          ? new Date(item.CapitalRestantDate)
+          : null,
+        commentairesClient: item.CommentairesClient || null,
+        partExclure: item.PartExclure,
+        partActive: item.PartActive,
+        partVentile: item.PartVentile,
+        taux: item.Taux,
+        tauxType: item.TauxType,
+        echeancesInterval: item.EcheancesInterval,
+        echeancesMontant: item.EcheancesMontant?.montant || 0,
+        assuranceIncluse: Boolean(item.AssuranceIncluse),
+        assuranceType: item.AssuranceType,
+        assuranceTaux: item.AssuranceTaux,
+        assuranceMontant: item.AssuranceMontant?.montant || 0,
+        deviseOid: item.Devise?.Oid ?? 0,
+        constitue: item.Constitue,
+        status: item.Status,
+        activityId,
+        anneeId,
+      },
+    });
+  }
+  console.log(`✅ Emprunts seeded (${datas.length})`);
+}

--- a/backend/prisma/seeds/fiscalYears.ts
+++ b/backend/prisma/seeds/fiscalYears.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function seedFiscalYears() {
+  console.log('▶️ seedFiscalYears démarré');
+
+  const rawFY = fs.readFileSync(
+    path.join(__dirname, '../seed_json/fiscal_years.json'),
+    'utf-8'
+  );
+  const { datas } = JSON.parse(rawFY);
+
+  const rawAct = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas: actDatas } = JSON.parse(rawAct);
+  const activityId = actDatas.length > 0 ? BigInt(actDatas[0].Oid) : BigInt(0);
+
+  await prisma.fiscalYear.deleteMany();
+  for (const item of datas) {
+    await prisma.fiscalYear.create({
+      data: {
+        id: BigInt(item.Oid),
+        prTexte: item.prTexte,
+        anneeFiscale: item.AnneeFiscale,
+        importCompta: item.importCompta,
+        importRCSV: item.importRCSV,
+        importDCSV: item.importDCSV,
+        repriseCompta: item.RepriseComptabilite,
+        clotureVersion: item.ClotureVersion,
+        status: item.Status,
+        debut: new Date(item.Debut),
+        fin: new Date(item.Fin),
+        integrale: item.Integrale,
+        modeAvance: item.ModeAvance,
+        step: item.Step,
+        firstYear: item.FirstYear,
+        yearCount: item.YearCount,
+        hasSIRET: item.HasSIRET,
+        dateSoumission: item.DateSoumission || null,
+        numeroOGA: item.NumeroOGA || '',
+        reductionImpotOGA: item.ReductionImpotOGA ?? 0,
+        renoncerRIOGA: item.RenoncerRIOGA ?? false,
+        reductionImpotOGALabel: item.ReductionImpotOGALabel || '',
+        commentairesClient: item.CommentairesClient || null,
+        repartitionVerifier: item.RepartitionVerifier ?? false,
+        accesOGA: item.AccesOGA ?? false,
+        canCloture: item.CanCloture ?? false,
+        validControls: item.ValidControls ?? false,
+        testimonial: item.Testimonial ?? false,
+        dernierControle: item.DernierControle
+          ? new Date(item.DernierControle)
+          : new Date(item.Fin),
+        activityId,
+      },
+    });
+  }
+  console.log(`✅ FiscalYears seeded (${datas.length})`);
+}

--- a/backend/prisma/seeds/logements.ts
+++ b/backend/prisma/seeds/logements.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function seedLogements() {
+  console.log('▶️ seedLogements démarré');
+
+  const rawData = fs.readFileSync(
+    path.join(__dirname, '../seed_json/logement.json'),
+    'utf-8'
+  );
+  const { datas } = JSON.parse(rawData);
+
+  const rawAct = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas: actDatas } = JSON.parse(rawAct);
+  const activityId = actDatas.length > 0 ? BigInt(actDatas[0].Oid) : BigInt(0);
+
+  await prisma.logement.deleteMany();
+  for (const item of datas) {
+    await prisma.logement.create({
+      data: {
+        id: BigInt(item.Oid),
+        libelle: item.Libelle,
+        prTexte: item.prTexte,
+        adresseVide: item.AdresseVide,
+        dateLocation: new Date(item.DateLocation),
+        dateVente: item.DateVente ? new Date(item.DateVente) : null,
+        causeVente: item.CauseVente,
+        dateAchat: new Date(item.DateAchat),
+        dateApport: item.DateApport ? new Date(item.DateApport) : null,
+        adresseComplete: item.AdresseComplete,
+        superficie: item.Superficie,
+        nbPieces: item.NbPieces,
+        classement: item.Classement,
+        immobilise: item.Immobilise,
+        dateModification: new Date(item.DateModification),
+        status: item.Status,
+        activityId,
+        profilOid: item.ProfilOid ? BigInt(item.ProfilOid) : null,
+      },
+    });
+  }
+  console.log(`✅ Logements seeded (${datas.length})`);
+}

--- a/backend/prisma/seeds/operations.ts
+++ b/backend/prisma/seeds/operations.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function seedOperations() {
+  console.log('▶️ seedOperations démarré');
+
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../seed_json/operation.json'),
+    'utf-8'
+  );
+  const { datas } = JSON.parse(raw);
+
+  const rawFY = fs.readFileSync(
+    path.join(__dirname, '../seed_json/fiscal_years.json'),
+    'utf-8'
+  );
+  const { datas: fyDatas } = JSON.parse(rawFY);
+  const anneeId = fyDatas.length > 0 ? BigInt(fyDatas[0].Oid) : BigInt(0);
+
+  const rawAct = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas: actDatas } = JSON.parse(rawAct);
+  const activityId = actDatas.length > 0 ? BigInt(actDatas[0].Oid) : BigInt(0);
+
+  await prisma.operation.deleteMany();
+  for (const item of datas) {
+    await prisma.operation.create({
+      data: {
+        id: BigInt(item.Oid),
+        libelle: item.Libelle,
+        date: new Date(item.Date),
+        dateEcheance: item.DateEcheance ? new Date(item.DateEcheance) : null,
+        debut: item.Debut ? new Date(item.Debut) : null,
+        fin: item.Fin ? new Date(item.Fin) : null,
+        montantTtc: item.TTC?.montant || 0,
+        montantTva: item.TVA?.montant || 0,
+        documentUrl: item.Facture || null,
+        activityId,
+        anneeId,
+        logementId: BigInt(item.Logement.Oid),
+        articleId: item.Article?.Oid ? BigInt(item.Article.Oid) : null,
+        payeurId: item.Payeur?.Oid ? BigInt(item.Payeur.Oid) : null,
+        immoId: item.Immobilisation?.Oid ? BigInt(item.Immobilisation.Oid) : null,
+      },
+    });
+  }
+  console.log(`✅ Operations seeded (${datas.length})`);
+}

--- a/backend/prisma/seeds/rof.ts
+++ b/backend/prisma/seeds/rof.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface RawRoF { Oid: number; prTexte: string | null }
+
+export async function seedRoF() {
+  console.log('▶️ seedRoF démarré');
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas }: { datas: any[] } = JSON.parse(raw);
+
+  const rofs: RawRoF[] = [];
+  for (const act of datas) {
+    if (act.ROF) rofs.push(act.ROF as RawRoF);
+    if (act.ROFTVA && act.ROFTVA.Oid !== null) rofs.push(act.ROFTVA as RawRoF);
+  }
+
+  const unique = rofs.filter((v, i, a) => a.findIndex(x => x.Oid === v.Oid) === i);
+
+  await prisma.roF.deleteMany();
+  await prisma.roF.createMany({
+    data: unique.map(r => ({ Oid: BigInt(r.Oid), prTexte: r.prTexte ?? null })),
+    skipDuplicates: true,
+  });
+  console.log(`✅ RoF seeded (${unique.length})`);
+}

--- a/backend/prisma/seeds/sie.ts
+++ b/backend/prisma/seeds/sie.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface RawSIE { Oid: number; prTexte: string; Email: string }
+
+export async function seedSIE() {
+  console.log('▶️ seedSIE démarré');
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas }: { datas: any[] } = JSON.parse(raw);
+
+  const sies = datas.map(d => d.SIE as RawSIE);
+  const unique = sies.filter((v, i, a) => a.findIndex(x => x.Oid === v.Oid) === i);
+
+  await prisma.sIE.deleteMany();
+  await prisma.sIE.createMany({
+    data: unique.map(s => ({ Oid: BigInt(s.Oid), prTexte: s.prTexte, email: s.Email })),
+    skipDuplicates: true,
+  });
+  console.log(`✅ SIE seeded (${unique.length})`);
+}

--- a/backend/prisma/seeds/societes.ts
+++ b/backend/prisma/seeds/societes.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface RawSociete { Oid: number; prTexte: string; LogoUrl: string }
+
+export async function seedSocietes() {
+  console.log('▶️ seedSocietes démarré');
+  const raw = fs.readFileSync(
+    path.join(__dirname, '../seed_json/activities.json'),
+    'utf-8'
+  );
+  const { datas }: { datas: any[] } = JSON.parse(raw);
+
+  const societes = datas.map(d => d.Societe as RawSociete);
+  const unique = societes.filter((v, i, a) => a.findIndex(x => x.Oid === v.Oid) === i);
+
+  await prisma.societe.deleteMany();
+  await prisma.societe.createMany({
+    data: unique.map(s => ({ Oid: BigInt(s.Oid), prTexte: s.prTexte, logoUrl: s.LogoUrl })),
+    skipDuplicates: true,
+  });
+  console.log(`✅ Societes seeded (${unique.length})`);
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,7 +13,8 @@
     },
     "include": [
         "src/**/*",
-        "tests/**/*"
+        "tests/**/*",
+        "prisma/**/*"
     ]
 }
   


### PR DESCRIPTION
## Summary
- load prisma directory in tsconfig
- remove eslint ignore for prisma
- implement seeds for fiscal years, logements, emprunts and operations
- register the new seed helpers in seed.ts

## Testing
- `pnpm turbo run lint --filter=backend` *(fails: fetch failed)*
- `pnpm turbo run test --filter=backend` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a9b720d88832995f35dd5ee42d5a7