### PR TITLE
[backend] add tenant CRUD and property route

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,6 +18,7 @@ import { cerfaRouter } from './routes/cerfa.routes';
 import { fecRouter } from './routes/fec.routes';
 import { reportRouter } from './routes/report.routes';
 import { locationRouter } from './routes/location.routes';
+import { locataireRouter } from './routes/locataire.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -80,6 +81,7 @@ app.use('/api/v1/articles', articleRouter);
 app.use('/api/v1/operations', operationRouter);
 app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/locations', locationRouter);
+app.use('/api/v1/locataires', locataireRouter);
 app.use('/api/v1/logements', logementRouter);
 app.use('/api/v1/profile/:profileId/biens', bienRouter);
 app.use('/api/v1/profile', profileRouter);

--- a/backend/src/controllers/locataire.controller.ts
+++ b/backend/src/controllers/locataire.controller.ts
@@ -1,0 +1,65 @@
+import type { Request, Response, NextFunction } from 'express';
+import { LocataireService } from '../services/locataire.service';
+
+export const LocataireController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const loc = await LocataireService.create(req.body);
+      res.status(201).json(loc);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const locs = await LocataireService.list();
+      res.json(locs);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const loc = await LocataireService.get(req.params.locataireId);
+      if (!loc) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(loc);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const loc = await LocataireService.update(req.params.locataireId, req.body);
+      res.json(loc);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await LocataireService.remove(req.params.locataireId);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async listForProperty(req: Request, res: Response, next: NextFunction) {
+    try {
+      const locs = await LocataireService.listForProperty(
+        req.user.id,
+        req.params.propertyId,
+      );
+      res.json(locs);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/locataire.routes.ts
+++ b/backend/src/routes/locataire.routes.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { LocataireController } from '../controllers/locataire.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createLocataireSchema,
+  updateLocataireSchema,
+  locataireIdParam,
+} from '../schemas/locataire.schema';
+import { bienIdParam } from '../schemas/bien.schema';
+
+export const locataireRouter = Router();
+
+locataireRouter
+  .route('/')
+  .post(validateBody(createLocataireSchema), LocataireController.create)
+  .get(LocataireController.list);
+
+locataireRouter
+  .route('/:locataireId')
+  .get(validateParams(locataireIdParam), LocataireController.get)
+  .patch(
+    validateParams(locataireIdParam),
+    validateBody(updateLocataireSchema),
+    LocataireController.update,
+  )
+  .delete(validateParams(locataireIdParam), LocataireController.remove);
+
+locataireRouter.get(
+  '/properties/:id/locataires',
+  validateParams(bienIdParam),
+  LocataireController.listForProperty,
+);

--- a/backend/src/schemas/locataire.schema.ts
+++ b/backend/src/schemas/locataire.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const createLocataireSchema = z.object({
+  civilite: z.string(),
+  prenom: z.string(),
+  nom: z.string(),
+  dateNaissance: z.coerce.date(),
+});
+
+export const updateLocataireSchema = createLocataireSchema.partial();
+export const locataireIdParam = z.object({ locataireId: z.string().uuid() });

--- a/backend/src/services/locataire.service.ts
+++ b/backend/src/services/locataire.service.ts
@@ -1,0 +1,49 @@
+import { prisma } from '../prisma';
+import type { NewLocataire, EditLocataire } from '@monorepo/shared';
+
+interface PrismaWithLocataire {
+  locataire: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    findFirst: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+  bien: {
+    findFirst: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithLocataire;
+
+export const LocataireService = {
+  create(data: NewLocataire) {
+    return db.locataire.create({ data });
+  },
+
+  list() {
+    return db.locataire.findMany();
+  },
+
+  get(id: string) {
+    return db.locataire.findUnique({ where: { id } });
+  },
+
+  update(id: string, data: EditLocataire) {
+    if (!data || Object.keys(data).length === 0) {
+      throw new Error('No update data provided for locataire ' + id);
+    }
+    return db.locataire.update({ where: { id }, data });
+  },
+
+  remove(id: string) {
+    return db.locataire.delete({ where: { id } });
+  },
+
+  listForProperty(userId: string, propertyId: string) {
+    return db.locataire.findMany({
+      where: { documents: { some: { bienId: propertyId, bien: { profile: { userId } } } } },
+    });
+  },
+};

--- a/backend/tests/locataire.routes.test.ts
+++ b/backend/tests/locataire.routes.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import app from '../src/app';
+import { LocataireService } from '../src/services/locataire.service';
+
+interface LocataireStub {
+  id: string;
+  nom: string;
+}
+
+jest.mock('../src/services/locataire.service');
+
+const mockedService = LocataireService as jest.Mocked<typeof LocataireService>;
+
+describe('GET /api/v1/locataires', () => {
+  it('returns locataires from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: '1', nom: 'Doe' } as LocataireStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/locataires');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});
+
+describe('GET /api/v1/locataires/properties/:id/locataires', () => {
+  it('returns locataires for property', async () => {
+    (mockedService.listForProperty as jest.Mock).mockResolvedValueOnce([
+      { id: '1', nom: 'Doe' } as LocataireStub,
+    ]);
+
+    const id = '00000000-0000-0000-0000-000000000000';
+    const res = await request(app).get(
+      `/api/v1/locataires/properties/${id}/locataires`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,6 +4,8 @@ export type NewBien = Prisma.BienCreateInput;
 export type EditBien = Prisma.BienUpdateInput;
 export type NewLocation = Prisma.LocationCreateInput;
 export type EditLocation = Prisma.LocationUpdateInput;
+export type NewLocataire = Prisma.LocataireCreateInput;
+export type EditLocataire = Prisma.LocataireUpdateInput;
 
 export * from './types/UserProfile';
 export * from './types/ApiResponse';


### PR DESCRIPTION
## Summary
- add locataire schema
- implement locataire service/controller/routes
- expose locataire endpoints in app
- export locataire types in shared package
- test locataire routes

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`

------
https://chatgpt.com/codex/tasks/task_e_6853095f93848329913b339fb320b9bf