### PR TITLE
[backend] secure profile routes with user context

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -21,6 +21,14 @@ class PrismaClient {
       update: jest.fn(),
       delete: jest.fn(),
     };
+    this.profile = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
+      deleteMany: jest.fn(),
+    };
     this.logement = {
       create: jest.fn(),
       findMany: jest.fn(),

--- a/backend/src/@types/prisma-client.d.ts
+++ b/backend/src/@types/prisma-client.d.ts
@@ -11,10 +11,11 @@ declare module '@prisma/client' {
     };
     profile: {
       create: (args: unknown) => unknown;
-      findMany: () => unknown;
+      findMany: (args: unknown) => unknown;
+      findFirst: (args: unknown) => unknown;
       findUnique: (args: unknown) => unknown;
-      update: (args: unknown) => unknown;
-      delete: (args: unknown) => unknown;
+      updateMany: (args: unknown) => { count: number };
+      deleteMany: (args: unknown) => { count: number };
     };
   }
 }

--- a/backend/src/@types/prisma.d.ts
+++ b/backend/src/@types/prisma.d.ts
@@ -13,9 +13,10 @@ declare module '@prisma/client' {
     profile: {
       create: (...args: any[]) => any;
       findMany: (...args: any[]) => any;
+      findFirst: (...args: any[]) => any;
       findUnique: (...args: any[]) => any;
-      update: (...args: any[]) => any;
-      delete: (...args: any[]) => any;
+      updateMany: (...args: any[]) => { count: number };
+      deleteMany: (...args: any[]) => { count: number };
     };
   }
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -57,7 +57,7 @@ app.use((req, res, next) => {
       try {
         const parsedBody = JSON.parse(body);
         console.log('Body parsé:', JSON.stringify(parsedBody, null, 2));
-      } catch (e) {
+      } catch {
         console.log('Body non-JSON:', body);
       }
     }
@@ -80,7 +80,7 @@ app.use('/api/v1/operations', operationRouter);
 app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/logements', logementRouter);
 app.use('/api/v1/biens', bienRouter);
-app.use('/api/v1/profile', profileRouter);
+app.use('/api/v1/profiles', profileRouter);
 app.use('/api/v1/fiscal', fiscalRouter);
 app.use('/api/v1/fec', fecRouter);
 app.use('/api/v1/amortissements', amortissementRouter);

--- a/backend/src/controllers/profile.controller.ts
+++ b/backend/src/controllers/profile.controller.ts
@@ -4,16 +4,16 @@ import { ProfileService } from '../services/profile.service';
 export const ProfileController = {
   async create(req: Request, res: Response, next: NextFunction) {
     try {
-      const profile = await ProfileService.create(req.body);
+      const profile = await ProfileService.create(req.user.id, req.body);
       res.status(201).json(profile);
     } catch (e) {
       next(e);
     }
   },
 
-  async list(_req: Request, res: Response, next: NextFunction) {
+  async list(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await ProfileService.list());
+      res.json(await ProfileService.list(req.user.id));
     } catch (e) {
       next(e);
     }
@@ -21,7 +21,7 @@ export const ProfileController = {
 
   async get(req: Request, res: Response, next: NextFunction) {
     try {
-      const profile = await ProfileService.get(req.params.id);
+      const profile = await ProfileService.get(req.params.profileId, req.user.id);
       if (!profile) {
         res.sendStatus(404);
         return;
@@ -33,10 +33,12 @@ export const ProfileController = {
   },
 
   async update(req: Request, res: Response, next: NextFunction) {
-    console.log('[Controller.updateProfile] params.id =', req.params.id);
-    console.log('[Controller.updateProfile] req.body =', req.body);  
     try {
-      const profile = await ProfileService.update(req.params.id, req.body);
+      const profile = await ProfileService.update(
+        req.params.profileId,
+        req.user.id,
+        req.body
+      );
       res.json(profile);
     } catch (e) {
       next(e);
@@ -45,7 +47,7 @@ export const ProfileController = {
 
   async remove(req: Request, res: Response, next: NextFunction) {
     try {
-      await ProfileService.remove(req.params.id);
+      await ProfileService.remove(req.params.profileId, req.user.id);
       res.sendStatus(204);
     } catch (e) {
       next(e);

--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction, ErrorRequestHandler } from 'express';
 import { ZodError } from 'zod';
+import { NotFoundError } from '../services/profile.service';
 
 export const errorHandler: ErrorRequestHandler = (
   err: unknown,
@@ -12,6 +13,10 @@ export const errorHandler: ErrorRequestHandler = (
       message: 'Validation error',
       errors: err.flatten(),
     });
+    return;
+  }
+  if (err instanceof NotFoundError) {
+    res.status(404).json({ message: 'Not Found' });
     return;
   }
   console.error(err);

--- a/backend/src/middlewares/requireAuth.ts
+++ b/backend/src/middlewares/requireAuth.ts
@@ -29,7 +29,7 @@ export const requireAuth: RequestHandler = (
     req.user = { id: payload.sub }
     next()
     return
-  } catch (error) {
+  } catch {
     res.status(401).send('Invalid token')
     return
   }

--- a/backend/src/schemas/profile.schema.ts
+++ b/backend/src/schemas/profile.schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 export const createProfileSchema = z.object({
-  userId: z.string().uuid(),
   prTexte: z.string().max(255),
   nif: z.string().max(255),
   nifReadonly: z.boolean(),
@@ -16,4 +15,4 @@ export const createProfileSchema = z.object({
 });
 
 export const updateProfileSchema = createProfileSchema.partial();
-export const profileIdParam = z.object({id: z.string().uuid()});
+export const profileIdParam = z.object({ profileId: z.string().uuid() });

--- a/backend/src/services/profile.service.ts
+++ b/backend/src/services/profile.service.ts
@@ -2,31 +2,37 @@ import { prisma } from '../prisma';
 
 type ProfileData = Record<string, unknown>;
 
+export class NotFoundError extends Error {}
+
 export const ProfileService = {
-  create(data: ProfileData) {
-    return prisma.profile.create({ data });
+  list(userId: string) {
+    return prisma.profile.findMany({ where: { userId } });
   },
 
-  list() {
-    return prisma.profile.findMany();
+  create(userId: string, data: ProfileData) {
+    return prisma.profile.create({ data: { userId, ...data } });
   },
 
-  get(id: string) {
-    return prisma.profile.findUnique({ where: { id } });
+  get(profileId: string, userId: string) {
+    return prisma.profile.findFirst({ where: { id: profileId, userId } });
   },
 
-  update(id: string, data: Partial<ProfileData>) {
-    console.log(`[ProfileService.update] id=`, id, `data=`, data)
+  async update(profileId: string, userId: string, data: Partial<ProfileData>) {
     if (!data || Object.keys(data).length === 0) {
-      throw new Error("No update data provided for profile " + id)
+      throw new Error('No update data provided for profile ' + profileId);
     }
-    return prisma.profile.update({ 
-      where: { id }, 
-      data 
+    const { count } = await prisma.profile.updateMany({
+      where: { id: profileId, userId },
+      data,
     });
+    if (count === 0) throw new NotFoundError();
+    return prisma.profile.findUnique({ where: { id: profileId } });
   },
 
-  remove(id: string) {
-    return prisma.profile.delete({ where: { id } });
+  async remove(profileId: string, userId: string) {
+    const { count } = await prisma.profile.deleteMany({
+      where: { id: profileId, userId },
+    });
+    if (count === 0) throw new NotFoundError();
   },
 };

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -3,7 +3,7 @@ import 'express'
 declare global {
   namespace Express {
     interface Request {
-      user?: { id: string }
+      user: { id: string }
     }
   }
 }

--- a/backend/tests/profile.routes.test.ts
+++ b/backend/tests/profile.routes.test.ts
@@ -20,5 +20,6 @@ describe('GET /api/v1/profiles', () => {
     const res = await request(app).get('/api/v1/profiles');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith('demo-user');
   });
 });


### PR DESCRIPTION
## Summary
- enforce user-based profile ownership
- rename API prefix to `/api/v1/profiles`
- wire controller to pass `req.user.id`
- restrict profile schema to backend user id
- add NotFoundError and hook error middleware
- update Prisma mocks and type stubs
- adjust profile route tests for ownership

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`

------
https://chatgpt.com/codex/tasks/task_e_6852ad2f3f548329bf77702eae10947b