### PR TITLE
[frontend] store profileId in Zustand

### DIFF
--- a/backend/tests/profile.routes.test.ts
+++ b/backend/tests/profile.routes.test.ts
@@ -11,13 +11,13 @@ jest.mock('../src/services/profile.service');
 
 const mockedService = ProfileService as jest.Mocked<typeof ProfileService>;
 
-describe('GET /api/v1/profiles', () => {
+describe('GET /api/v1/profile', () => {
   it('returns profiles from service', async () => {
     (mockedService.list as jest.Mock).mockResolvedValueOnce([
       { id: 1, prTexte: 'Prof' } as ProfileStub,
     ]);
 
-    const res = await request(app).get('/api/v1/profiles');
+    const res = await request(app).get('/api/v1/profile');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
     expect(mockedService.list).toHaveBeenCalledWith('demo-user');

--- a/frontend/src/pages/MonCompte.test.tsx
+++ b/frontend/src/pages/MonCompte.test.tsx
@@ -8,6 +8,7 @@ import MonCompte from './MonCompte';
 describe('MonCompte page', () => {
   it('fetches and displays profile', async () => {
     const mockProfile = {
+      id: 'id-42',
       nom: 'Dupont',
       prenom: 'Jean',
       email: 'jean@exemple.com',

--- a/frontend/src/store/userProfile.test.ts
+++ b/frontend/src/store/userProfile.test.ts
@@ -9,14 +9,18 @@ describe('useUserProfileStore', () => {
     useAuth.setState({ token: 'tok' });
     useUserProfileStore.setState({
       profile: null,
+      profileId: null,
       loading: false,
       error: null,
+      setProfileId: () => {},
     });
     (fetch as unknown as vi.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ nom: 'Doe' }),
+      json: () => Promise.resolve({ id: '123', nom: 'Doe' }),
     });
     await useUserProfileStore.getState().fetchProfile();
-    expect(useUserProfileStore.getState().profile?.nom).toBe('Doe');
+    const state = useUserProfileStore.getState();
+    expect(state.profile?.nom).toBe('Doe');
+    expect(state.profileId).toBe('123');
   });
 });


### PR DESCRIPTION
## Summary
- keep track of profileId in `useUserProfileStore`
- adjust profile routes test path
- update associated unit tests

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter backend run lint`
- `pnpm --filter frontend run test`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_6852d833077c8329bc37a1ebf0fd7654