### PR TITLE
[frontend] add cerfa 2042 download

### DIFF
--- a/backend/src/controllers/cerfa.controller.ts
+++ b/backend/src/controllers/cerfa.controller.ts
@@ -18,4 +18,21 @@ export const CerfaController = {
       next(e);
     }
   },
+
+  async generate2042(req: Request, res: Response, next: NextFunction) {
+    try {
+      const anneeId = BigInt(req.query.anneeId as string);
+      const activityId = BigInt(req.query.activityId as string);
+      const pdf = await CerfaService.generate2042({ anneeId, activityId });
+      res
+        .status(200)
+        .set({
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': 'attachment; filename="2042_5124.pdf"',
+        })
+        .send(pdf);
+    } catch (e) {
+      next(e);
+    }
+  },
 };

--- a/backend/src/routes/cerfa.routes.ts
+++ b/backend/src/routes/cerfa.routes.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
 import { CerfaController } from '../controllers/cerfa.controller';
 import { validate } from '../middlewares/validate.middleware';
-import { cerfa2031QuerySchema } from '../schemas/cerfa.schema';
+import { cerfa2031QuerySchema, cerfa2042QuerySchema } from '../schemas/cerfa.schema';
 
 export const cerfaRouter = Router();
 
 cerfaRouter.get('/2031-sd', validate(cerfa2031QuerySchema), CerfaController.generate2031);
+cerfaRouter.get('/2042', validate(cerfa2042QuerySchema), CerfaController.generate2042);

--- a/backend/src/schemas/cerfa.schema.ts
+++ b/backend/src/schemas/cerfa.schema.ts
@@ -6,3 +6,5 @@ export const cerfa2031QuerySchema = z.object({
     activityId: z.coerce.bigint(),
   }),
 });
+
+export const cerfa2042QuerySchema = cerfa2031QuerySchema;

--- a/backend/src/services/cerfa.service.ts
+++ b/backend/src/services/cerfa.service.ts
@@ -63,4 +63,51 @@ export const CerfaService = {
     const bytes = await pdfDoc.save();
     return Buffer.from(bytes);
   },
+
+  async generate2042({ anneeId, activityId: _activityId }: Generate2031Options) {
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL ?? 'http://localhost',
+      process.env.SUPABASE_KEY ?? 'key'
+    );
+
+    const fiscal = await db.fiscalYear.findUnique({
+      where: { id: anneeId },
+      select: { debut: true, fin: true },
+    });
+    if (!fiscal) throw new Error('Fiscal year not found');
+
+    const { data, error } = await supabase.storage
+      .from('cerfa')
+      .download('2042_5124.pdf');
+    if (error || !data) throw new Error('Unable to download PDF');
+
+    const pdfDoc = await PDFDocument.load(await data.arrayBuffer());
+
+    try {
+      const helveticaFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+      const page = pdfDoc.getPage(0);
+
+      page.drawText(fiscal.debut.toISOString().slice(0, 10), {
+        x: 100,
+        y: 500,
+        size: 12,
+        font: helveticaFont,
+        color: rgb(0, 0, 0),
+      });
+
+      page.drawText(fiscal.fin.toISOString().slice(0, 10), {
+        x: 100,
+        y: 480,
+        size: 12,
+        font: helveticaFont,
+        color: rgb(0, 0, 0),
+      });
+    } catch {
+      // ignore missing fields
+    }
+    const bytes = await pdfDoc.save();
+    return Buffer.from(bytes);
+  },
 };

--- a/backend/tests/cerfa.routes.test.ts
+++ b/backend/tests/cerfa.routes.test.ts
@@ -20,3 +20,18 @@ describe('GET /api/v1/cerfa/2031-sd', () => {
     });
   });
 });
+
+describe('GET /api/v1/cerfa/2042', () => {
+  it('returns pdf from service', async () => {
+    mockedService.generate2042.mockResolvedValueOnce(Buffer.from('pdf'));
+    const res = await request(app).get(
+      '/api/v1/cerfa/2042?anneeId=1&activityId=1'
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/pdf');
+    expect(mockedService.generate2042).toHaveBeenCalledWith({
+      anneeId: 1n,
+      activityId: 1n,
+    });
+  });
+});

--- a/backend/tests/cerfa.service.test.ts
+++ b/backend/tests/cerfa.service.test.ts
@@ -40,3 +40,25 @@ describe('CerfaService.generate2031', () => {
     expect(Buffer.isBuffer(buf)).toBe(true);
   });
 });
+
+describe('CerfaService.generate2042', () => {
+  it('downloads and fills pdf', async () => {
+    mockedPrisma.fiscalYear.findUnique.mockResolvedValueOnce({
+      debut: new Date('2024-01-01'),
+      fin: new Date('2024-12-31'),
+    });
+    const doc = await PDFDocument.create();
+    const pdfBytes = await doc.save();
+    const downloadMock = jest.fn().mockResolvedValue({
+      data: new Blob([pdfBytes]),
+      error: null,
+    });
+    mockedCreate.mockReturnValue({
+      storage: { from: () => ({ download: downloadMock }) },
+    });
+
+    const buf = await CerfaService.generate2042({ anneeId: 1n, activityId: 1n });
+    expect(downloadMock).toHaveBeenCalled();
+    expect(Buffer.isBuffer(buf)).toBe(true);
+  });
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,12 +27,41 @@ describe('App component', () => {
     fireEvent.change(screen.getByPlaceholderText('activityId'), {
       target: { value: '2' },
     });
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('button', { name: /2031/i }));
     await Promise.resolve();
     await Promise.resolve();
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/cerfa/2031-sd?anneeId=1&activityId=2'
+    );
+    expect(urlMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+  });
+
+  it('telecharge le cerfa 2042 au clic', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ blob: () => Promise.resolve(new Blob()) })
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const urlMock = vi.fn(() => 'blob:url');
+    global.URL.createObjectURL = urlMock;
+    global.URL.revokeObjectURL = vi.fn();
+    const clickMock = vi.fn();
+    HTMLAnchorElement.prototype.click = clickMock;
+
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('activityId'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /2042/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/cerfa/2042?anneeId=1&activityId=2'
     );
     expect(urlMock).toHaveBeenCalled();
     expect(clickMock).toHaveBeenCalled();

--- a/frontend/src/pages/Resultats.tsx
+++ b/frontend/src/pages/Resultats.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { downloadCerfa2031 } from "../services/api";
+import { downloadCerfa2031, downloadCerfa2042 } from "../services/api";
 
 
 export default function Resultats() {
@@ -12,13 +12,28 @@ export default function Resultats() {
   const anneeId = 345319370
   const activityId= 139054534
 
-  const handleDownload = async () => {
+  const handleDownload2031 = async () => {
     try {
       const blob = await downloadCerfa2031(anneeId, activityId);
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
       a.download = "2031-sd.pdf";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      alert("Échec du téléchargement");
+    }
+  };
+
+  const handleDownload2042 = async () => {
+    try {
+      const blob = await downloadCerfa2042(anneeId, activityId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "2042_5124.pdf";
       a.click();
       URL.revokeObjectURL(url);
     } catch (err) {
@@ -42,7 +57,8 @@ export default function Resultats() {
         value={activityId}
         onChange={e => setActivityId(e.target.value)}
       />
-      <button onClick={handleDownload}>Télécharger le Cerfa 2031-SD</button>
+      <button onClick={handleDownload2031}>Télécharger le Cerfa 2031-SD</button>
+      <button onClick={handleDownload2042}>Télécharger le Cerfa 2042</button>
     </div>
   );
-} 
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -27,4 +27,9 @@ export const downloadCerfa2031 = (
   activityId: string | number
 ) => fetchBlob("/api/v1/cerfa/2031-sd", { anneeId, activityId });
 
+export const downloadCerfa2042 = (
+  anneeId: string | number,
+  activityId: string | number
+) => fetchBlob("/api/v1/cerfa/2042", { anneeId, activityId });
+
 export { buildURL, fetchBlob };


### PR DESCRIPTION
## Summary
- expose Cerfa 2042 API on backend
- support 2042 download in frontend
- add tests for new Cerfa actions

## Testing
- `pnpm run lint` *(fails: unable to reach telemetry.vercel.com)*
- `pnpm run test` *(fails: unable to reach telemetry.vercel.com)*

------
https://chatgpt.com/codex/tasks/task_e_684bcedc23fc8329b5294a97a493d31e