### PR TITLE
[frontend] restructure profile page

### DIFF
--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../utils/api';
+import type { UserProfile } from '@monorepo/shared';
+
+export function useUserProfile() {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProfile = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiFetch<UserProfile | null>('/api/user/profile');
+      setProfile(data);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const updateProfile = useCallback(async (data: Partial<UserProfile>) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const updated = await apiFetch<UserProfile>('/api/user/profile', {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      });
+      setProfile(updated);
+      return updated;
+    } catch (e) {
+      setError((e as Error).message);
+      throw e;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const deleteProfile = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await apiFetch('/api/user/profile', { method: 'DELETE' });
+      setProfile(null);
+    } catch (e) {
+      setError((e as Error).message);
+      throw e;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  return {
+    profile,
+    loading,
+    error,
+    fetchProfile,
+    updateProfile,
+    deleteProfile,
+  };
+}

--- a/frontend/src/pages/MonCompte.test.tsx
+++ b/frontend/src/pages/MonCompte.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import MonCompte from './MonCompte';
+
+// basic test to ensure profile is fetched and shown
+
+describe('MonCompte page', () => {
+  it('fetches and displays profile', async () => {
+    const mockProfile = {
+      nom: 'Dupont',
+      prenom: 'Jean',
+      email: 'jean@exemple.com',
+      telephone: '0102030405',
+      adresse: '1 rue ici',
+    };
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(mockProfile) }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(
+      <MemoryRouter>
+        <MonCompte />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(await screen.findByDisplayValue('Dupont')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('Jean')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MonCompte.tsx
+++ b/frontend/src/pages/MonCompte.tsx
@@ -1,3 +1,113 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { UserProfile } from '@monorepo/shared';
+import { useUserProfile } from '../hooks/useUserProfile';
+import { formatPhone } from '../utils/formatPhone';
+import { validateEmail } from '../utils/validateEmail';
+
 export default function MonCompte() {
-  return <h1>Mon compte</h1>;
+  const navigate = useNavigate();
+  const { profile, loading, error, updateProfile, deleteProfile } =
+    useUserProfile();
+  const [editing, setEditing] = useState(false);
+  const [form, setForm] = useState<UserProfile>({
+    nom: '',
+    prenom: '',
+    email: '',
+    telephone: '',
+    adresse: '',
+  });
+
+  // met à jour le formulaire quand le profil est chargé
+  useEffect(() => {
+    if (profile) setForm(profile);
+  }, [profile]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const save = async () => {
+    if (!validateEmail(form.email)) {
+      alert('Email invalide');
+      return;
+    }
+    await updateProfile({ ...form, telephone: formatPhone(form.telephone) });
+    setEditing(false);
+  };
+
+  const remove = async () => {
+    if (
+      window.confirm(
+        'Attention : cette opération est irréversible.\nSouhaitez-vous vraiment supprimer votre compte ?',
+      )
+    ) {
+      await deleteProfile();
+      navigate('/');
+    }
+  };
+
+  if (loading && !editing) return <div>Chargement...</div>;
+  return (
+    <div>
+      <h1>Mon compte</h1>
+      {error && <div role="alert">{error}</div>}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          save();
+        }}
+        className="space-y-2"
+      >
+        <input
+          name="nom"
+          value={form.nom}
+          onChange={handleChange}
+          disabled={!editing}
+          placeholder="Nom"
+        />
+        <input
+          name="prenom"
+          value={form.prenom}
+          onChange={handleChange}
+          disabled={!editing}
+          placeholder="Prénom"
+        />
+        <input
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          disabled={!editing}
+          placeholder="Email"
+        />
+        <input
+          name="telephone"
+          value={form.telephone}
+          onChange={handleChange}
+          disabled={!editing}
+          placeholder="Téléphone"
+        />
+        <input
+          name="adresse"
+          value={form.adresse}
+          onChange={handleChange}
+          disabled={!editing}
+          placeholder="Adresse"
+        />
+        {editing ? (
+          <button type="submit" disabled={loading}>
+            Enregistrer
+          </button>
+        ) : (
+          <button type="button" onClick={() => setEditing(true)}>
+            Modifier
+          </button>
+        )}
+      </form>
+      <button onClick={remove} disabled={loading}>
+        Supprimer mon profil
+      </button>
+    </div>
+  );
 }

--- a/frontend/src/utils/formatPhone.ts
+++ b/frontend/src/utils/formatPhone.ts
@@ -1,0 +1,4 @@
+export function formatPhone(value: string): string {
+  const digits = value.replace(/\D/g, '');
+  return digits.replace(/(\d{2})(?=\d)/g, '$1 ').trim();
+}

--- a/frontend/src/utils/validateEmail.ts
+++ b/frontend/src/utils/validateEmail.ts
@@ -1,0 +1,3 @@
+export function validateEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({  plugins: [react()],
+export default defineConfig({
+  plugins: [react()],
   resolve: {
-    extensions: ['.js', '.ts', '.jsx', '.tsx']
+    extensions: ['.js', '.ts', '.jsx', '.tsx'],
+    alias: {
+      '@monorepo/shared': resolve(__dirname, '../shared/src'),
+    },
   },
   test: {
     environment: 'jsdom',

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,7 @@
 import type { Prisma } from '@prisma/client';
 
-export type NewBien  = Prisma.BienCreateInput;
+export type NewBien = Prisma.BienCreateInput;
 export type EditBien = Prisma.BienUpdateInput;
+
+export * from './types/UserProfile';
+export * from './types/ApiResponse';

--- a/shared/src/types/ApiResponse.ts
+++ b/shared/src/types/ApiResponse.ts
@@ -1,0 +1,4 @@
+export interface ApiResponse<T> {
+  data: T;
+  error?: string;
+}

--- a/shared/src/types/UserProfile.ts
+++ b/shared/src/types/UserProfile.ts
@@ -1,0 +1,8 @@
+export interface UserProfile {
+  id?: number;
+  nom: string;
+  prenom: string;
+  email: string;
+  telephone?: string;
+  adresse?: string;
+}


### PR DESCRIPTION
## Summary
- move profile utilities and hook to frontend
- keep `/compte` route and update sidebar link
- export only types from shared package
- ensure MonCompte page uses local helpers

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6851a08e848c8329a516991f441790da