### PR TITLE
[frontend] add signup page and auth

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Resultats from './pages/Resultats';
 import Abonnement from './pages/Abonnement';
 import MonCompte from './pages/MonCompte';
 import Login from './pages/Login';
+import SignUp from './pages/SignUp';
 import { usePageStore } from './store/pageContext';
 import { Sidebar } from './components/Sidebar';
 
@@ -53,6 +54,7 @@ export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<SignUp />} />
       <Route path="/*" element={<ProtectedLayout />} />
     </Routes>
   );

--- a/frontend/src/__mocks__/supabase.ts
+++ b/frontend/src/__mocks__/supabase.ts
@@ -2,6 +2,7 @@ export const createClient = () => ({
   auth: {
     getUser: () => Promise.resolve({ data: { user: null } }),
     signInWithPassword: () => Promise.resolve({ data: { user: null } }),
+    signUp: () => Promise.resolve({ data: { user: null, session: null } }),
     signOut: () => Promise.resolve(),
   },
 });

--- a/frontend/src/lib/auth.fake.ts
+++ b/frontend/src/lib/auth.fake.ts
@@ -25,7 +25,9 @@ export function createAuthProvider() {
   return {
     getCurrentUser: async () => user,
     getSession: async () => ({ data: { session } }),
-    onAuthStateChange: (callback: (event: string, session: Session | null) => void) => {
+    onAuthStateChange: (
+      callback: (event: string, session: Session | null) => void,
+    ) => {
       // Simuler un changement d'état immédiat
       callback('SIGNED_IN', session);
       return { data: { subscription: { unsubscribe: () => {} } } };
@@ -35,6 +37,42 @@ export function createAuthProvider() {
         return user;
       }
       throw new Error('Identifiants invalides');
+    },
+    signInWithPassword: async ({
+      email,
+      password,
+    }: {
+      email: string;
+      password: string;
+    }) => {
+      if (email && password) {
+        return {
+          data: { user, session },
+          error: null,
+        } as { data: { user: User; session: Session }; error: null };
+      }
+      return {
+        data: { user: null, session: null },
+        error: { message: 'invalid' },
+      } as { data: { user: null; session: null }; error: { message: string } };
+    },
+    signUp: async ({
+      email,
+      password,
+    }: {
+      email: string;
+      password: string;
+    }) => {
+      if (email && password) {
+        return {
+          data: { user, session },
+          error: null,
+        } as { data: { user: User; session: Session }; error: null };
+      }
+      return {
+        data: { user: null, session: null },
+        error: { message: 'invalid' },
+      } as { data: { user: null; session: null }; error: { message: string } };
     },
     signOut: async () => {
       return { error: null };

--- a/frontend/src/lib/auth.supabase.ts
+++ b/frontend/src/lib/auth.supabase.ts
@@ -15,8 +15,9 @@ export function createAuthProvider() {
       return user;
     },
     getSession: () => supabase.auth.getSession(),
-    onAuthStateChange: (callback: (event: string, session: Session | null) => void) => 
-      supabase.auth.onAuthStateChange(callback),
+    onAuthStateChange: (
+      callback: (event: string, session: Session | null) => void,
+    ) => supabase.auth.onAuthStateChange(callback),
     signIn: (email: string, password: string) =>
       supabase.auth
         .signInWithPassword({ email, password })
@@ -25,7 +26,12 @@ export function createAuthProvider() {
           return data.user;
         }),
     signOut: () => supabase.auth.signOut(),
-    signInWithPassword: (credentials: { email: string; password: string }) => 
-      supabase.auth.signInWithPassword(credentials)
+    signInWithPassword: (credentials: { email: string; password: string }) =>
+      supabase.auth.signInWithPassword(credentials),
+    signUp: (params: {
+      email: string;
+      password: string;
+      options?: { data: { firstName: string; lastName: string } };
+    }) => supabase.auth.signUp(params),
   };
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -75,6 +75,14 @@ export default function Login() {
             ➡︎ Accès démo direct
           </button>
         )}
+        <button
+          type="button"
+          onClick={() => navigate('/signup')}
+          className="border p-2 rounded hover:bg-gray-100 disabled:opacity-50"
+          disabled={loading}
+        >
+          Créer un compte
+        </button>
       </form>
     </div>
   );

--- a/frontend/src/pages/SignUp.test.tsx
+++ b/frontend/src/pages/SignUp.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import SignUp from './SignUp';
+import { useAuth, type AuthState } from '../store/auth';
+
+describe('SignUp page', () => {
+  it('calls signUp with form values', async () => {
+    const signUpMock = vi.fn(() => Promise.resolve());
+    useAuth.setState({ signUp: signUpMock } as Partial<AuthState>);
+    render(
+      <MemoryRouter>
+        <SignUp />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Prénom'), {
+      target: { value: 'John' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Nom'), {
+      target: { value: 'Doe' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('E-mail'), {
+      target: { value: 'john@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Mot de passe'), {
+      target: { value: 'Passw0rd!' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Confirmation'), {
+      target: { value: 'Passw0rd!' },
+    });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /s’inscrire/i }));
+
+    await waitFor(() => expect(signUpMock).toHaveBeenCalled());
+    expect(signUpMock).toHaveBeenCalledWith(
+      'john@example.com',
+      'Passw0rd!',
+      'John',
+      'Doe',
+    );
+  });
+});

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,0 +1,122 @@
+import { FormEvent, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../store/auth';
+import { validateEmail } from '../utils/validateEmail';
+
+export default function SignUp() {
+  const navigate = useNavigate();
+  const signUp = useAuth((s) => s.signUp);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [accept, setAccept] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const [emailValid, setEmailValid] = useState(true);
+  const [pwdValid, setPwdValid] = useState(true);
+  const [confirmValid, setConfirmValid] = useState(true);
+
+  useEffect(() => {
+    setEmailValid(!email || validateEmail(email));
+  }, [email]);
+
+  useEffect(() => {
+    setPwdValid(
+      !password || (password.length >= 8 && /[^A-Za-z0-9]/.test(password)),
+    );
+    setConfirmValid(!confirm || confirm === password);
+  }, [password, confirm]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const isEmailValid = validateEmail(email);
+    const isPwdValid = password.length >= 8 && /[^A-Za-z0-9]/.test(password);
+    const isConfirmValid = password === confirm;
+    setEmailValid(isEmailValid);
+    setPwdValid(isPwdValid);
+    setConfirmValid(isConfirmValid);
+    if (!isEmailValid || !isPwdValid || !isConfirmValid || !accept) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await signUp(email, password, firstName, lastName);
+      navigate('/');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-4 max-w-xs w-full p-4"
+      >
+        <h1 className="text-2xl font-bold mb-4">Inscription</h1>
+        {error && (
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+            {error}
+          </div>
+        )}
+        <input
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          placeholder="Prénom"
+          className="border p-2 rounded"
+          disabled={loading}
+        />
+        <input
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          placeholder="Nom"
+          className="border p-2 rounded"
+          disabled={loading}
+        />
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="E-mail"
+          className={`border p-2 rounded ${emailValid ? '' : 'border-red-500'}`}
+          disabled={loading}
+        />
+        <input
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Mot de passe"
+          type="password"
+          className={`border p-2 rounded ${pwdValid ? '' : 'border-red-500'}`}
+          disabled={loading}
+        />
+        <input
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          placeholder="Confirmation"
+          type="password"
+          className={`border p-2 rounded ${confirmValid ? '' : 'border-red-500'}`}
+          disabled={loading}
+        />
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={accept}
+            onChange={(e) => setAccept(e.target.checked)}
+            disabled={loading}
+          />
+          J’accepte les CGU
+        </label>
+        <button
+          type="submit"
+          className="bg-blue-500 text-white p-2 rounded hover:bg-blue-600 disabled:opacity-50"
+          disabled={loading}
+        >
+          {loading ? 'S\u2019inscrire...' : 'S\u2019inscrire'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -6,6 +6,7 @@ vi.mock('@supabase/supabase-js', () => ({
     auth: {
       getUser: () => Promise.resolve({ data: { user: null } }),
       signInWithPassword: () => Promise.resolve({ data: { user: null } }),
+      signUp: () => Promise.resolve({ data: { user: null, session: null } }),
       signOut: () => Promise.resolve(),
     },
   }),


### PR DESCRIPTION
## Summary
- add SignUp page with realtime validation and Supabase call
- integrate sign-up route and link from login page
- extend auth store with signUp
- update auth providers and test mocks
- cover sign-up with a new test

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_685254fa0600832983e638bbb33a8462