### PR TITLE
[backend] handle amortisable components

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -34,6 +34,9 @@ class PrismaClient {
     this.immobilisation = {
       findMany: jest.fn(),
     };
+    this.composant = {
+      findMany: jest.fn(),
+    };
     this.$disconnect = jest.fn();
   }
 }

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.0
+info:
+  title: Super Umbrella API
+  version: 1.0.0
+paths:
+  /api/v1/amortissements:
+    get:
+      summary: Compute amortissements for immobilisations and composants
+      parameters:
+        - in: query
+          name: anneeId
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: activityId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: List of amortissements
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AmortissementItem'
+components:
+  schemas:
+    AmortissementItem:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        type:
+          type: string
+          enum: [immobilisation, composant]
+        libelle:
+          type: string
+        valeurBrute:
+          type: number
+          format: float
+        dureeAnnees:
+          type: integer
+        debut:
+          type: string
+          format: date-time
+        fin:
+          type: string
+          format: date-time
+        prorataMois:
+          type: integer
+        dotation:
+          type: number
+          format: float

--- a/backend/tests/amortissement.service.test.ts
+++ b/backend/tests/amortissement.service.test.ts
@@ -3,14 +3,18 @@ import { AmortissementService } from '../src/services/amortissement.service';
 jest.mock('../src/prisma', () => ({
   prisma: {
     fiscalYear: { findUnique: jest.fn() },
+    logement: { findMany: jest.fn() },
     immobilisation: { findMany: jest.fn() },
+    composant: { findMany: jest.fn() },
   },
 }));
 
 import { prisma } from '../src/prisma';
 const mockedPrisma = prisma as unknown as {
   fiscalYear: { findUnique: jest.Mock };
+  logement: { findMany: jest.Mock };
   immobilisation: { findMany: jest.Mock };
+  composant: { findMany: jest.Mock };
 };
 
 describe('AmortissementService.compute', () => {
@@ -19,6 +23,9 @@ describe('AmortissementService.compute', () => {
       debut: new Date('2024-01-01'),
       fin: new Date('2024-12-31'),
     });
+    mockedPrisma.logement.findMany.mockResolvedValueOnce([
+      { id: 1n, dateLocation: new Date('2024-02-01') },
+    ]);
     mockedPrisma.immobilisation.findMany.mockResolvedValueOnce([
       {
         id: 1n,
@@ -27,6 +34,7 @@ describe('AmortissementService.compute', () => {
         duree: 5,
         miseEnService: new Date('2024-03-15'),
         dateSortie: null,
+        logementOid: 1n,
       },
       {
         id: 2n,
@@ -35,14 +43,88 @@ describe('AmortissementService.compute', () => {
         duree: 5,
         miseEnService: new Date('2023-01-01'),
         dateSortie: new Date('2023-12-31'),
+        logementOid: 1n,
       },
     ]);
+    mockedPrisma.composant.findMany.mockResolvedValueOnce([]);
 
     const res = await AmortissementService.compute({ anneeId: 1n, activityId: 1n });
 
     expect(res).toHaveLength(1);
+    expect(res[0].type).toBe('immobilisation');
     expect(res[0].debut).toEqual(new Date('2024-03-15'));
     expect(res[0].prorataMois).toBe(10);
     expect(res[0].dotation).toBe(200);
+  });
+
+  it('ignores non amortissable components', async () => {
+    mockedPrisma.fiscalYear.findUnique.mockResolvedValueOnce({
+      debut: new Date('2024-01-01'),
+      fin: new Date('2024-12-31'),
+    });
+    mockedPrisma.logement.findMany.mockResolvedValueOnce([
+      { id: 1n, dateLocation: new Date('2024-01-01') },
+    ]);
+    mockedPrisma.immobilisation.findMany.mockResolvedValueOnce([]);
+    mockedPrisma.composant.findMany.mockResolvedValueOnce([
+      {
+        id: 10n,
+        amortissable: false,
+        duree: 5,
+        miseEnService: new Date('2024-02-01'),
+        prixProfilMontant: 1000,
+        immobilisationId: 1n,
+        article: { prTexte: 'Comp' },
+      },
+    ]);
+
+    const res = await AmortissementService.compute({ anneeId: 1n, activityId: 1n });
+    expect(res).toHaveLength(0);
+  });
+
+  it('mixes immobilisations and components', async () => {
+    mockedPrisma.fiscalYear.findUnique.mockResolvedValueOnce({
+      debut: new Date('2024-01-01'),
+      fin: new Date('2024-12-31'),
+    });
+    mockedPrisma.logement.findMany.mockResolvedValueOnce([
+      { id: 1n, dateLocation: new Date('2024-01-01') },
+    ]);
+    mockedPrisma.immobilisation.findMany.mockResolvedValueOnce([
+      {
+        id: 1n,
+        prTexte: 'Immo',
+        prixMontant: 1200,
+        duree: 5,
+        miseEnService: new Date('2024-01-01'),
+        dateSortie: null,
+        logementOid: 1n,
+      },
+    ]);
+    mockedPrisma.composant.findMany.mockResolvedValueOnce([
+      {
+        id: 20n,
+        amortissable: true,
+        duree: 5,
+        miseEnService: new Date('2024-06-01'),
+        prixProfilMontant: 500,
+        immobilisationId: 1n,
+        article: { prTexte: 'Comp1' },
+      },
+      {
+        id: 21n,
+        amortissable: true,
+        duree: 5,
+        miseEnService: new Date('2024-07-01'),
+        prixProfilMontant: 600,
+        immobilisationId: 1n,
+        article: { prTexte: 'Comp2' },
+      },
+    ]);
+
+    const res = await AmortissementService.compute({ anneeId: 1n, activityId: 1n });
+    expect(res).toHaveLength(3);
+    const types = res.map(r => r.type).sort();
+    expect(types).toEqual(['composant', 'composant', 'immobilisation']);
   });
 });


### PR DESCRIPTION
## Summary
- update amortissements service to support composants with prorata calculation
- document the endpoint in a new OpenAPI file
- extend prisma mock for composants
- add unit tests covering components logic

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b438b57cc83298a05bf982e1515ea