### PR TITLE
[backend] Improve validation middleware

### DIFF
--- a/backend/src/middlewares/validate.middleware.ts
+++ b/backend/src/middlewares/validate.middleware.ts
@@ -1,28 +1,28 @@
 import type { AnyZodObject } from 'zod';
 import type { Request, Response, NextFunction } from 'express';
 
-export const validate = (schema: AnyZodObject) => (
+type Key = 'body' | 'params' | 'query';
+
+const makeValidator = (key: Key) => (schema: AnyZodObject) => (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
-  console.log('🔍 [validate] Validating request:', {
-    url: req.url,
-    method: req.method,
-    body: req.body,
-    params: req.params
-  });
-  
-  try {
-    schema.parse({
-      body: req.body,
-      params: req.params,
-      query: req.query,
+  const result = schema.safeParse(req[key]);
+  if (!result.success) {
+    res.status(400).json({
+      message: 'Validation failed',
+      issues: result.error.format(),
     });
-    console.log('✅ [validate] Validation passed');
-    next();
-  } catch (err) {
-    console.log('❌ [validate] Validation failed:', err);
-    next(err);
+    return;
   }
+
+  if (key !== 'query') {
+    (req as Record<Key, unknown>)[key] = result.data;
+  }
+  next();
 };
+
+export const validateBody = makeValidator('body');
+export const validateParams = makeValidator('params');
+export const validateQuery = makeValidator('query');

--- a/backend/src/routes/activity.routes.ts
+++ b/backend/src/routes/activity.routes.ts
@@ -1,6 +1,9 @@
 import { Router } from 'express';
 import { ActivityController } from '../controllers/activity.controller';
-import { validate } from '../middlewares/validate.middleware';
+import {
+  validateBody,
+  validateParams,
+} from '../middlewares/validate.middleware';
 import {
   createActivitySchema,
   updateActivitySchema,
@@ -11,11 +14,15 @@ export const activityRouter = Router();
 
 activityRouter
   .route('/')
-  .post(validate(createActivitySchema), ActivityController.create)
+  .post(validateBody(createActivitySchema), ActivityController.create)
   .get(ActivityController.list);
 
 activityRouter
   .route('/:id')
-  .get(validate(activityIdParam), ActivityController.get)
-  .patch(validate(updateActivitySchema), ActivityController.update)
-  .delete(validate(activityIdParam), ActivityController.remove);
+  .get(validateParams(activityIdParam), ActivityController.get)
+  .patch(
+    validateParams(activityIdParam),
+    validateBody(updateActivitySchema),
+    ActivityController.update,
+  )
+  .delete(validateParams(activityIdParam), ActivityController.remove);

--- a/backend/src/routes/amortissement.routes.ts
+++ b/backend/src/routes/amortissement.routes.ts
@@ -1,8 +1,12 @@
 import { Router } from 'express';
 import { AmortissementController } from '../controllers/amortissement.controller';
-import { validate } from '../middlewares/validate.middleware';
+import { validateQuery } from '../middlewares/validate.middleware';
 import { amortissementQuerySchema } from '../schemas/amortissement.schema';
 
 export const amortissementRouter = Router();
 
-amortissementRouter.get('/', validate(amortissementQuerySchema), AmortissementController.compute);
+amortissementRouter.get(
+  '/',
+  validateQuery(amortissementQuerySchema),
+  AmortissementController.compute,
+);

--- a/backend/src/routes/article.routes.ts
+++ b/backend/src/routes/article.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { ArticleController } from '../controllers/article.controller';
-import { validate } from '../middlewares/validate.middleware';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
 import {
   createArticleSchema,
   updateArticleSchema,
@@ -11,11 +11,15 @@ export const articleRouter = Router();
 
 articleRouter
   .route('/')
-  .post(validate(createArticleSchema), ArticleController.create)
+  .post(validateBody(createArticleSchema), ArticleController.create)
   .get(ArticleController.list);
 
 articleRouter
   .route('/:id')
-  .get(validate(articleIdParam), ArticleController.get)
-  .patch(validate(updateArticleSchema), ArticleController.update)
-  .delete(validate(articleIdParam), ArticleController.remove);
+  .get(validateParams(articleIdParam), ArticleController.get)
+  .patch(
+    validateParams(articleIdParam),
+    validateBody(updateArticleSchema),
+    ArticleController.update,
+  )
+  .delete(validateParams(articleIdParam), ArticleController.remove);

--- a/backend/src/routes/bien.routes.ts
+++ b/backend/src/routes/bien.routes.ts
@@ -6,7 +6,6 @@ import {
   updateBienSchema,
   bienIdParam,
 } from '../schemas/bien.schema';
-import { profileIdParam } from '../schemas/profile.schema';
 
 export const bienRouter = Router({ mergeParams: true });
 
@@ -18,5 +17,9 @@ bienRouter
 bienRouter
   .route('/:id')
   .get(validateParams(bienIdParam), BienController.get)
-  .patch(validateBody(updateBienSchema), BienController.update)
+  .patch(
+    validateParams(bienIdParam),
+    validateBody(updateBienSchema),
+    BienController.update,
+  )
   .delete(validateParams(bienIdParam), BienController.remove);

--- a/backend/src/routes/cerfa.routes.ts
+++ b/backend/src/routes/cerfa.routes.ts
@@ -1,10 +1,22 @@
 import { Router } from 'express';
 import { CerfaController } from '../controllers/cerfa.controller';
-import { validate } from '../middlewares/validate.middleware';
+import { validateQuery } from '../middlewares/validate.middleware';
 import { cerfa2031QuerySchema, cerfa2033QuerySchema, cerfa2042QuerySchema } from '../schemas/cerfa.schema';
 
 export const cerfaRouter = Router();
 
-cerfaRouter.get('/2031-sd', validate(cerfa2031QuerySchema), CerfaController.generate2031);
-cerfaRouter.get('/2033', validate(cerfa2033QuerySchema), CerfaController.generate2033);
-cerfaRouter.get('/2042', validate(cerfa2042QuerySchema), CerfaController.generate2042);
+cerfaRouter.get(
+  '/2031-sd',
+  validateQuery(cerfa2031QuerySchema),
+  CerfaController.generate2031,
+);
+cerfaRouter.get(
+  '/2033',
+  validateQuery(cerfa2033QuerySchema),
+  CerfaController.generate2033,
+);
+cerfaRouter.get(
+  '/2042',
+  validateQuery(cerfa2042QuerySchema),
+  CerfaController.generate2042,
+);

--- a/backend/src/routes/fec.routes.ts
+++ b/backend/src/routes/fec.routes.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { FecController } from '../controllers/fec.controller';
-import { validate } from '../middlewares/validate.middleware';
+import { validateQuery } from '../middlewares/validate.middleware';
 import { fecQuerySchema } from '../schemas/fec.schema';
 
 export const fecRouter = Router();
 
-fecRouter.get('/', validate(fecQuerySchema), FecController.export);
+fecRouter.get('/', validateQuery(fecQuerySchema), FecController.export);

--- a/backend/src/routes/fiscal.routes.ts
+++ b/backend/src/routes/fiscal.routes.ts
@@ -1,8 +1,12 @@
 import { Router } from 'express';
 import { FiscalController } from '../controllers/fiscal.controller';
-import { validate } from '../middlewares/validate.middleware';
+import { validateQuery } from '../middlewares/validate.middleware';
 import { fiscalQuerySchema } from '../schemas/fiscal.schema';
 
 export const fiscalRouter = Router();
 
-fiscalRouter.get('/result', validate(fiscalQuerySchema), FiscalController.result);
+fiscalRouter.get(
+  '/result',
+  validateQuery(fiscalQuerySchema),
+  FiscalController.result,
+);

--- a/backend/src/routes/logement.routes.ts
+++ b/backend/src/routes/logement.routes.ts
@@ -1,6 +1,9 @@
 import { Router } from 'express';
 import { LogementController } from '../controllers/logement.controller';
-import { validate } from '../middlewares/validate.middleware';
+import {
+  validateBody,
+  validateParams,
+} from '../middlewares/validate.middleware';
 import {
   createLogementSchema,
   updateLogementSchema,
@@ -11,11 +14,15 @@ export const logementRouter = Router();
 
 logementRouter
   .route('/')
-  .post(validate(createLogementSchema), LogementController.create)
+  .post(validateBody(createLogementSchema), LogementController.create)
   .get(LogementController.list);
 
 logementRouter
   .route('/:id')
-  .get(validate(logementIdParam), LogementController.get)
-  .patch(validate(updateLogementSchema), LogementController.update)
-  .delete(validate(logementIdParam), LogementController.remove);
+  .get(validateParams(logementIdParam), LogementController.get)
+  .patch(
+    validateParams(logementIdParam),
+    validateBody(updateLogementSchema),
+    LogementController.update,
+  )
+  .delete(validateParams(logementIdParam), LogementController.remove);

--- a/backend/src/routes/operation.routes.ts
+++ b/backend/src/routes/operation.routes.ts
@@ -1,6 +1,9 @@
 import { Router } from 'express';
 import { OperationController } from '../controllers/operation.controller';
-import { validate } from '../middlewares/validate.middleware';
+import {
+  validateBody,
+  validateParams,
+} from '../middlewares/validate.middleware';
 import {
   createOperationSchema,
   updateOperationSchema,
@@ -11,11 +14,15 @@ export const operationRouter = Router();
 
 operationRouter
   .route('/')
-  .post(validate(createOperationSchema), OperationController.create)
+  .post(validateBody(createOperationSchema), OperationController.create)
   .get(OperationController.list);
 
 operationRouter
   .route('/:id')
-  .get(validate(operationIdParam), OperationController.get)
-  .patch(validate(updateOperationSchema), OperationController.update)
-  .delete(validate(operationIdParam), OperationController.remove);
+  .get(validateParams(operationIdParam), OperationController.get)
+  .patch(
+    validateParams(operationIdParam),
+    validateBody(updateOperationSchema),
+    OperationController.update,
+  )
+  .delete(validateParams(operationIdParam), OperationController.remove);

--- a/backend/src/routes/profile.routes.ts
+++ b/backend/src/routes/profile.routes.ts
@@ -1,6 +1,9 @@
 import { Router } from 'express';
 import { ProfileController } from '../controllers/profile.controller';
-import { validate } from '../middlewares/validate.middleware';
+import {
+  validateBody,
+  validateParams,
+} from '../middlewares/validate.middleware';
 import {
   createProfileSchema,
   updateProfileSchema,
@@ -11,11 +14,15 @@ export const profileRouter = Router();
 
 profileRouter
   .route('/')
-  .post(validate(createProfileSchema), ProfileController.create)
+  .post(validateBody(createProfileSchema), ProfileController.create)
   .get(ProfileController.list);
 
 profileRouter
   .route('/:profileId')
-  .get(validate(profileIdParam), ProfileController.get)
-  .patch(validate(updateProfileSchema), ProfileController.update)
-  .delete(validate(profileIdParam), ProfileController.remove);
+  .get(validateParams(profileIdParam), ProfileController.get)
+  .patch(
+    validateParams(profileIdParam),
+    validateBody(updateProfileSchema),
+    ProfileController.update,
+  )
+  .delete(validateParams(profileIdParam), ProfileController.remove);

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -1,8 +1,12 @@
 import { Router } from 'express';
 import { ReportController } from '../controllers/report.controller';
-import { validate } from '../middlewares/validate.middleware';
+import { validateQuery } from '../middlewares/validate.middleware';
 import { reportQuerySchema } from '../schemas/report.schema';
 
 export const reportRouter = Router();
 
-reportRouter.get('/pdf', validate(reportQuerySchema), ReportController.exportPdf);
+reportRouter.get(
+  '/pdf',
+  validateQuery(reportQuerySchema),
+  ReportController.exportPdf,
+);

--- a/backend/src/schemas/amortissement.schema.ts
+++ b/backend/src/schemas/amortissement.schema.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 
 export const amortissementQuerySchema = z.object({
-  query: z.object({
-    anneeId: z.coerce.bigint(),
-    activityId: z.coerce.bigint(),
-  }),
+  anneeId: z.coerce.bigint(),
+  activityId: z.coerce.bigint(),
 });

--- a/backend/src/schemas/cerfa.schema.ts
+++ b/backend/src/schemas/cerfa.schema.ts
@@ -1,10 +1,8 @@
 import { z } from 'zod';
 
 export const cerfa2031QuerySchema = z.object({
-  query: z.object({
-    anneeId: z.coerce.bigint(),
-    activityId: z.coerce.bigint(),
-  }),
+  anneeId: z.coerce.bigint(),
+  activityId: z.coerce.bigint(),
 });
 
 export const cerfa2033QuerySchema = cerfa2031QuerySchema;

--- a/backend/src/schemas/fec.schema.ts
+++ b/backend/src/schemas/fec.schema.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 
 export const fecQuerySchema = z.object({
-  query: z.object({
-    anneeId: z.coerce.bigint(),
-    activityId: z.coerce.bigint(),
-  }),
+  anneeId: z.coerce.bigint(),
+  activityId: z.coerce.bigint(),
 });

--- a/backend/src/schemas/fiscal.schema.ts
+++ b/backend/src/schemas/fiscal.schema.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 
 export const fiscalQuerySchema = z.object({
-  query: z.object({
-    anneeId: z.coerce.bigint(),
-    activityId: z.coerce.bigint(),
-  }),
+  anneeId: z.coerce.bigint(),
+  activityId: z.coerce.bigint(),
 });

--- a/backend/src/schemas/report.schema.ts
+++ b/backend/src/schemas/report.schema.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 
 export const reportQuerySchema = z.object({
-  query: z.object({
-    anneeId: z.coerce.bigint(),
-    activityId: z.coerce.bigint(),
-  }),
+  anneeId: z.coerce.bigint(),
+  activityId: z.coerce.bigint(),
 });


### PR DESCRIPTION
## Summary
- implement generic `makeValidator` helper
- add `validateBody`, `validateParams`, and `validateQuery` middlewares
- update routes to use the new validation helpers
- adjust query schemas to validate direct query objects

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6852f50e2794832980e43ae2dee580f2