### PR TITLE
[frontend] use standard tailwind colors

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1" />
     <title>TEST</title>
   </head>
-  <body>
+  <body class="bg-gray-50 text-gray-800">
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -109,7 +109,7 @@ export function AppSidebar({ onNavigate }: SidebarProps) {
               <DropdownMenuTrigger asChild>
                 <SidebarMenuButton
                   size="lg"
-                  className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                  className="data-[state=open]:bg-blue-50 data-[state=open]:text-blue-700"
                 >
                   <Avatar className="h-8 w-8 rounded-lg">
                     <AvatarImage

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -36,7 +36,7 @@ const AvatarFallback = React.forwardRef<
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
-      'flex h-full w-full items-center justify-center rounded-full bg-muted',
+      'flex h-full w-full items-center justify-center rounded-full bg-gray-200',
       className,
     )}
     {...props}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -7,18 +7,14 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          'bg-primary text-primary-foreground shadow hover:bg-gray-200',
-        primary:
-          'bg-primary text-primary-foreground shadow hover:bg-gray-200',
-        destructive:
-          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        default: 'bg-blue-600 text-white shadow hover:bg-blue-700',
+        primary: 'bg-blue-600 text-white shadow hover:bg-blue-700',
+        destructive: 'bg-red-600 text-white shadow-sm hover:bg-red-700',
         outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
-        secondary:
-          'bg-secondary text-secondary-foreground shadow-sm hover:bg-gray-200',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'border border-gray-300 bg-white shadow-sm hover:bg-blue-50 hover:text-blue-700',
+        secondary: 'bg-gray-200 text-gray-800 shadow-sm hover:bg-gray-300',
+        ghost: 'hover:bg-blue-50 hover:text-blue-700',
+        link: 'text-blue-600 underline-offset-4 hover:underline',
       },
       size: {
         default: 'h-10 py-2 px-4',

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -16,7 +16,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-blue-50 data-[state=open]:bg-blue-50',
       inset && 'pl-8',
       className,
     )}
@@ -33,7 +33,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out',
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white text-gray-900 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out',
       className,
     )}
     {...props}
@@ -50,7 +50,7 @@ const DropdownMenuContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out',
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white text-gray-900 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out',
       className,
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-blue-50 focus:text-blue-700 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       className,
     )}
@@ -96,7 +96,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    className={cn('-mx-1 my-1 h-px bg-gray-200', className)}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -13,7 +13,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         typeof collapsible !== 'undefined' ? collapsible : undefined
       }
       className={cn(
-        'flex min-h-screen w-60 flex-col border-r bg-muted/40',
+        'flex min-h-screen w-60 flex-col border-r bg-gray-100',
         className,
       )}
       {...props}
@@ -104,9 +104,9 @@ const SidebarMenuButton = React.forwardRef<
     ref={ref}
     data-active={isActive}
     className={cn(
-      'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
+      'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-blue-50 hover:text-blue-700',
       size === 'lg' && 'px-2 py-2',
-      isActive && 'bg-accent text-accent-foreground',
+      isActive && 'bg-blue-50 text-blue-700',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- update UI components to use official Tailwind colors
- lighten app theme with gray background and blue accents

## Testing
- `pnpm run lint` in `frontend`
- `pnpm run test` in `frontend`
- `pnpm run lint` in `backend`
- `pnpm run test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68532a23fc908329aa4221cd281689c1