### PR TITLE
[backend] Format fiscal result table in PDF

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(BigInt.prototype as any).toJSON = function () {
   return this.toString();
 };

--- a/backend/src/services/report.service.ts
+++ b/backend/src/services/report.service.ts
@@ -1,7 +1,78 @@
-import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { PDFDocument, StandardFonts, PDFFont, rgb } from 'pdf-lib';
 import { FiscalService } from './fiscal.service';
 import { AmortissementService } from './amortissement.service';
 import { CerfaService } from './cerfa.service';
+
+interface TableRow {
+  code: string | null;
+  label: string | null;
+  amount: number;
+}
+
+function formatAmount(value: number): string {
+  const formatted = Math.abs(value).toLocaleString('fr-FR');
+  return value < 0 ? `(${formatted})` : formatted;
+}
+
+function drawFiscalTable(doc: PDFDocument, font: PDFFont, rows: TableRow[], totals: { produits: number; charges: number; resultat: number }) {
+  const margin = 50;
+  const rowHeight = 20;
+  const headerHeight = 20;
+  const colWidths = [80, 300, 100];
+  const tableWidth = colWidths.reduce((a, b) => a + b, 0);
+  let page = doc.addPage();
+  let y = page.getSize().height - margin;
+
+  page.drawText(`Tableau fiscal - ${new Date().toLocaleDateString('fr-FR')}`,
+    { x: margin, y: y, size: 16, font });
+  y -= 30;
+
+  const drawHeader = () => {
+    page.drawText('Code', { x: margin + 2, y: y - 15, size: 12, font });
+    page.drawText('Libellé', { x: margin + colWidths[0] + 2, y: y - 15, size: 12, font });
+    page.drawText('Montant', { x: margin + colWidths[0] + colWidths[1] + 2, y: y - 15, size: 12, font });
+    y -= headerHeight;
+  };
+
+  const checkPageBreak = () => {
+    if (y - rowHeight < margin) {
+      page = doc.addPage();
+      y = page.getSize().height - margin;
+      drawHeader();
+    }
+  };
+
+  drawHeader();
+  let index = 0;
+  for (const r of rows) {
+    checkPageBreak();
+    if (index % 2 === 1) {
+      page.drawRectangle({ x: margin, y: y - rowHeight + 4, width: tableWidth, height: rowHeight, color: rgb(0.95, 0.95, 0.95) });
+    }
+    page.drawText(r.code ?? '', { x: margin + 2, y: y - 15, size: 12, font });
+    page.drawText(r.label ?? '', { x: margin + colWidths[0] + 2, y: y - 15, size: 12, font });
+    const amountText = formatAmount(r.amount);
+    const textWidth = font.widthOfTextAtSize(amountText, 12);
+    page.drawText(amountText, { x: margin + colWidths[0] + colWidths[1] + colWidths[2] - textWidth - 2, y: y - 15, size: 12, font });
+    y -= rowHeight;
+    index++;
+  }
+
+  const totalRows: TableRow[] = [
+    { code: null, label: 'Produits', amount: totals.produits },
+    { code: null, label: 'Charges', amount: totals.charges },
+    { code: null, label: 'Résultat', amount: totals.resultat },
+  ];
+  for (const r of totalRows) {
+    checkPageBreak();
+    page.drawRectangle({ x: margin, y: y - rowHeight + 4, width: tableWidth, height: rowHeight, color: rgb(0.8, 0.8, 0.8) });
+    page.drawText(r.label ?? '', { x: margin + colWidths[0] + 2, y: y - 15, size: 12, font });
+    const amountText = formatAmount(r.amount);
+    const textWidth = font.widthOfTextAtSize(amountText, 12);
+    page.drawText(amountText, { x: margin + colWidths[0] + colWidths[1] + colWidths[2] - textWidth - 2, y: y - 15, size: 12, font });
+    y -= rowHeight;
+  }
+}
 
 interface Options {
   anneeId: bigint;
@@ -20,15 +91,24 @@ export const ReportService = {
     const doc = await PDFDocument.create();
     const font = await doc.embedFont(StandardFonts.Helvetica);
 
-    const page1 = doc.addPage();
-    const { height: h1 } = page1.getSize();
-    page1.drawText('Tableau fiscal', { x: 50, y: h1 - 50, size: 16, font });
-    page1.drawText(JSON.stringify(fiscal), { x: 50, y: h1 - 80, size: 12, font });
+    const rows: TableRow[] = [];
+    for (const g of fiscal.groupes) {
+      for (const a of g.articles) {
+        rows.push({ code: g.code, label: a.label, amount: a.montant });
+      }
+      rows.push({ code: g.code, label: `Total ${g.label}`, amount: g.total });
+    }
 
-    const page2 = doc.addPage();
-    const { height: h2 } = page2.getSize();
-    page2.drawText("Tableau d'amortissement", { x: 50, y: h2 - 50, size: 16, font });
-    page2.drawText(JSON.stringify(amortissements), { x: 50, y: h2 - 80, size: 12, font });
+    drawFiscalTable(doc, font, rows, {
+      produits: fiscal.produits,
+      charges: fiscal.charges,
+      resultat: fiscal.resultat,
+    });
+
+    let page = doc.addPage();
+    const { height: h2 } = page.getSize();
+    page.drawText("Tableau d'amortissement", { x: 50, y: h2 - 50, size: 16, font });
+    page.drawText(JSON.stringify(amortissements), { x: 50, y: h2 - 80, size: 12, font });
 
     const cerfa2031Doc = await PDFDocument.load(cerfa2031);
     const pages2031 = await doc.copyPages(cerfa2031Doc, cerfa2031Doc.getPageIndices());

--- a/backend/tests/report.service.test.ts
+++ b/backend/tests/report.service.test.ts
@@ -13,12 +13,21 @@ const mockedAmort = AmortissementService as jest.Mocked<typeof AmortissementServ
 const mockedCerfa = CerfaService as jest.Mocked<typeof CerfaService>;
 
 describe('ReportService.generate', () => {
-  it('returns a pdf buffer', async () => {
+  it('returns a pdf buffer with fiscal table', async () => {
     mockedFiscal.compute.mockResolvedValueOnce({
-      produits: 0,
-      charges: 0,
-      resultat: 0,
-      groupes: [],
+      produits: 10,
+      charges: 5,
+      resultat: 5,
+      groupes: [
+        {
+          code: 'A',
+          label: 'Test',
+          total: 10,
+          articles: [
+            { id: 1n, label: 'Article', montant: 10 },
+          ],
+        },
+      ],
     });
     mockedAmort.compute.mockResolvedValueOnce([]);
     const doc = await PDFDocument.create();
@@ -28,6 +37,8 @@ describe('ReportService.generate', () => {
 
     const buf = await ReportService.generate({ anneeId: 1n, activityId: 1n });
     expect(Buffer.isBuffer(buf)).toBe(true);
+    const pdf = await PDFDocument.load(buf);
+    expect(pdf.getPageCount()).toBeGreaterThan(0);
     expect(mockedFiscal.compute).toHaveBeenCalled();
     expect(mockedAmort.compute).toHaveBeenCalled();
     expect(mockedCerfa.generate2031).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add helper to draw a styled fiscal table in PDF reports
- use the helper when generating PDF reports
- allow BigInt JSON serialization without lint errors
- update tests for new PDF generation

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`

------
https://chatgpt.com/codex/tasks/task_e_684c10fdf19883298bc8a7bb943d92d0