### PR TITLE
[backend] add fiscal result service

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,7 @@ import { articleRouter } from './routes/article.routes';
 import { operationRouter } from './routes/operation.routes';
 import { activityRouter } from './routes/activity.routes';
 import { logementRouter } from './routes/logement.routes';
+import { fiscalRouter } from './routes/fiscal.routes';
 import { errorHandler } from './middlewares/error.middleware';
 
 dotenv.config();
@@ -19,6 +20,7 @@ app.use('/api/v1/articles', articleRouter);
 app.use('/api/v1/operations', operationRouter);
 app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/logements', logementRouter);
+app.use('/api/v1/fiscal', fiscalRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/fiscal.controller.ts
+++ b/backend/src/controllers/fiscal.controller.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, NextFunction } from 'express';
+import { FiscalService } from '../services/fiscal.service';
+
+export const FiscalController = {
+  async result(req: Request, res: Response, next: NextFunction) {
+    try {
+      const anneeId = BigInt(req.query.anneeId as string);
+      const activityId = BigInt(req.query.activityId as string);
+      const data = await FiscalService.compute({ anneeId, activityId });
+      res.json(data);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/fiscal.routes.ts
+++ b/backend/src/routes/fiscal.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { FiscalController } from '../controllers/fiscal.controller';
+import { validate } from '../middlewares/validate.middleware';
+import { fiscalQuerySchema } from '../schemas/fiscal.schema';
+
+export const fiscalRouter = Router();
+
+fiscalRouter.get('/result', validate(fiscalQuerySchema), FiscalController.result);

--- a/backend/src/schemas/fiscal.schema.ts
+++ b/backend/src/schemas/fiscal.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const fiscalQuerySchema = z.object({
+  query: z.object({
+    anneeId: z.coerce.bigint(),
+    activityId: z.coerce.bigint(),
+  }),
+});

--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -1,0 +1,67 @@
+import { prisma } from '../prisma';
+
+interface PrismaWithOperations {
+  operation: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    findMany: (...args: unknown[]) => Promise<any[]>;
+  };
+}
+
+const db = prisma as unknown as PrismaWithOperations;
+
+interface ComputeOptions {
+  anneeId: bigint;
+  activityId: bigint;
+}
+
+export const FiscalService = {
+  async compute({ anneeId, activityId }: ComputeOptions) {
+    const operations = await db.operation.findMany({
+      where: { anneeId, activityId },
+      include: { article: { include: { famille: true } } },
+    });
+
+    const groups = new Map<string | null, {
+      code: string | null;
+      label: string | null;
+      total: number;
+      articles: { id: bigint; label: string | null; montant: number }[];
+    }>();
+
+    let charges = 0;
+    let produits = 0;
+
+    for (const op of operations) {
+      if (!op.article) continue;
+
+      const art = op.article;
+      const key = art.groupe ?? null;
+      if (!groups.has(key)) {
+        groups.set(key, { code: key, label: art.groupe ?? null, total: 0, articles: [] });
+      }
+      const group = groups.get(key)!;
+
+      const montant = Number(op.montantTtc);
+      let articleEntry = group.articles.find(a => a.id === art.id);
+      if (!articleEntry) {
+        articleEntry = { id: art.id, label: art.prTexte, montant: 0 };
+        group.articles.push(articleEntry);
+      }
+      articleEntry.montant += montant;
+      group.total += montant;
+
+      if (art.famille?.mnem === 'JD2M_DEPENSE') {
+        charges += montant;
+      } else if (art.famille?.mnem === 'JD2M_RECETTE') {
+        produits += montant;
+      }
+    }
+
+    return {
+      produits,
+      charges,
+      resultat: produits - charges,
+      groupes: Array.from(groups.values()),
+    };
+  },
+};

--- a/backend/tests/fiscal.routes.test.ts
+++ b/backend/tests/fiscal.routes.test.ts
@@ -1,0 +1,23 @@
+import request from 'supertest';
+import app from '../src/app';
+import { FiscalService } from '../src/services/fiscal.service';
+
+jest.mock('../src/services/fiscal.service');
+
+const mockedService = FiscalService as jest.Mocked<typeof FiscalService>;
+
+describe('GET /api/v1/fiscal/result', () => {
+  it('returns result from service', async () => {
+    (mockedService.compute as jest.Mock).mockResolvedValueOnce({
+      produits: 200,
+      charges: 50,
+      resultat: 150,
+      groupes: [],
+    });
+
+    const res = await request(app).get('/api/v1/fiscal/result?anneeId=1&activityId=1');
+    expect(res.status).toBe(200);
+    expect(res.body.produits).toBe(200);
+    expect(mockedService.compute).toHaveBeenCalledWith({ anneeId: 1n, activityId: 1n });
+  });
+});

--- a/backend/tests/fiscal.service.test.ts
+++ b/backend/tests/fiscal.service.test.ts
@@ -1,0 +1,48 @@
+import { FiscalService } from '../src/services/fiscal.service';
+
+jest.mock('../src/prisma', () => ({
+  prisma: {
+    operation: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../src/prisma';
+const mockedPrisma = prisma as unknown as { operation: { findMany: jest.Mock } };
+
+describe('FiscalService.compute', () => {
+  it('aggregates operations by article and group', async () => {
+    mockedPrisma.operation.findMany.mockResolvedValueOnce([
+      {
+        montantTtc: 100,
+        articleId: 1n,
+        article: { id: 1n, prTexte: 'A1', groupe: 'G1', famille: { mnem: 'JD2M_RECETTE' } },
+      },
+      {
+        montantTtc: 50,
+        articleId: 1n,
+        article: { id: 1n, prTexte: 'A1', groupe: 'G1', famille: { mnem: 'JD2M_RECETTE' } },
+      },
+      {
+        montantTtc: 30,
+        articleId: 2n,
+        article: { id: 2n, prTexte: 'B1', groupe: 'G1', famille: { mnem: 'JD2M_DEPENSE' } },
+      },
+      {
+        montantTtc: 20,
+        articleId: 3n,
+        article: { id: 3n, prTexte: 'C1', groupe: 'G2', famille: { mnem: 'JD2M_DEPENSE' } },
+      },
+    ]);
+
+    const res = await FiscalService.compute({ anneeId: 1n, activityId: 1n });
+
+    expect(res.produits).toBe(150);
+    expect(res.charges).toBe(50);
+    expect(res.resultat).toBe(100);
+    const g1 = res.groupes.find(g => g.code === 'G1');
+    expect(g1?.total).toBe(180);
+    expect(g1?.articles).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `FiscalService.compute` to aggregate operations by group
- expose `GET /api/v1/fiscal/result` route
- add controller and schema for fiscal result queries
- cover new logic with Jest tests

## Testing
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_684ae5f811a08329a142e699ef799b1c