### PR TITLE
[frontend] Ajout bouton téléchargement 2042

### DIFF
--- a/backend/src/controllers/cerfa.controller.ts
+++ b/backend/src/controllers/cerfa.controller.ts
@@ -35,4 +35,21 @@ export const CerfaController = {
       next(e);
     }
   },
+
+  async generate2042(req: Request, res: Response, next: NextFunction) {
+    try {
+      const anneeId = BigInt(req.query.anneeId as string);
+      const activityId = BigInt(req.query.activityId as string);
+      const pdf = await CerfaService.generate2042({ anneeId, activityId });
+      res
+        .status(200)
+        .set({
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': 'attachment; filename="2042_5124.pdf"',
+        })
+        .send(pdf);
+    } catch (e) {
+      next(e);
+    }
+  },
 };

--- a/backend/src/routes/cerfa.routes.ts
+++ b/backend/src/routes/cerfa.routes.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { CerfaController } from '../controllers/cerfa.controller';
 import { validate } from '../middlewares/validate.middleware';
-import { cerfa2031QuerySchema, cerfa2033QuerySchema } from '../schemas/cerfa.schema';
+import { cerfa2031QuerySchema, cerfa2033QuerySchema, cerfa2042QuerySchema } from '../schemas/cerfa.schema';
 
 export const cerfaRouter = Router();
 
 cerfaRouter.get('/2031-sd', validate(cerfa2031QuerySchema), CerfaController.generate2031);
 cerfaRouter.get('/2033', validate(cerfa2033QuerySchema), CerfaController.generate2033);
+cerfaRouter.get('/2042', validate(cerfa2042QuerySchema), CerfaController.generate2042);

--- a/backend/src/schemas/cerfa.schema.ts
+++ b/backend/src/schemas/cerfa.schema.ts
@@ -8,3 +8,4 @@ export const cerfa2031QuerySchema = z.object({
 });
 
 export const cerfa2033QuerySchema = cerfa2031QuerySchema;
+export const cerfa2042QuerySchema = cerfa2031QuerySchema;

--- a/backend/tests/cerfa.routes.test.ts
+++ b/backend/tests/cerfa.routes.test.ts
@@ -35,3 +35,18 @@ describe('GET /api/v1/cerfa/2033', () => {
     });
   });
 });
+
+describe('GET /api/v1/cerfa/2042', () => {
+  it('returns pdf from service', async () => {
+    mockedService.generate2042.mockResolvedValueOnce(Buffer.from('pdf'));
+    const res = await request(app).get(
+      '/api/v1/cerfa/2042?anneeId=1&activityId=1'
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/pdf');
+    expect(mockedService.generate2042).toHaveBeenCalledWith({
+      anneeId: 1n,
+      activityId: 1n,
+    });
+  });
+});

--- a/backend/tests/cerfa.service.test.ts
+++ b/backend/tests/cerfa.service.test.ts
@@ -62,3 +62,25 @@ describe('CerfaService.generate2033', () => {
     expect(Buffer.isBuffer(buf)).toBe(true);
   });
 });
+
+describe('CerfaService.generate2042', () => {
+  it('downloads and fills pdf', async () => {
+    mockedPrisma.fiscalYear.findUnique.mockResolvedValueOnce({
+      debut: new Date('2024-01-01'),
+      fin: new Date('2024-12-31'),
+    });
+    const doc = await PDFDocument.create();
+    const pdfBytes = await doc.save();
+    const downloadMock = jest.fn().mockResolvedValue({
+      data: new Blob([pdfBytes]),
+      error: null,
+    });
+    mockedCreate.mockReturnValue({
+      storage: { from: () => ({ download: downloadMock }) },
+    });
+
+    const buf = await CerfaService.generate2042({ anneeId: 1n, activityId: 1n });
+    expect(downloadMock).toHaveBeenCalled();
+    expect(Buffer.isBuffer(buf)).toBe(true);
+  });
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -67,6 +67,35 @@ describe('App component', () => {
     expect(clickMock).toHaveBeenCalled();
   });
 
+  it('telecharge le cerfa 2042 au clic', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const urlMock = vi.fn(() => 'blob:url');
+    global.URL.createObjectURL = urlMock;
+    global.URL.revokeObjectURL = vi.fn();
+    const clickMock = vi.fn();
+    HTMLAnchorElement.prototype.click = clickMock;
+
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('activityId'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /2042/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/cerfa/2042?anneeId=1&activityId=2',
+      { credentials: 'include' },
+    );
+    expect(urlMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+  });
+
   it('exporte le FEC au clic', async () => {
     const fetchMock = vi.fn(() =>
       Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),

--- a/frontend/src/pages/Resultats.tsx
+++ b/frontend/src/pages/Resultats.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import {
   downloadCerfa2031,
   downloadCerfa2033,
+  downloadCerfa2042,
   downloadFec,
   downloadReportPdf,
 } from '../services/api';
@@ -34,6 +35,21 @@ export default function Resultats() {
       const a = document.createElement('a');
       a.href = url;
       a.download = '2033.pdf';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error(err);
+      alert('Échec du téléchargement');
+    }
+  };
+
+  const handleDownload2042 = async () => {
+    try {
+      const blob = await downloadCerfa2042(anneeId, activityId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = '2042_5124.pdf';
       a.click();
       URL.revokeObjectURL(url);
     } catch (err) {
@@ -89,6 +105,7 @@ export default function Resultats() {
       />
       <button onClick={handleDownload2031}>Télécharger le Cerfa 2031-SD</button>
       <button onClick={handleDownload2033}>Télécharger le Cerfa 2033</button>
+      <button onClick={handleDownload2042}>Télécharger le Cerfa 2042</button>
       <button onClick={handleDownloadFec}>
         Exporter le Fichier des Écritures Comptables
       </button>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -33,6 +33,11 @@ export const downloadCerfa2033 = (
   activityId: string | number,
 ) => fetchBlob('/api/v1/cerfa/2033', { anneeId, activityId });
 
+export const downloadCerfa2042 = (
+  anneeId: string | number,
+  activityId: string | number,
+) => fetchBlob('/api/v1/cerfa/2042', { anneeId, activityId });
+
 export const downloadFec = (
   anneeId: string | number,
   activityId: string | number,


### PR DESCRIPTION
## Summary
- add `generate2042` in CerfaService and expose new route `/api/v1/cerfa/2042`
- allow frontend to fetch this pdf
- provide a button in Resultats page
- cover new behaviour with tests

## Testing
- `pnpm --filter ./backend run lint`
- `pnpm --filter ./frontend run lint`
- `pnpm --filter ./backend run test`
- `pnpm --filter ./frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_684c061a3250832988e1e186e6e86b4a