### PR TITLE
[backend] secure Bien routes by profile

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -7,6 +7,14 @@ class PrismaClient {
       update: jest.fn(),
       delete: jest.fn(),
     };
+    this.bien = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
     this.operation = {
       create: jest.fn(),
       findMany: jest.fn(),

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -79,7 +79,7 @@ app.use('/api/v1/articles', articleRouter);
 app.use('/api/v1/operations', operationRouter);
 app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/logements', logementRouter);
-app.use('/api/v1/biens', bienRouter);
+app.use('/api/v1/profile/:profileId/biens', bienRouter);
 app.use('/api/v1/profile', profileRouter);
 app.use('/api/v1/fiscal', fiscalRouter);
 app.use('/api/v1/fec', fecRouter);

--- a/backend/src/controllers/bien.controller.ts
+++ b/backend/src/controllers/bien.controller.ts
@@ -4,16 +4,20 @@ import { BienService } from '../services/bien.service';
 export const BienController = {
   async create(req: Request, res: Response, next: NextFunction) {
     try {
-      const bien = await BienService.create(req.body);
+      const bien = await BienService.create(
+        req.user.id,
+        req.params.profileId,
+        req.body,
+      );
       res.status(201).json(bien);
     } catch (e) {
       next(e);
     }
   },
 
-  async list(_req: Request, res: Response, next: NextFunction) {
+  async list(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await BienService.list());
+      res.json(await BienService.list(req.user.id, req.params.profileId));
     } catch (e) {
       next(e);
     }
@@ -21,11 +25,11 @@ export const BienController = {
 
   async get(req: Request, res: Response, next: NextFunction) {
     try {
-      const bien = await BienService.get(req.params.id);
-      if (!bien) {
-        res.sendStatus(404);
-        return;
-      }
+      const bien = await BienService.get(
+        req.user.id,
+        req.params.profileId,
+        req.params.id,
+      );
       res.json(bien);
     } catch (e) {
       next(e);
@@ -34,7 +38,12 @@ export const BienController = {
 
   async update(req: Request, res: Response, next: NextFunction) {
     try {
-      const bien = await BienService.update(req.params.id, req.body);
+      const bien = await BienService.update(
+        req.user.id,
+        req.params.profileId,
+        req.params.id,
+        req.body,
+      );
       res.json(bien);
     } catch (e) {
       next(e);
@@ -43,7 +52,11 @@ export const BienController = {
 
   async remove(req: Request, res: Response, next: NextFunction) {
     try {
-      await BienService.remove(req.params.id);
+      await BienService.remove(
+        req.user.id,
+        req.params.profileId,
+        req.params.id,
+      );
       res.sendStatus(204);
     } catch (e) {
       next(e);

--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction, ErrorRequestHandler } from 'express';
 import { ZodError } from 'zod';
 import { NotFoundError } from '../services/profile.service';
+import { ForbiddenError } from '../services/bien.service';
 
 export const errorHandler: ErrorRequestHandler = (
   err: unknown,
@@ -17,6 +18,10 @@ export const errorHandler: ErrorRequestHandler = (
   }
   if (err instanceof NotFoundError) {
     res.status(404).json({ message: 'Not Found' });
+    return;
+  }
+  if (err instanceof ForbiddenError) {
+    res.status(403).json({ message: 'Forbidden' });
     return;
   }
   console.error(err);

--- a/backend/src/routes/bien.routes.ts
+++ b/backend/src/routes/bien.routes.ts
@@ -6,8 +6,9 @@ import {
   updateBienSchema,
   bienIdParam,
 } from '../schemas/bien.schema';
+import { profileIdParam } from '../schemas/profile.schema';
 
-export const bienRouter = Router();
+export const bienRouter = Router({ mergeParams: true });
 
 bienRouter
   .route('/')

--- a/backend/src/services/bien.service.ts
+++ b/backend/src/services/bien.service.ts
@@ -1,36 +1,62 @@
 import { prisma } from '../prisma';
 import type { EditBien, NewBien } from '@monorepo/shared';
+import { NotFoundError } from './profile.service';
+
+export class ForbiddenError extends Error {}
 
 interface PrismaWithBien {
   bien: {
     create: (...args: unknown[]) => unknown;
     findMany: (...args: unknown[]) => unknown;
+    findFirst: (...args: unknown[]) => unknown;
     findUnique: (...args: unknown[]) => unknown;
     update: (...args: unknown[]) => unknown;
     delete: (...args: unknown[]) => unknown;
   };
 }
 
-const db = prisma as unknown as PrismaWithBien;
+const db = prisma as unknown as PrismaWithBien & {
+  profile: { findFirst: (...args: unknown[]) => unknown };
+};
+
+async function ensureProfileOwnership(profileId: string, userId: string) {
+  const profile = (await db.profile.findFirst({ where: { id: profileId, userId } })) as unknown;
+  if (!profile) throw new ForbiddenError();
+}
 
 export const BienService = {
-  create(data: NewBien) {
-    return db.bien.create({ data });
+  async create(userId: string, profileId: string, data: NewBien) {
+    await ensureProfileOwnership(profileId, userId);
+    return db.bien.create({ data: { ...data, profileId } });
   },
 
-  list() {
-    return db.bien.findMany();
+  async list(userId: string, profileId: string) {
+    await ensureProfileOwnership(profileId, userId);
+    return db.bien.findMany({ where: { profileId } });
   },
 
-  get(id: string) {
-    return db.bien.findUnique({ where: { id } });
+  async get(userId: string, profileId: string, id: string) {
+    const bien = (await db.bien.findFirst({
+      where: { id, profileId, profile: { userId } },
+    })) as unknown;
+    if (!bien) {
+      const exists = await db.bien.findUnique({ where: { id } });
+      if (!exists) throw new NotFoundError();
+      throw new ForbiddenError();
+    }
+    return bien;
   },
 
-  update(id: string, data: EditBien) {
+  async update(userId: string, profileId: string, id: string, data: EditBien) {
+    if (!data || Object.keys(data).length === 0) {
+      throw new Error('No update data provided for bien ' + id);
+    }
+    await BienService.get(userId, profileId, id);
     return db.bien.update({ where: { id }, data });
   },
 
-  remove(id: string) {
+  async remove(userId: string, profileId: string, id: string) {
+    await BienService.get(userId, profileId, id);
     return db.bien.delete({ where: { id } });
   },
 };

--- a/backend/tests/bien.routes.test.ts
+++ b/backend/tests/bien.routes.test.ts
@@ -11,14 +11,16 @@ jest.mock('../src/services/bien.service');
 
 const mockedService = BienService as jest.Mocked<typeof BienService>;
 
-describe('GET /api/v1/biens', () => {
+describe('GET /api/v1/profile/:profileId/biens', () => {
   it('returns biens from service', async () => {
     (mockedService.list as jest.Mock).mockResolvedValueOnce([
       { id: '1', typeBien: 'APPARTEMENT' } as BienStub,
     ]);
 
-    const res = await request(app).get('/api/v1/biens');
+    const id = '00000000-0000-0000-0000-000000000000';
+    const res = await request(app).get(`/api/v1/profile/${id}/biens`);
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith('demo-user', id);
   });
 });

--- a/backend/tests/bien.service.test.ts
+++ b/backend/tests/bien.service.test.ts
@@ -1,0 +1,66 @@
+import { BienService, ForbiddenError } from '../src/services/bien.service';
+import { NotFoundError } from '../src/services/profile.service';
+import type { NewBien, EditBien } from '@monorepo/shared';
+
+jest.mock('../src/prisma', () => ({
+  prisma: {
+    profile: { findFirst: jest.fn() },
+    bien: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '../src/prisma';
+const mockedPrisma = prisma as unknown as {
+  profile: { findFirst: jest.Mock };
+  bien: {
+    create: jest.Mock;
+    findMany: jest.Mock;
+    findFirst: jest.Mock;
+    findUnique: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
+};
+
+describe('BienService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a bien with profileId', async () => {
+    mockedPrisma.profile.findFirst.mockResolvedValueOnce({ id: 'p1' });
+    mockedPrisma.bien.create.mockResolvedValueOnce({ id: 'b1', profileId: 'p1' });
+    await BienService.create('u1', 'p1', { typeBien: 'APT', adresse: 'a' } as NewBien);
+    expect(mockedPrisma.bien.create).toHaveBeenCalledWith({ data: { typeBien: 'APT', adresse: 'a', profileId: 'p1' } });
+  });
+
+  it('lists biens for profile', async () => {
+    mockedPrisma.profile.findFirst.mockResolvedValueOnce({ id: 'p1' });
+    mockedPrisma.bien.findMany.mockResolvedValueOnce([]);
+    await BienService.list('u1', 'p1');
+    expect(mockedPrisma.bien.findMany).toHaveBeenCalledWith({ where: { profileId: 'p1' } });
+  });
+
+  it('throws ForbiddenError on update of other profile', async () => {
+    mockedPrisma.bien.findFirst.mockResolvedValueOnce(null);
+    mockedPrisma.bien.findUnique.mockResolvedValueOnce({ id: 'b1' });
+    await expect(
+      BienService.update('u1', 'p1', 'b1', { adresse: 'b' } as EditBien),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it('throws NotFoundError on update of missing bien', async () => {
+    mockedPrisma.bien.findFirst.mockResolvedValueOnce(null);
+    mockedPrisma.bien.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      BienService.update('u1', 'p1', 'b1', { adresse: 'b' } as EditBien),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,12 +5,19 @@ import App from './App';
 import { PageProvider } from './store/pageContext';
 import { BrowserRouter } from 'react-router-dom';
 import { useAuth } from './store/auth';
+import {
+  useUserProfileStore,
+  type UserProfileState,
+} from './store/userProfile';
 
 // Tests simplifiés pour la navigation
 
 describe('App navigation', () => {
   it('affiche le dashboard par défaut', async () => {
     useAuth.setState({ user: { id: '1' } as unknown as User, loading: false });
+    useUserProfileStore.setState(
+      (state) => ({ ...state, profileId: 'p1' }) as UserProfileState,
+    );
     global.fetch = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
     ) as unknown as typeof fetch;
@@ -28,6 +35,9 @@ describe('App navigation', () => {
 
   it('active le menu MesBiens après clic', async () => {
     useAuth.setState({ user: { id: '1' } as unknown as User, loading: false });
+    useUserProfileStore.setState(
+      (state) => ({ ...state, profileId: 'p1' }) as UserProfileState,
+    );
     global.fetch = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
     ) as unknown as typeof fetch;

--- a/frontend/src/pages/MonCompte.test.tsx
+++ b/frontend/src/pages/MonCompte.test.tsx
@@ -2,6 +2,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 import MonCompte from './MonCompte';
+import { useAuth, type AuthState } from '../store/auth';
+import {
+  useUserProfileStore,
+  type UserProfileState,
+} from '../store/userProfile';
 
 // basic test to ensure profile is fetched and shown
 
@@ -16,7 +21,11 @@ describe('MonCompte page', () => {
       adresse: '1 rue ici',
     };
     const fetchMock = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(mockProfile) }),
+      Promise.resolve({ ok: true, json: () => Promise.resolve([mockProfile]) }),
+    );
+    useAuth.setState((state) => ({ ...state, token: 'tok' }) as AuthState);
+    useUserProfileStore.setState(
+      (state) => ({ ...state, profileId: 'id-42' }) as UserProfileState,
     );
     global.fetch = fetchMock as unknown as typeof fetch;
 

--- a/frontend/src/store/biens.test.ts
+++ b/frontend/src/store/biens.test.ts
@@ -1,16 +1,25 @@
 import { vi, describe, it, expect } from 'vitest';
 import { useBienStore } from './biens';
+import { useAuth, type AuthState } from './auth';
+import { useUserProfileStore, type UserProfileState } from './userProfile';
 
 vi.stubGlobal('fetch', vi.fn());
 
 describe('useBienStore', () => {
   it('adds a bien with create()', async () => {
+    useAuth.setState((state) => ({ ...state, token: 'tok' }) as AuthState);
+    useUserProfileStore.setState(
+      (state) => ({ ...state, profileId: 'p1' }) as UserProfileState,
+    );
     useBienStore.setState((state) => ({ ...state, items: [] }));
     (fetch as unknown as vi.Mock).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ id: '1', typeBien: 'APT', adresse: 'a' }),
     });
     await useBienStore.getState().create({ typeBien: 'APT', adresse: 'a' });
+    expect((fetch as unknown as vi.Mock).mock.calls[0][0]).toBe(
+      '/api/v1/profile/p1/biens',
+    );
     expect(useBienStore.getState().items).toHaveLength(1);
     expect(useBienStore.getState().items[0].id).toBe('1');
   });

--- a/frontend/src/store/biens.ts
+++ b/frontend/src/store/biens.ts
@@ -43,10 +43,10 @@ function clean<T extends object>(obj: T): Partial<T> {
   ) as Partial<T>;
 }
 
-//const BASE_URL = import.meta.env.VITE_API_URL as string;
-const ENDPOINT = `/api/v1/biens`;
+import { useUserProfileStore } from './userProfile';
 
-console.log("endpoint", ENDPOINT);
+//const BASE_URL = import.meta.env.VITE_API_URL as string;
+const endpoint = (profileId: string) => `/api/v1/profile/${profileId}/biens`;
 
 interface BienState {
   items: Bien[];
@@ -61,8 +61,10 @@ export const useBienStore = create<BienState>((set) => ({
 
   fetchAll: async () => {
     const token = useAuth.getState().token;
+    const profileId = useUserProfileStore.getState().profileId;
     if (!token) throw new Error('Non authentifié');
-    const items = await apiFetch<Bien[]>(ENDPOINT, {
+    if (!profileId) throw new Error('Profil introuvable');
+    const items = await apiFetch<Bien[]>(endpoint(profileId), {
       headers: { Authorization: `Bearer ${token}` },
     });
     set({ items });
@@ -70,9 +72,11 @@ export const useBienStore = create<BienState>((set) => ({
 
   create: async (data: NewBien) => {
     const token = useAuth.getState().token;
+    const profileId = useUserProfileStore.getState().profileId;
     if (!token) throw new Error('Non authentifié');
+    if (!profileId) throw new Error('Profil introuvable');
     const payload = clean<NewBien>(data);
-    const bien = await apiFetch<Bien>(ENDPOINT, {
+    const bien = await apiFetch<Bien>(endpoint(profileId), {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -85,9 +89,11 @@ export const useBienStore = create<BienState>((set) => ({
 
   update: async (id, data: EditBien) => {
     const token = useAuth.getState().token;
+    const profileId = useUserProfileStore.getState().profileId;
     if (!token) throw new Error('Non authentifié');
+    if (!profileId) throw new Error('Profil introuvable');
     const payload = clean<EditBien>(data);
-    const bien = await apiFetch<Bien>(`${ENDPOINT}/${id}`, {
+    const bien = await apiFetch<Bien>(`${endpoint(profileId)}/${id}`, {
       method: 'PATCH',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -102,8 +108,10 @@ export const useBienStore = create<BienState>((set) => ({
 
   remove: async (id) => {
     const token = useAuth.getState().token;
+    const profileId = useUserProfileStore.getState().profileId;
     if (!token) throw new Error('Non authentifié');
-    await apiFetch<void>(`${ENDPOINT}/${id}`, {
+    if (!profileId) throw new Error('Profil introuvable');
+    await apiFetch<void>(`${endpoint(profileId)}/${id}`, {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/frontend/src/store/userProfile.test.ts
+++ b/frontend/src/store/userProfile.test.ts
@@ -16,7 +16,7 @@ describe('useUserProfileStore', () => {
     });
     (fetch as unknown as vi.Mock).mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ id: '123', nom: 'Doe' }),
+      json: () => Promise.resolve([{ id: '123', nom: 'Doe' }]),
     });
     await useUserProfileStore.getState().fetchProfile();
     const state = useUserProfileStore.getState();


### PR DESCRIPTION
## Summary
- make Bien router param aware of profile
- enforce profile ownership in service
- expose ForbiddenError and handle in middleware
- update Bien controller and routes
- adjust zustand stores for new profileId param
- extend Prisma mock and add Bien service tests

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6852e39201ac8329b44b36116dd78e3a