### PR TITLE
[backend] protect routes with auth middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test jest --coverage",
+    "test": "cross-env AUTH_PROVIDER=fake NODE_ENV=test jest --coverage",
     "start": "node src/index.ts",
     "dev": "tsx watch src/index.ts --respawn",
     "lint": "eslint . --ext .ts",
@@ -23,6 +23,7 @@
     "@types/dotenv": "^8.2.3",
     "@types/express": "^5.0.3",
     "@types/jest": "^29.5.14",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.0.0",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^8.34.0",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ import { cerfaRouter } from './routes/cerfa.routes';
 import { fecRouter } from './routes/fec.routes';
 import { reportRouter } from './routes/report.routes';
 import { errorHandler } from './middlewares/error.middleware';
+import { requireAuth } from './middlewares/requireAuth';
 
 dotenv.config();
 
@@ -42,6 +43,8 @@ app.use(express.json());
 app.get('/health', (req: Request, res: Response) => {
   res.status(200).json({ ok: true });
 });
+
+app.use(requireAuth);
 
 app.use('/api/v1/articles', articleRouter);
 app.use('/api/v1/operations', operationRouter);

--- a/backend/src/middlewares/requireAuth.ts
+++ b/backend/src/middlewares/requireAuth.ts
@@ -1,23 +1,38 @@
+import { RequestHandler } from 'express'
 import jwt from 'jsonwebtoken'
 
-export function requireAuth(req, res, next) {
+interface SupabasePayload extends jwt.JwtPayload {
+  sub: string
+}
+
+export const requireAuth: RequestHandler = (
+  req,
+  res,
+  next
+) => {
   if (process.env.AUTH_PROVIDER === 'fake') {
     req.user = { id: 'demo-user' }
-    return next()
+    next()
+    return
   }
 
   const token = req.headers.authorization?.split(' ')[1]
-  if (!token) return res.status(401).send('No token')
+  if (!token) {
+    res.status(401).send('No token')
+    return
+  }
 
   try {
-    const payload = jwt.verify(token, process.env.SUPABASE_JWT_SECRET, {
+    const payload = jwt.verify(token, process.env.SUPABASE_JWT_SECRET as string, {
       audience: 'authenticated',
       issuer: 'supabase'
-    })
+    }) as SupabasePayload
     req.user = { id: payload.sub }
     console.log("auth success");
     next()
+    return
   } catch {
     res.status(401).send('Invalid token')
+    return
   }
 }

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,0 +1,10 @@
+import 'express'
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: { id: string }
+    }
+  }
+}
+export {}


### PR DESCRIPTION
## Summary
- add express Request augmentation
- implement `requireAuth` middleware with supabase/fake providers
- protect API routes in `app.ts`
- ensure tests run with `AUTH_PROVIDER=fake`

## Testing
- `pnpm run lint` in backend
- `pnpm run test` in backend
- `pnpm run lint` in frontend
- `pnpm run test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6850f42a55b483298caa18050625b626