### PR TITLE
[frontend] add persistent sidebar with shadcn style

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,20 +1,29 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import App from './App';
+import { PageProvider } from './store/pageContext';
 
 // Tests simplifiés pour la navigation
 
 describe('App navigation', () => {
   it('affiche le dashboard par défaut', () => {
-    render(<App />);
+    render(
+      <PageProvider>
+        <App />
+      </PageProvider>,
+    );
     expect(
       screen.getByRole('heading', { name: /dashboard/i }),
     ).toBeInTheDocument();
   });
 
-  it('active le menu Résultats après clic', () => {
-    render(<App />);
-    const btn = screen.getByRole('button', { name: /résultats/i });
+  it('active le menu MesBiens après clic', () => {
+    render(
+      <PageProvider>
+        <App />
+      </PageProvider>,
+    );
+    const btn = screen.getByRole('button', { name: /mesbiens/i });
     fireEvent.click(btn);
     expect(btn).toHaveAttribute('data-active', 'true');
   });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,17 +1,42 @@
-import { useState } from 'react';
 import Dashboard from './pages/Dashboard';
 import MesBiens from './pages/MesBiens';
 import Agenda from './pages/Agenda';
 import Resultats from './pages/Resultats';
 import Abonnement from './pages/Abonnement';
 import MonCompte from './pages/MonCompte';
-import { PageProvider, usePageStore } from './store/pageContext';
+import { usePageStore } from './store/pageContext';
 import type { Page } from './store/pageContext';
+import { Sidebar } from './components/Sidebar';
 
+function PageRenderer({ page }: { page: Page }) {
+  switch (page) {
+    case 'Dashboard':
+      return <Dashboard />;
+    case 'MesBiens':
+      return <MesBiens />;
+    case 'Agenda':
+      return <Agenda />;
+    case 'Resultats':
+      return <Resultats />;
+    case 'Abonnement':
+      return <Abonnement />;
+    case 'MonCompte':
+      return <MonCompte />;
+    default:
+      return null;
+  }
+}
 
 export default function App() {
-
-  }
+  const currentPage = usePageStore((s) => s.currentPage);
+  const setCurrentPage = usePageStore((s) => s.setCurrentPage);
 
   return (
+    <div className="flex">
+      <Sidebar current={currentPage} onNavigate={setCurrentPage} />
+      <main className="flex-1 p-4">
+        <PageRenderer page={currentPage} />
+      </main>
+    </div>
+  );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,32 @@
+import { Button } from './ui/button';
+import type { Page } from '../store/pageContext';
+
+interface SidebarProps {
+  current: Page;
+  onNavigate: (page: Page) => void;
+}
+
+const items: { label: string; page: Page }[] = [
+  { label: 'Dashboard', page: 'Dashboard' },
+  { label: 'MesBiens', page: 'MesBiens' },
+  { label: 'Abonnement', page: 'Abonnement' },
+  { label: 'Mon Agenda', page: 'Agenda' },
+];
+
+export function Sidebar({ current, onNavigate }: SidebarProps) {
+  return (
+    <nav className="w-48 border-r min-h-screen p-4 space-y-2">
+      {items.map((item) => (
+        <Button
+          key={item.page}
+          variant={current === item.page ? 'secondary' : 'ghost'}
+          className="w-full justify-start"
+          data-active={current === item.page}
+          onClick={() => onNavigate(item.page)}
+        >
+          {item.label}
+        </Button>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/hooks/use-mobile.tsx
+++ b/frontend/src/hooks/use-mobile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 
 /**
  * Hook to detect if the current viewport is considered mobile.
@@ -8,7 +8,7 @@ import { useState, useEffect } from "react";
 export function useIsMobile(breakpoint: number = 768): boolean {
   // Initialize state based on current window width (handles SSR by defaulting to false)
   const [isMobile, setIsMobile] = useState<boolean>(
-    typeof window !== "undefined" ? window.innerWidth < breakpoint : false
+    typeof window !== 'undefined' ? window.innerWidth < breakpoint : false,
   );
 
   useEffect(() => {
@@ -18,12 +18,12 @@ export function useIsMobile(breakpoint: number = 768): boolean {
     }
 
     // Add event listener
-    window.addEventListener("resize", handleResize);
+    window.addEventListener('resize', handleResize);
     // Call handler once to set initial state
     handleResize();
 
     // Remove event listener on cleanup
-    return () => window.removeEventListener("resize", handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, [breakpoint]);
 
   return isMobile;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import './index.css';
+import './globals.css';
+import { PageProvider } from './store/pageContext';
 
 const container = document.getElementById('root');
 if (!container) {
@@ -11,6 +12,8 @@ if (!container) {
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
-    <App />
+    <PageProvider>
+      <App />
+    </PageProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/layout.tsx
+++ b/frontend/src/layout.tsx
@@ -1,17 +1,17 @@
-import type React from "react"
-import { Inter } from "next/font/google"
-import "./globals.css"
+import type React from 'react';
+import { Inter } from 'next/font/google';
+import './globals.css';
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ['latin'] });
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html lang="fr">
       <body className={inter.className}>{children}</body>
     </html>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add `Sidebar` component using shadcn style buttons
- create reusable `Button` component
- wire sidebar into `App` and wrap application with provider
- add global Tailwind CSS file
- update tests for new navigation

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_6850e765c28c8329b403a22d47b33c7f