### PR TITLE
[backend] add CRUD for Operation

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -7,6 +7,13 @@ class PrismaClient {
       update: jest.fn(),
       delete: jest.fn(),
     };
+    this.operation = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
     this.$disconnect = jest.fn();
   }
 }

--- a/backend/src/@types/prisma.d.ts
+++ b/backend/src/@types/prisma.d.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import '@prisma/client';
+
+declare module '@prisma/client' {
+  interface PrismaClient {
+    operation: {
+      create: (...args: any[]) => any;
+      findMany: (...args: any[]) => any;
+      findUnique: (...args: any[]) => any;
+      update: (...args: any[]) => any;
+      delete: (...args: any[]) => any;
+    };
+  }
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response } from 'express';
 import dotenv from 'dotenv';
 import { articleRouter } from './routes/article.routes';
+import { operationRouter } from './routes/operation.routes';
 import { errorHandler } from './middlewares/error.middleware';
 
 dotenv.config();
@@ -13,6 +14,7 @@ app.get('/health', (req: Request, res: Response) => {
 });
 
 app.use('/api/v1/articles', articleRouter);
+app.use('/api/v1/operations', operationRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/operation.controller.ts
+++ b/backend/src/controllers/operation.controller.ts
@@ -1,0 +1,52 @@
+import type { Request, Response, NextFunction } from 'express';
+import { OperationService } from '../services/operation.service';
+
+export const OperationController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const operation = await OperationService.create(req.body);
+      res.status(201).json(operation);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await OperationService.list());
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const operation = await OperationService.get(BigInt(req.params.id));
+      if (!operation) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(operation);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const operation = await OperationService.update(BigInt(req.params.id), req.body);
+      res.json(operation);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await OperationService.remove(BigInt(req.params.id));
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/operation.routes.ts
+++ b/backend/src/routes/operation.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { OperationController } from '../controllers/operation.controller';
+import { validate } from '../middlewares/validate.middleware';
+import {
+  createOperationSchema,
+  updateOperationSchema,
+  operationIdParam,
+} from '../schemas/operation.schema';
+
+export const operationRouter = Router();
+
+operationRouter
+  .route('/')
+  .post(validate(createOperationSchema), OperationController.create)
+  .get(OperationController.list);
+
+operationRouter
+  .route('/:id')
+  .get(validate(operationIdParam), OperationController.get)
+  .patch(validate(updateOperationSchema), OperationController.update)
+  .delete(validate(operationIdParam), OperationController.remove);

--- a/backend/src/schemas/operation.schema.ts
+++ b/backend/src/schemas/operation.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const createOperationSchema = z.object({
+  id: z.coerce.bigint(),
+  date: z.coerce.date(),
+  montantTtc: z.coerce.number(),
+  activityId: z.coerce.bigint(),
+  anneeId: z.coerce.bigint(),
+  libelle: z.string().optional(),
+  dateEcheance: z.coerce.date().optional(),
+  debut: z.coerce.date().optional(),
+  fin: z.coerce.date().optional(),
+  montantTva: z.coerce.number().optional(),
+  documentUrl: z.string().optional(),
+  logementId: z.coerce.bigint().optional(),
+  articleId: z.coerce.bigint().optional(),
+  payeurId: z.coerce.bigint().optional(),
+  immoId: z.coerce.bigint().optional(),
+});
+
+export const updateOperationSchema = createOperationSchema.partial();
+export const operationIdParam = z.object({ id: z.coerce.bigint() });

--- a/backend/src/services/operation.service.ts
+++ b/backend/src/services/operation.service.ts
@@ -1,0 +1,37 @@
+import { prisma } from '../prisma';
+
+interface PrismaWithOperation {
+  operation: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithOperation;
+
+type OperationData = Record<string, unknown>;
+
+export const OperationService = {
+  create(data: OperationData) {
+    return db.operation.create({ data });
+  },
+
+  list() {
+    return db.operation.findMany();
+  },
+
+  get(id: bigint) {
+    return db.operation.findUnique({ where: { id } });
+  },
+
+  update(id: bigint, data: Partial<OperationData>) {
+    return db.operation.update({ where: { id }, data });
+  },
+
+  remove(id: bigint) {
+    return db.operation.delete({ where: { id } });
+  },
+};

--- a/backend/tests/operation.routes.test.ts
+++ b/backend/tests/operation.routes.test.ts
@@ -1,0 +1,24 @@
+import request from 'supertest';
+import app from '../src/app';
+import { OperationService } from '../src/services/operation.service';
+
+interface OperationStub {
+  id: number;
+  libelle?: string | null;
+}
+
+jest.mock('../src/services/operation.service');
+
+const mockedService = OperationService as jest.Mocked<typeof OperationService>;
+
+describe('GET /api/v1/operations', () => {
+  it('returns operations from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: 1, libelle: 'test' } as OperationStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/operations');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Operation CRUD with service, controller, routes and schema
- augment prisma mock to support operations
- expose operations route in the app
- provide Jest tests for operations

## Testing
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_684adceda9408329962a5033bd1a4162