### PR TITLE
[frontend] add location creation page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useRequireAuth } from './hooks/useRequireAuth';
 import { useEffect } from 'react';
 import Dashboard from './pages/Dashboard';
 import MesBiens from './pages/MesBiens';
+import NewLocation from './pages/NewLocation';
 import Agenda from './pages/Agenda';
 import Resultats from './pages/Resultats';
 import Abonnement from './pages/Abonnement';
@@ -40,6 +41,7 @@ function ProtectedLayout() {
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/biens" element={<MesBiens />} />
+          <Route path="/biens/:id/locations/new" element={<NewLocation />} />
           <Route path="/agenda" element={<Agenda />} />
           <Route path="/resultats" element={<Resultats />} />
           <Route path="/abonnement" element={<Abonnement />} />

--- a/frontend/src/components/LocationForm.tsx
+++ b/frontend/src/components/LocationForm.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { InputField } from './ui/input-field';
+import { Button } from './ui/button';
+import { useLocationStore } from '../store/locations';
+import type { NewLocation } from '@monorepo/shared';
+
+interface LocationFormProps {
+  bienId: string;
+  onCancel: () => void;
+}
+
+export default function LocationForm({ bienId, onCancel }: LocationFormProps) {
+  const createForBien = useLocationStore((s) => s.createForBien);
+  const [baseRent, setBaseRent] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const payload: NewLocation = {
+        baseRent: Number(baseRent),
+        bienId,
+      } as NewLocation;
+      await createForBien(bienId, payload);
+      onCancel();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border p-4 rounded">
+      {error && <div className="text-red-600">{error}</div>}
+      <InputField
+        label="Loyer hors charges"
+        value={baseRent}
+        onChange={setBaseRent}
+        type="number"
+        required
+      />
+      <div className="space-x-2">
+        <Button type="submit" variant="primary">
+          Valider
+        </Button>
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Annuler
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/MesBiens.test.tsx
+++ b/frontend/src/pages/MesBiens.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import MesBiens from './MesBiens';
+import { useBienStore, type Bien } from '../store/biens';
+
+describe('MesBiens page', () => {
+  it('shows "Nouvelle location" button', () => {
+    const bien: Bien = { id: '1', typeBien: 'APT', adresse: 'a' } as Bien;
+    useBienStore.setState({ items: [bien], fetchAll: async () => {} });
+    render(
+      <MemoryRouter>
+        <MesBiens />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.getByRole('link', { name: /nouvelle location/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MesBiens.tsx
+++ b/frontend/src/pages/MesBiens.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useBienStore, Bien } from '../store/biens';
 import BienForm from '../components/BienForm';
-import { Button } from '../components/ui/button';
+import { Button, buttonVariants } from '../components/ui/button';
+import { Link } from 'react-router-dom';
 
 export default function MesBiens() {
   const { items, fetchAll, remove } = useBienStore();
@@ -72,6 +73,13 @@ export default function MesBiens() {
                 <Button variant="destructive" onClick={() => remove(b.id)}>
                   Supprimer
                 </Button>
+                <Link
+                  to={`/biens/${b.id}/locations/new`}
+                  className={buttonVariants({ variant: 'secondary' })}
+                  aria-label="Nouvelle location"
+                >
+                  Nouvelle location
+                </Link>
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/NewLocation.test.tsx
+++ b/frontend/src/pages/NewLocation.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import NewLocation from './NewLocation';
+
+describe('NewLocation page', () => {
+  it('renders the location form', () => {
+    render(
+      <MemoryRouter initialEntries={['/biens/1/locations/new']}>
+        <Routes>
+          <Route path="/biens/:id/locations/new" element={<NewLocation />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText(/loyer hors charges/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/NewLocation.tsx
+++ b/frontend/src/pages/NewLocation.tsx
@@ -1,0 +1,14 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import LocationForm from '../components/LocationForm';
+
+export default function NewLocation() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  if (!id) return <div>Bien introuvable</div>;
+  return (
+    <div className="space-y-4">
+      <h1>Nouvelle location</h1>
+      <LocationForm bienId={id} onCancel={() => navigate('/biens')} />
+    </div>
+  );
+}

--- a/frontend/src/store/locations.ts
+++ b/frontend/src/store/locations.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { apiFetch } from '../utils/api';
+import { useAuth } from './auth';
+import type { NewLocation } from '@monorepo/shared';
+
+interface LocationState {
+  createForBien: (bienId: string, data: NewLocation) => Promise<void>;
+}
+
+export const useLocationStore = create<LocationState>(() => ({
+  async createForBien(bienId, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    await apiFetch(`/api/v1/locations/properties/${bienId}/location`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(data),
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- add route for location creation and button from property list
- implement `LocationForm` and zustand store
- test location page and button

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_68530ce7ea308329a2d343f5f8395a7f