### PR TITLE
[frontend] extend BienForm with full property fields

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import type { User } from '@supabase/supabase-js';
 import App from './App';
 import { PageProvider } from './store/pageContext';
 import { BrowserRouter } from 'react-router-dom';
@@ -9,7 +10,7 @@ import { useAuth } from './store/auth';
 
 describe('App navigation', () => {
   it('affiche le dashboard par défaut', async () => {
-    useAuth.setState({ user: { id: '1' } as any, loading: false });
+    useAuth.setState({ user: { id: '1' } as unknown as User, loading: false });
     global.fetch = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
     ) as unknown as typeof fetch;
@@ -26,7 +27,7 @@ describe('App navigation', () => {
   });
 
   it('active le menu MesBiens après clic', async () => {
-    useAuth.setState({ user: { id: '1' } as any, loading: false });
+    useAuth.setState({ user: { id: '1' } as unknown as User, loading: false });
     global.fetch = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
     ) as unknown as typeof fetch;

--- a/frontend/src/components/BienForm.test.tsx
+++ b/frontend/src/components/BienForm.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import BienForm from './BienForm';
+import { describe, it, expect } from 'vitest';
+
+describe('BienForm', () => {
+  it('renders extra fields', () => {
+    render(<BienForm onCancel={() => {}} />);
+    expect(screen.getByLabelText(/code postal/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/nombre de chambres/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/BienForm.tsx
+++ b/frontend/src/components/BienForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { InputField } from './ui/input-field';
 import { Button } from './ui/button';
-import { useBienStore, Bien } from '../store/biens';
+import { useBienStore, Bien, BienInput } from '../store/biens';
 
 interface BienFormProps {
   bien?: Bien | null;
@@ -12,14 +12,103 @@ export default function BienForm({ bien, onCancel }: BienFormProps) {
   const isEdit = Boolean(bien);
   const [typeBien, setTypeBien] = useState(bien?.typeBien ?? '');
   const [adresse, setAdresse] = useState(bien?.adresse ?? '');
+  const [codePostal, setCodePostal] = useState(bien?.codePostal ?? '');
+  const [ville, setVille] = useState(bien?.ville ?? '');
+  const [pays, setPays] = useState(bien?.pays ?? '');
+  const [numeroIdentifiantFiscal, setNumeroIdentifiantFiscal] = useState(
+    bien?.numeroIdentifiantFiscal ?? '',
+  );
+  const [dpe, setDpe] = useState(bien?.dpe ?? '');
+  const [regimeJuridique, setRegimeJuridique] = useState(
+    bien?.regimeJuridique ?? '',
+  );
+  const [surfaceHabitable, setSurfaceHabitable] = useState(
+    bien?.surfaceHabitable?.toString() ?? '',
+  );
+  const [nombrePieces, setNombrePieces] = useState(
+    bien?.nombrePieces?.toString() ?? '',
+  );
+  const [anneeConstruction, setAnneeConstruction] = useState(
+    bien?.anneeConstruction?.toString() ?? '',
+  );
+  const [cuisine, setCuisine] = useState(bien?.cuisine ?? '');
+  const [nombreChambres, setNombreChambres] = useState(
+    bien?.nombreChambres?.toString() ?? '',
+  );
+  const [nombreSejours, setNombreSejours] = useState(
+    bien?.nombreSejours?.toString() ?? '',
+  );
+  const [nombreSallesDEau, setNombreSallesDEau] = useState(
+    bien?.nombreSallesDEau?.toString() ?? '',
+  );
+  const [nombreSallesDeBains, setNombreSallesDeBains] = useState(
+    bien?.nombreSallesDeBains?.toString() ?? '',
+  );
+  const [nombreWC, setNombreWC] = useState(bien?.nombreWC?.toString() ?? '');
+  const [typeChauffage, setTypeChauffage] = useState(bien?.typeChauffage ?? '');
+  const [autresTypesChauffage, setAutresTypesChauffage] = useState(
+    bien?.autresTypesChauffage ?? '',
+  );
+  const [typeEauChaude, setTypeEauChaude] = useState(bien?.typeEauChaude ?? '');
+  const [equipementsDivers, setEquipementsDivers] = useState(
+    bien?.equipementsDivers?.join(', ') ?? '',
+  );
+  const [equipementsNTIC, setEquipementsNTIC] = useState(
+    bien?.equipementsNTIC?.join(', ') ?? '',
+  );
+  const [autresPieces, setAutresPieces] = useState(bien?.autresPieces ?? '');
+  const [
+    autresInformationsComplementaires,
+    setAutresInformationsComplementaires,
+  ] = useState(bien?.autresInformationsComplementaires ?? '');
   const { create, update } = useBienStore();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const payload: BienInput = {
+      typeBien,
+      adresse,
+      codePostal,
+      ville,
+      pays,
+      numeroIdentifiantFiscal,
+      dpe,
+      regimeJuridique,
+      surfaceHabitable: surfaceHabitable ? Number(surfaceHabitable) : undefined,
+      nombrePieces: nombrePieces ? Number(nombrePieces) : undefined,
+      anneeConstruction: anneeConstruction
+        ? Number(anneeConstruction)
+        : undefined,
+      cuisine,
+      nombreChambres: nombreChambres ? Number(nombreChambres) : undefined,
+      nombreSejours: nombreSejours ? Number(nombreSejours) : undefined,
+      nombreSallesDEau: nombreSallesDEau ? Number(nombreSallesDEau) : undefined,
+      nombreSallesDeBains: nombreSallesDeBains
+        ? Number(nombreSallesDeBains)
+        : undefined,
+      nombreWC: nombreWC ? Number(nombreWC) : undefined,
+      typeChauffage,
+      autresTypesChauffage,
+      typeEauChaude,
+      equipementsDivers: equipementsDivers
+        ? equipementsDivers
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined,
+      equipementsNTIC: equipementsNTIC
+        ? equipementsNTIC
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined,
+      autresPieces,
+      autresInformationsComplementaires,
+    };
     if (isEdit && bien) {
-      await update(bien.id, { typeBien, adresse });
+      await update(bien.id, payload);
     } else {
-      await create({ typeBien, adresse });
+      await create(payload);
     }
     onCancel();
   };
@@ -37,6 +126,108 @@ export default function BienForm({ bien, onCancel }: BienFormProps) {
         value={adresse}
         onChange={setAdresse}
         required
+      />
+      <InputField
+        label="Code postal"
+        value={codePostal}
+        onChange={setCodePostal}
+      />
+      <InputField label="Ville" value={ville} onChange={setVille} />
+      <InputField label="Pays" value={pays} onChange={setPays} />
+      <InputField
+        label="Numéro fiscal"
+        value={numeroIdentifiantFiscal}
+        onChange={setNumeroIdentifiantFiscal}
+      />
+      <InputField label="DPE" value={dpe} onChange={setDpe} />
+      <InputField
+        label="Régime juridique"
+        value={regimeJuridique}
+        onChange={setRegimeJuridique}
+      />
+      <InputField
+        label="Surface habitable"
+        value={surfaceHabitable}
+        onChange={setSurfaceHabitable}
+        type="number"
+      />
+      <InputField
+        label="Nombre de pièces"
+        value={nombrePieces}
+        onChange={setNombrePieces}
+        type="number"
+      />
+      <InputField
+        label="Année de construction"
+        value={anneeConstruction}
+        onChange={setAnneeConstruction}
+        type="number"
+      />
+      <InputField label="Cuisine" value={cuisine} onChange={setCuisine} />
+      <InputField
+        label="Nombre de chambres"
+        value={nombreChambres}
+        onChange={setNombreChambres}
+        type="number"
+      />
+      <InputField
+        label="Nombre de séjours"
+        value={nombreSejours}
+        onChange={setNombreSejours}
+        type="number"
+      />
+      <InputField
+        label="Nombre de salles d'eau"
+        value={nombreSallesDEau}
+        onChange={setNombreSallesDEau}
+        type="number"
+      />
+      <InputField
+        label="Nombre de salles de bains"
+        value={nombreSallesDeBains}
+        onChange={setNombreSallesDeBains}
+        type="number"
+      />
+      <InputField
+        label="Nombre de WC"
+        value={nombreWC}
+        onChange={setNombreWC}
+        type="number"
+      />
+      <InputField
+        label="Type de chauffage"
+        value={typeChauffage}
+        onChange={setTypeChauffage}
+      />
+      <InputField
+        label="Autres types de chauffage"
+        value={autresTypesChauffage}
+        onChange={setAutresTypesChauffage}
+      />
+      <InputField
+        label="Type d'eau chaude"
+        value={typeEauChaude}
+        onChange={setTypeEauChaude}
+      />
+      <InputField
+        label="Équipements divers"
+        value={equipementsDivers}
+        onChange={setEquipementsDivers}
+      />
+      <InputField
+        label="Équipements NTIC"
+        value={equipementsNTIC}
+        onChange={setEquipementsNTIC}
+      />
+      <InputField
+        label="Autres pièces"
+        value={autresPieces}
+        onChange={setAutresPieces}
+      />
+      <InputField
+        label="Autres informations"
+        value={autresInformationsComplementaires}
+        onChange={setAutresInformationsComplementaires}
       />
       <div className="space-x-2">
         <Button variant="primary" type="submit">

--- a/frontend/src/components/ui/input-field.test.tsx
+++ b/frontend/src/components/ui/input-field.test.tsx
@@ -16,4 +16,15 @@ describe('InputField', () => {
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
     expect(onChange).toHaveBeenCalledWith('a');
   });
+
+  it('supports a custom type', () => {
+    const onChange = vi.fn();
+    render(
+      <InputField label="Age" value="" onChange={onChange} type="number" />,
+    );
+    fireEvent.change(screen.getByRole('spinbutton'), {
+      target: { value: '2' },
+    });
+    expect(onChange).toHaveBeenCalledWith('2');
+  });
 });

--- a/frontend/src/components/ui/input-field.tsx
+++ b/frontend/src/components/ui/input-field.tsx
@@ -6,6 +6,7 @@ interface InputFieldProps {
   onChange: (value: string) => void;
   placeholder?: string;
   required?: boolean;
+  type?: React.HTMLInputTypeAttribute;
 }
 
 export function InputField({
@@ -14,6 +15,7 @@ export function InputField({
   onChange,
   placeholder,
   required,
+  type = 'text',
 }: InputFieldProps) {
   return (
     <label className="block space-y-1">
@@ -23,6 +25,7 @@ export function InputField({
         value={value}
         placeholder={placeholder}
         required={required}
+        type={type}
         onChange={(e) => onChange(e.target.value)}
       />
     </label>

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -1,33 +1,33 @@
-import { create } from 'zustand'
-import { auth } from '../lib/auth'
-import type { User, Session } from '@supabase/supabase-js'
+import { create } from 'zustand';
+import { auth } from '../lib/auth';
+import type { User, Session } from '@supabase/supabase-js';
 
 interface AuthState {
-  user: User | null
-  token: string | null
-  loading: boolean
-  error: string | null
-  initialize: () => Promise<void>
-  signIn: (email: string, password: string) => Promise<void>
-  signOut: () => Promise<void>
+  user: User | null;
+  token: string | null;
+  loading: boolean;
+  error: string | null;
+  initialize: () => Promise<void>;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
 }
 
-export const useAuth = create<AuthState>((set, get) => {
+export const useAuth = create<AuthState>((set) => {
   // initialise user & token depuis la session existante (si l'utilisateur est déjà connecté)
   auth.getSession().then(({ data: { session } }) => {
     set({
       user: session?.user ?? null,
-      token: session?.access_token ?? null
-    })
-  })
+      token: session?.access_token ?? null,
+    });
+  });
 
   // écoute les changements d'authentification (p. ex. refresh du token, sign out)
   auth.onAuthStateChange((_event, session) => {
     set({
       user: session?.user ?? null,
-      token: session?.access_token ?? null
-    })
-  })
+      token: session?.access_token ?? null,
+    });
+  });
 
   return {
     user: null,
@@ -36,44 +36,46 @@ export const useAuth = create<AuthState>((set, get) => {
     error: null,
 
     initialize: async () => {
-      const { data: { session } } = await auth.getSession()
+      const {
+        data: { session },
+      } = await auth.getSession();
       set({
         user: session?.user ?? null,
-        token: session?.access_token ?? null
-      })
+        token: session?.access_token ?? null,
+      });
     },
 
     signIn: async (email, password) => {
-      set({ loading: true, error: null })
+      set({ loading: true, error: null });
       const { data, error } = await auth.signInWithPassword({
         email,
-        password
-      })
+        password,
+      });
       if (error) {
-        set({ error: error.message, loading: false })
-        throw error
+        set({ error: error.message, loading: false });
+        throw error;
       }
       // data.session contient user + access_token
-      const session: Session = data.session!
+      const session: Session = data.session!;
       set({
         user: session.user,
         token: session.access_token,
-        loading: false
-      })
+        loading: false,
+      });
     },
 
     signOut: async () => {
-      set({ loading: true })
-      const { error } = await auth.signOut()
+      set({ loading: true });
+      const { error } = await auth.signOut();
       if (error) {
-        set({ error: error.message, loading: false })
-        throw error
+        set({ error: error.message, loading: false });
+        throw error;
       }
       set({
         user: null,
         token: null,
-        loading: false
-      })
-    }
-  }
-})
+        loading: false,
+      });
+    },
+  };
+});

--- a/frontend/src/store/biens.ts
+++ b/frontend/src/store/biens.ts
@@ -32,13 +32,13 @@ export interface Bien {
 
 export type BienInput = Omit<Bien, 'id'>;
 
-/** 
- * Supprime les entrées à `undefined` ou `''` 
- * pour ne pas envoyer de champs vides au back. 
+/**
+ * Supprime les entrées à `undefined` ou `''`
+ * pour ne pas envoyer de champs vides au back.
  */
 function clean<T extends object>(obj: T): Partial<T> {
   return Object.fromEntries(
-    Object.entries(obj).filter(([_, v]) => v != null && v !== '')
+    Object.entries(obj).filter(([, v]) => v != null && v !== ''),
   ) as Partial<T>;
 }
 


### PR DESCRIPTION
## Summary
- allow InputField to accept custom `type`
- render all property-related fields in BienForm and process them on submit
- test InputField with custom type
- test BienForm for presence of new fields
- fix lint warnings in App.test and stores

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_68513961e074832980b95b636c321631