### PR TITLE
[backend] Add amortissement calculation service

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -28,6 +28,12 @@ class PrismaClient {
       update: jest.fn(),
       delete: jest.fn(),
     };
+    this.fiscalYear = {
+      findUnique: jest.fn(),
+    };
+    this.immobilisation = {
+      findMany: jest.fn(),
+    };
     this.$disconnect = jest.fn();
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import { operationRouter } from './routes/operation.routes';
 import { activityRouter } from './routes/activity.routes';
 import { logementRouter } from './routes/logement.routes';
 import { fiscalRouter } from './routes/fiscal.routes';
+import { amortissementRouter } from './routes/amortissement.routes';
 import { errorHandler } from './middlewares/error.middleware';
 
 dotenv.config();
@@ -21,6 +22,7 @@ app.use('/api/v1/operations', operationRouter);
 app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/logements', logementRouter);
 app.use('/api/v1/fiscal', fiscalRouter);
+app.use('/api/v1/amortissements', amortissementRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/amortissement.controller.ts
+++ b/backend/src/controllers/amortissement.controller.ts
@@ -1,0 +1,15 @@
+import type { Request, Response, NextFunction } from 'express';
+import { AmortissementService } from '../services/amortissement.service';
+
+export const AmortissementController = {
+  async compute(req: Request, res: Response, next: NextFunction) {
+    try {
+      const anneeId = BigInt(req.query.anneeId as string);
+      const activityId = BigInt(req.query.activityId as string);
+      const data = await AmortissementService.compute({ anneeId, activityId });
+      res.json(data);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/amortissement.routes.ts
+++ b/backend/src/routes/amortissement.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { AmortissementController } from '../controllers/amortissement.controller';
+import { validate } from '../middlewares/validate.middleware';
+import { amortissementQuerySchema } from '../schemas/amortissement.schema';
+
+export const amortissementRouter = Router();
+
+amortissementRouter.get('/', validate(amortissementQuerySchema), AmortissementController.compute);

--- a/backend/src/schemas/amortissement.schema.ts
+++ b/backend/src/schemas/amortissement.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const amortissementQuerySchema = z.object({
+  query: z.object({
+    anneeId: z.coerce.bigint(),
+    activityId: z.coerce.bigint(),
+  }),
+});

--- a/backend/src/services/amortissement.service.ts
+++ b/backend/src/services/amortissement.service.ts
@@ -1,0 +1,80 @@
+import { prisma } from '../prisma';
+
+interface PrismaWithAmortissement {
+  fiscalYear: {
+    findUnique: (args: unknown) => Promise<{ debut: Date; fin: Date } | null>;
+  };
+  immobilisation: {
+    findMany: (args: unknown) => Promise<{
+      id: bigint;
+      prTexte: string;
+      prixMontant: number;
+      duree: number;
+      miseEnService: Date;
+      dateSortie: Date | null;
+    }[]>;
+  };
+}
+
+const db = prisma as unknown as PrismaWithAmortissement;
+
+interface ComputeOptions {
+  anneeId: bigint;
+  activityId: bigint;
+}
+
+export interface AmortissementItem {
+  id: bigint;
+  libelle: string;
+  valeurBrute: number;
+  dureeAnnees: number;
+  debut: Date;
+  fin: Date;
+  prorataMois: number;
+  dotation: number;
+}
+
+export const AmortissementService = {
+  async compute({ anneeId, activityId }: ComputeOptions): Promise<AmortissementItem[]> {
+    const fiscal = await db.fiscalYear.findUnique({
+      where: { id: anneeId },
+      select: { debut: true, fin: true },
+    });
+    if (!fiscal) throw new Error('Fiscal year not found');
+
+    const immobs = await db.immobilisation.findMany({
+      where: { logement: { activityId } },
+      select: {
+        id: true,
+        prTexte: true,
+        prixMontant: true,
+        duree: true,
+        miseEnService: true,
+        dateSortie: true,
+      },
+    });
+
+    const results: AmortissementItem[] = [];
+
+    for (const immo of immobs) {
+      const debut = immo.miseEnService > fiscal.debut ? immo.miseEnService : fiscal.debut;
+      const sortie = immo.dateSortie ?? fiscal.fin;
+      const fin = sortie < fiscal.fin ? sortie : fiscal.fin;
+      if (debut > fin) continue;
+      const prorataMois = (fin.getFullYear() - debut.getFullYear()) * 12 +
+        (fin.getMonth() - debut.getMonth()) + 1;
+      const dotation = Math.round((immo.prixMontant / immo.duree) * (prorataMois / 12));
+      results.push({
+        id: immo.id,
+        libelle: immo.prTexte,
+        valeurBrute: immo.prixMontant,
+        dureeAnnees: immo.duree,
+        debut,
+        fin,
+        prorataMois,
+        dotation,
+      });
+    }
+    return results;
+  },
+};

--- a/backend/tests/amortissement.routes.test.ts
+++ b/backend/tests/amortissement.routes.test.ts
@@ -1,0 +1,16 @@
+import request from 'supertest';
+import app from '../src/app';
+import { AmortissementService } from '../src/services/amortissement.service';
+
+jest.mock('../src/services/amortissement.service');
+
+const mockedService = AmortissementService as jest.Mocked<typeof AmortissementService>;
+
+describe('GET /api/v1/amortissements', () => {
+  it('returns result from service', async () => {
+    mockedService.compute.mockResolvedValueOnce([]);
+    const res = await request(app).get('/api/v1/amortissements?anneeId=1&activityId=1');
+    expect(res.status).toBe(200);
+    expect(mockedService.compute).toHaveBeenCalledWith({ anneeId: 1n, activityId: 1n });
+  });
+});

--- a/backend/tests/amortissement.service.test.ts
+++ b/backend/tests/amortissement.service.test.ts
@@ -1,0 +1,48 @@
+import { AmortissementService } from '../src/services/amortissement.service';
+
+jest.mock('../src/prisma', () => ({
+  prisma: {
+    fiscalYear: { findUnique: jest.fn() },
+    immobilisation: { findMany: jest.fn() },
+  },
+}));
+
+import { prisma } from '../src/prisma';
+const mockedPrisma = prisma as unknown as {
+  fiscalYear: { findUnique: jest.Mock };
+  immobilisation: { findMany: jest.Mock };
+};
+
+describe('AmortissementService.compute', () => {
+  it('calculates dotation for eligible immobilisations', async () => {
+    mockedPrisma.fiscalYear.findUnique.mockResolvedValueOnce({
+      debut: new Date('2024-01-01'),
+      fin: new Date('2024-12-31'),
+    });
+    mockedPrisma.immobilisation.findMany.mockResolvedValueOnce([
+      {
+        id: 1n,
+        prTexte: 'Immo',
+        prixMontant: 1200,
+        duree: 5,
+        miseEnService: new Date('2024-03-15'),
+        dateSortie: null,
+      },
+      {
+        id: 2n,
+        prTexte: 'Old',
+        prixMontant: 1000,
+        duree: 5,
+        miseEnService: new Date('2023-01-01'),
+        dateSortie: new Date('2023-12-31'),
+      },
+    ]);
+
+    const res = await AmortissementService.compute({ anneeId: 1n, activityId: 1n });
+
+    expect(res).toHaveLength(1);
+    expect(res[0].debut).toEqual(new Date('2024-03-15'));
+    expect(res[0].prorataMois).toBe(10);
+    expect(res[0].dotation).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `AmortissementService` to compute amortization allowances
- expose `/api/v1/amortissements` route
- add controller and validation schema
- update Prisma mock for tests
- add unit and route tests

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_684af4428cb48329be5b54de56d62be8