### PR TITLE
[backend] add Logement CRUD

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -14,6 +14,13 @@ class PrismaClient {
       update: jest.fn(),
       delete: jest.fn(),
     };
+    this.logement = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
     this.$disconnect = jest.fn();
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import dotenv from 'dotenv';
 import { articleRouter } from './routes/article.routes';
 import { operationRouter } from './routes/operation.routes';
+import { logementRouter } from './routes/logement.routes';
 import { errorHandler } from './middlewares/error.middleware';
 
 dotenv.config();
@@ -15,6 +16,7 @@ app.get('/health', (req: Request, res: Response) => {
 
 app.use('/api/v1/articles', articleRouter);
 app.use('/api/v1/operations', operationRouter);
+app.use('/api/v1/logements', logementRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/logement.controller.ts
+++ b/backend/src/controllers/logement.controller.ts
@@ -1,0 +1,52 @@
+import type { Request, Response, NextFunction } from 'express';
+import { LogementService } from '../services/logement.service';
+
+export const LogementController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const logement = await LogementService.create(req.body);
+      res.status(201).json(logement);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await LogementService.list());
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const logement = await LogementService.get(BigInt(req.params.id));
+      if (!logement) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(logement);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const logement = await LogementService.update(BigInt(req.params.id), req.body);
+      res.json(logement);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await LogementService.remove(BigInt(req.params.id));
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/logement.routes.ts
+++ b/backend/src/routes/logement.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { LogementController } from '../controllers/logement.controller';
+import { validate } from '../middlewares/validate.middleware';
+import {
+  createLogementSchema,
+  updateLogementSchema,
+  logementIdParam,
+} from '../schemas/logement.schema';
+
+export const logementRouter = Router();
+
+logementRouter
+  .route('/')
+  .post(validate(createLogementSchema), LogementController.create)
+  .get(LogementController.list);
+
+logementRouter
+  .route('/:id')
+  .get(validate(logementIdParam), LogementController.get)
+  .patch(validate(updateLogementSchema), LogementController.update)
+  .delete(validate(logementIdParam), LogementController.remove);

--- a/backend/src/schemas/logement.schema.ts
+++ b/backend/src/schemas/logement.schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const createLogementSchema = z.object({
+  id: z.coerce.bigint(),
+  profilOid: z.coerce.bigint(),
+  libelle: z.string(),
+  prTexte: z.string(),
+  adresseVide: z.boolean(),
+  dateLocation: z.coerce.date(),
+  dateVente: z.coerce.date().optional(),
+  causeVente: z.number().int(),
+  dateAchat: z.coerce.date(),
+  dateApport: z.coerce.date().optional(),
+  adresseComplete: z.string(),
+  superficie: z.number().int(),
+  nbPieces: z.number().int(),
+  classement: z.number().int(),
+  immobilise: z.boolean(),
+  dateModification: z.coerce.date(),
+  status: z.number().int(),
+  activityId: z.coerce.bigint(),
+  prixId: z.coerce.bigint().optional(),
+  prixVenteId: z.coerce.bigint().optional(),
+  adresseId: z.coerce.bigint().optional(),
+});
+
+export const updateLogementSchema = createLogementSchema.partial();
+export const logementIdParam = z.object({ id: z.coerce.bigint() });

--- a/backend/src/services/logement.service.ts
+++ b/backend/src/services/logement.service.ts
@@ -1,0 +1,37 @@
+import { prisma } from '../prisma';
+
+interface PrismaWithLogement {
+  logement: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithLogement;
+
+type LogementData = Record<string, unknown>;
+
+export const LogementService = {
+  create(data: LogementData) {
+    return db.logement.create({ data });
+  },
+
+  list() {
+    return db.logement.findMany();
+  },
+
+  get(id: bigint) {
+    return db.logement.findUnique({ where: { id } });
+  },
+
+  update(id: bigint, data: Partial<LogementData>) {
+    return db.logement.update({ where: { id }, data });
+  },
+
+  remove(id: bigint) {
+    return db.logement.delete({ where: { id } });
+  },
+};

--- a/backend/tests/logement.routes.test.ts
+++ b/backend/tests/logement.routes.test.ts
@@ -1,0 +1,24 @@
+import request from 'supertest';
+import app from '../src/app';
+import { LogementService } from '../src/services/logement.service';
+
+interface LogementStub {
+  id: number;
+  libelle: string;
+}
+
+jest.mock('../src/services/logement.service');
+
+const mockedService = LogementService as jest.Mocked<typeof LogementService>;
+
+describe('GET /api/v1/logements', () => {
+  it('returns logements from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: 1, libelle: 'Test' } as LogementStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/logements');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add CRUD routes for logement
- implement logement controller, service, schema and tests
- register new router in `app.ts`
- extend Prisma mock for logement

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`

------
https://chatgpt.com/codex/tasks/task_e_684ae09c3608832986700a2b20991499