### PR TITLE
[frontend] Sidebar page fixes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,8 @@
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+.main {
+  flex: 1;
+  padding: 1rem;
+}

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,158 +1,24 @@
-// frontend/src/App.test.tsx
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
-import App from './App'; // ← sans extension .js/.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import App from './App';
 
-describe('App component', () => {
-  it('affiche le texte de bienvenue', () => {
+// Tests simplifiés pour la navigation
+
+describe('App navigation', () => {
+  it('affiche le dashboard par défaut', () => {
     render(<App />);
-    expect(screen.getByText(/Test/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /dashboard/i }),
+    ).toBeInTheDocument();
   });
 
-  it('telecharge le cerfa au clic', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
-    );
-    global.fetch = fetchMock as unknown as typeof fetch;
-    const urlMock = vi.fn(() => 'blob:url');
-    global.URL.createObjectURL = urlMock;
-    global.URL.revokeObjectURL = vi.fn();
-    const clickMock = vi.fn();
-    HTMLAnchorElement.prototype.click = clickMock;
-
+  it('affiche les résultats après clic sur déclaration fiscale', () => {
     render(<App />);
-    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
-      target: { value: '1' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('activityId'), {
-      target: { value: '2' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /2031/i }));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/cerfa/2031-sd?anneeId=1&activityId=2',
-      { credentials: 'include' },
-    );
-    expect(urlMock).toHaveBeenCalled();
-    expect(clickMock).toHaveBeenCalled();
-  });
-
-  it('telecharge le cerfa 2033 au clic', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
-    );
-    global.fetch = fetchMock as unknown as typeof fetch;
-    const urlMock = vi.fn(() => 'blob:url');
-    global.URL.createObjectURL = urlMock;
-    global.URL.revokeObjectURL = vi.fn();
-    const clickMock = vi.fn();
-    HTMLAnchorElement.prototype.click = clickMock;
-
-    render(<App />);
-    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
-      target: { value: '1' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('activityId'), {
-      target: { value: '2' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /2033/i }));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/cerfa/2033?anneeId=1&activityId=2',
-      { credentials: 'include' },
-    );
-    expect(urlMock).toHaveBeenCalled();
-    expect(clickMock).toHaveBeenCalled();
-  });
-
-  it('telecharge le cerfa 2042 au clic', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
-    );
-    global.fetch = fetchMock as unknown as typeof fetch;
-    const urlMock = vi.fn(() => 'blob:url');
-    global.URL.createObjectURL = urlMock;
-    global.URL.revokeObjectURL = vi.fn();
-    const clickMock = vi.fn();
-    HTMLAnchorElement.prototype.click = clickMock;
-
-    render(<App />);
-    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
-      target: { value: '1' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('activityId'), {
-      target: { value: '2' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /2042/i }));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/cerfa/2042?anneeId=1&activityId=2',
-      { credentials: 'include' },
-    );
-    expect(urlMock).toHaveBeenCalled();
-    expect(clickMock).toHaveBeenCalled();
-  });
-
-  it('exporte le FEC au clic', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
-    );
-    global.fetch = fetchMock as unknown as typeof fetch;
-    const urlMock = vi.fn(() => 'blob:url');
-    global.URL.createObjectURL = urlMock;
-    global.URL.revokeObjectURL = vi.fn();
-    const clickMock = vi.fn();
-    HTMLAnchorElement.prototype.click = clickMock;
-
-    render(<App />);
-    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
-      target: { value: '1' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('activityId'), {
-      target: { value: '2' },
-    });
     fireEvent.click(
-      screen.getByRole('button', { name: /Fichier des Écritures/i }),
+      screen.getByRole('button', { name: /déclaration fiscale/i }),
     );
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/fec?anneeId=1&activityId=2',
-      { credentials: 'include' },
-    );
-    expect(urlMock).toHaveBeenCalled();
-    expect(clickMock).toHaveBeenCalled();
-  });
-
-  it('exporte le PDF complet au clic', async () => {
-    const fetchMock = vi.fn(() =>
-      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
-    );
-    global.fetch = fetchMock as unknown as typeof fetch;
-    const urlMock = vi.fn(() => 'blob:url');
-    global.URL.createObjectURL = urlMock;
-    global.URL.revokeObjectURL = vi.fn();
-    const clickMock = vi.fn();
-    HTMLAnchorElement.prototype.click = clickMock;
-
-    render(<App />);
-    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
-      target: { value: '1' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('activityId'), {
-      target: { value: '2' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /Exporter en PDF/i }));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/reports/pdf?anneeId=1&activityId=2',
-      { credentials: 'include' },
-    );
-    expect(urlMock).toHaveBeenCalled();
-    expect(clickMock).toHaveBeenCalled();
+    expect(
+      screen.getByRole('heading', { name: /résultats/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,42 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import './App.css';
+import Sidebar from './components/Sidebar';
+import Dashboard from './pages/Dashboard';
+import MesBiens from './pages/MesBiens';
+import Agenda from './pages/Agenda';
 import Resultats from './pages/Resultats';
+import Abonnement from './pages/Abonnement';
+import MonCompte from './pages/MonCompte';
+import { PageProvider, usePageStore } from './store/pageContext';
+
+function CurrentPage() {
+  const page = usePageStore((s) => s.currentPage);
+  switch (page) {
+    case 'Dashboard':
+      return <Dashboard />;
+    case 'MesBiens':
+      return <MesBiens />;
+    case 'Agenda':
+      return <Agenda />;
+    case 'Resultats':
+      return <Resultats />;
+    case 'Abonnement':
+      return <Abonnement />;
+    case 'MonCompte':
+      return <MonCompte />;
+    default:
+      return null;
+  }
+}
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Resultats />} />
-        <Route path="/Resultats" element={<Resultats />} />
-        {/* tes autres pages */}
-      </Routes>
-    </BrowserRouter>
+    <PageProvider>
+      <div className="app">
+        <Sidebar />
+        <main className="main">
+          <CurrentPage />
+        </main>
+      </div>
+    </PageProvider>
   );
 }

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,0 +1,23 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  background: #f0f0f0;
+  padding: 1rem;
+  height: 100vh;
+  box-sizing: border-box;
+}
+.sidebar button {
+  background: none;
+  border: none;
+  padding: 0.5rem 0;
+  text-align: left;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.sidebar button.active {
+  font-weight: bold;
+}
+.sidebar .bottom {
+  margin-top: auto;
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,38 @@
+import './Sidebar.css';
+import { usePageStore } from '../store/pageContext';
+
+export default function Sidebar() {
+  const current = usePageStore((s) => s.currentPage);
+  const setCurrentPage = usePageStore((s) => s.setCurrentPage);
+
+  const items: { label: string; page: Parameters<typeof setCurrentPage>[0] }[] =
+    [
+      { label: 'Dashboard', page: 'Dashboard' },
+      { label: 'Mes biens', page: 'MesBiens' },
+      { label: 'Mon agenda', page: 'Agenda' },
+      { label: 'Déclaration fiscale', page: 'Resultats' },
+      { label: 'Abonnement', page: 'Abonnement' },
+    ];
+
+  return (
+    <nav className="sidebar">
+      {items.map((item) => (
+        <button
+          key={item.page}
+          className={current === item.page ? 'active' : ''}
+          onClick={() => setCurrentPage(item.page)}
+        >
+          {item.label}
+        </button>
+      ))}
+      <div className="bottom">
+        <button
+          className={current === 'MonCompte' ? 'active' : ''}
+          onClick={() => setCurrentPage('MonCompte')}
+        >
+          Mon compte
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/pages/Abonnement.tsx
+++ b/frontend/src/pages/Abonnement.tsx
@@ -1,0 +1,3 @@
+export default function Abonnement() {
+  return <h1>Abonnement</h1>;
+}

--- a/frontend/src/pages/Agenda.tsx
+++ b/frontend/src/pages/Agenda.tsx
@@ -1,0 +1,3 @@
+export default function Agenda() {
+  return <h1>Mon agenda</h1>;
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <h1>Dashboard</h1>;
+}

--- a/frontend/src/pages/MesBiens.tsx
+++ b/frontend/src/pages/MesBiens.tsx
@@ -1,0 +1,3 @@
+export default function MesBiens() {
+  return <h1>Mes biens</h1>;
+}

--- a/frontend/src/pages/MonCompte.tsx
+++ b/frontend/src/pages/MonCompte.tsx
@@ -1,0 +1,3 @@
+export default function MonCompte() {
+  return <h1>Mon compte</h1>;
+}

--- a/frontend/src/pages/Resultats.test.tsx
+++ b/frontend/src/pages/Resultats.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Resultats from './Resultats';
+
+describe('Resultats page', () => {
+  it('affiche les résultats', () => {
+    render(<Resultats />);
+    expect(screen.getByText(/résultats/i)).toBeInTheDocument();
+  });
+
+  it('telecharge le cerfa au clic', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const urlMock = vi.fn(() => 'blob:url');
+    global.URL.createObjectURL = urlMock;
+    global.URL.revokeObjectURL = vi.fn();
+    const clickMock = vi.fn();
+    HTMLAnchorElement.prototype.click = clickMock;
+
+    render(<Resultats />);
+    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('activityId'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /2031/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/cerfa/2031-sd?anneeId=1&activityId=2',
+      { credentials: 'include' },
+    );
+    expect(urlMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+  });
+
+  it('telecharge le cerfa 2033 au clic', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const urlMock = vi.fn(() => 'blob:url');
+    global.URL.createObjectURL = urlMock;
+    global.URL.revokeObjectURL = vi.fn();
+    const clickMock = vi.fn();
+    HTMLAnchorElement.prototype.click = clickMock;
+
+    render(<Resultats />);
+    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('activityId'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /2033/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/cerfa/2033?anneeId=1&activityId=2',
+      { credentials: 'include' },
+    );
+    expect(urlMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+  });
+
+  it('telecharge le cerfa 2042 au clic', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const urlMock = vi.fn(() => 'blob:url');
+    global.URL.createObjectURL = urlMock;
+    global.URL.revokeObjectURL = vi.fn();
+    const clickMock = vi.fn();
+    HTMLAnchorElement.prototype.click = clickMock;
+
+    render(<Resultats />);
+    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('activityId'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /2042/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/cerfa/2042?anneeId=1&activityId=2',
+      { credentials: 'include' },
+    );
+    expect(urlMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+  });
+
+  it('exporte le FEC au clic', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const urlMock = vi.fn(() => 'blob:url');
+    global.URL.createObjectURL = urlMock;
+    global.URL.revokeObjectURL = vi.fn();
+    const clickMock = vi.fn();
+    HTMLAnchorElement.prototype.click = clickMock;
+
+    render(<Resultats />);
+    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('activityId'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Fichier des Écritures/i }),
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/fec?anneeId=1&activityId=2',
+      { credentials: 'include' },
+    );
+    expect(urlMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+  });
+
+  it('exporte le PDF complet au clic', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob()) }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const urlMock = vi.fn(() => 'blob:url');
+    global.URL.createObjectURL = urlMock;
+    global.URL.revokeObjectURL = vi.fn();
+    const clickMock = vi.fn();
+    HTMLAnchorElement.prototype.click = clickMock;
+
+    render(<Resultats />);
+    fireEvent.change(screen.getByPlaceholderText('anneeId'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('activityId'), {
+      target: { value: '2' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Exporter en PDF/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/reports/pdf?anneeId=1&activityId=2',
+      { credentials: 'include' },
+    );
+    expect(urlMock).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/Resultats.tsx
+++ b/frontend/src/pages/Resultats.tsx
@@ -90,7 +90,7 @@ export default function Resultats() {
 
   return (
     <div>
-      <h1>Test</h1>
+      <h1>Résultats</h1>
       <input
         type="text"
         placeholder="anneeId"

--- a/frontend/src/store/pageContext.tsx
+++ b/frontend/src/store/pageContext.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { createStore } from 'zustand';
+import { StoreApi, useStore } from 'zustand';
+
+export type Page =
+  | 'Dashboard'
+  | 'MesBiens'
+  | 'Agenda'
+  | 'Resultats'
+  | 'Abonnement'
+  | 'MonCompte';
+
+interface PageState {
+  currentPage: Page;
+  setCurrentPage: (page: Page) => void;
+}
+
+const pageStore = createStore<PageState>((set) => ({
+  currentPage: 'Dashboard',
+  setCurrentPage: (page) => set({ currentPage: page }),
+}));
+
+export const PageContext = React.createContext<StoreApi<PageState> | null>(
+  null,
+);
+
+export function PageProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <PageContext.Provider value={pageStore}>{children}</PageContext.Provider>
+  );
+}
+
+export function usePageStore<T>(selector: (state: PageState) => T): T {
+  const store = React.useContext(PageContext);
+  if (!store) throw new Error('PageContext not found');
+  return useStore(store, selector);
+}


### PR DESCRIPTION
## Summary
- route sidebar Declaration fiscale to existing Resultats page
- rename Resultats heading
- restore previous download tests in a dedicated page test
- adjust App navigation test

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_68500efcc0c48329b21151023320c26a