### PR TITLE
[frontend] Add sidebar navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,8 +8,9 @@ import Resultats from './pages/Resultats';
 import Abonnement from './pages/Abonnement';
 import MonCompte from './pages/MonCompte';
 import { PageProvider, usePageStore } from './store/pageContext';
+import type { Page } from './store/pageContext';
 
-function PageContainer({ currentPage }) {
+function PageContainer({ currentPage }: { currentPage: Page }) {
   switch (currentPage) {
     case 'Dashboard':
       return <Dashboard />;

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -1,7 +1,8 @@
-"use client"
+'use client';
 
-import type * as React from "react"
-import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar"
+import type * as React from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
+import type { Page } from '../../store/pageContext';
 import {
   Sidebar,
   SidebarContent,
@@ -13,7 +14,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
-} from "../ui/sidebar"
+} from '../ui/sidebar';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -21,50 +22,67 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "../ui/dropdown-menu"
-import { LayoutDashboard, Home, Calendar, CreditCard, Settings, LogOut, User, Crown } from "lucide-react"
+} from '../ui/dropdown-menu';
+import type { LucideIcon } from 'lucide-react';
+import {
+  LayoutDashboard,
+  Home,
+  Calendar,
+  CreditCard,
+  Settings,
+  LogOut,
+  User,
+  Crown,
+} from 'lucide-react';
 
-const menuItems = [
+const menuItems: { title: string; icon: LucideIcon; id: Page }[] = [
   {
-    title: "Dashboard",
+    title: 'Dashboard',
     icon: LayoutDashboard,
-    id: "dashboard",
+    id: 'Dashboard',
   },
   {
-    title: "Mes Biens",
+    title: 'Mes Biens',
     icon: Home,
-    id: "biens",
+    id: 'MesBiens',
   },
   {
-    title: "Mon Agenda",
+    title: 'Mon Agenda',
     icon: Calendar,
-    id: "agenda",
+    id: 'Agenda',
   },
   {
-    title: "Abonnement",
+    title: 'Abonnement',
     icon: CreditCard,
-    id: "abonnement",
+    id: 'Abonnement',
   },
   {
-    title: "Résultats",
+    title: 'Résultats',
     icon: CreditCard,
-    id: "resultats",
+    id: 'Resultats',
   },
-]
+];
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
-  activeSection: string
-  onSectionChange: (section: string) => void
-  onProfileEdit: () => void
+  activeSection: Page;
+  onSectionChange: (section: Page) => void;
+  onProfileEdit: () => void;
 }
 
-export default function AppSidebar({ activeSection, onSectionChange, onProfileEdit, ...props }: AppSidebarProps) {
+export default function AppSidebar({
+  activeSection,
+  onSectionChange,
+  onProfileEdit,
+  ...props
+}: AppSidebarProps) {
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
         <div className="flex items-center gap-3 px-3 py-2">
           <Home className="h-6 w-6 text-blue-600" />
-          <span className="font-semibold text-lg group-data-[collapsible=icon]:hidden">Gestion Locative</span>
+          <span className="font-semibold text-lg group-data-[collapsible=icon]:hidden">
+            Gestion Locative
+          </span>
         </div>
       </SidebarHeader>
 
@@ -81,7 +99,9 @@ export default function AppSidebar({ activeSection, onSectionChange, onProfileEd
                   >
                     <item.icon className="h-4 w-4" />
                     <span>{item.title}</span>
-                    {item.id === "abonnement" && <Crown className="h-3 w-3 ml-auto text-yellow-500" />}
+                    {item.id === 'Abonnement' && (
+                      <Crown className="h-3 w-3 ml-auto text-yellow-500" />
+                    )}
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -100,7 +120,10 @@ export default function AppSidebar({ activeSection, onSectionChange, onProfileEd
                   className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                 >
                   <Avatar className="h-8 w-8 rounded-lg">
-                    <AvatarImage src="/placeholder.svg?height=32&width=32&text=JD" alt="John Doe" />
+                    <AvatarImage
+                      src="/placeholder.svg?height=32&width=32&text=JD"
+                      alt="John Doe"
+                    />
                     <AvatarFallback className="rounded-lg">JD</AvatarFallback>
                   </Avatar>
                   <div className="grid flex-1 text-left text-sm leading-tight">
@@ -118,7 +141,10 @@ export default function AppSidebar({ activeSection, onSectionChange, onProfileEd
                 <DropdownMenuLabel className="p-0 font-normal">
                   <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                     <Avatar className="h-8 w-8 rounded-lg">
-                      <AvatarImage src="/placeholder.svg?height=32&width=32&text=JD" alt="John Doe" />
+                      <AvatarImage
+                        src="/placeholder.svg?height=32&width=32&text=JD"
+                        alt="John Doe"
+                      />
                       <AvatarFallback className="rounded-lg">JD</AvatarFallback>
                     </Avatar>
                     <div className="grid flex-1 text-left text-sm leading-tight">
@@ -148,5 +174,5 @@ export default function AppSidebar({ activeSection, onSectionChange, onProfileEd
       </SidebarFooter>
       <SidebarRail />
     </Sidebar>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- wire sidebar pages to dashboard/results/abonnement
- type AppSidebar props with `Page`

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6850d952b3548329957d1a034040b0c2