### PR TITLE
[frontend] fix payload forms and add backend route tests

### DIFF
--- a/backend/src/controllers/locataire.controller.ts
+++ b/backend/src/controllers/locataire.controller.ts
@@ -55,7 +55,7 @@ export const LocataireController = {
     try {
       const locs = await LocataireService.listForProperty(
         req.user.id,
-        req.params.bienId,
+        req.params.id,
       );
       res.json(locs);
     } catch (e) {

--- a/backend/src/controllers/location.controller.ts
+++ b/backend/src/controllers/location.controller.ts
@@ -62,7 +62,7 @@ export const LocationController = {
     try {
       const location = await LocationService.getByProperty(
         req.user.id,
-        req.params.bienId,
+        req.params.id,
       );
       res.json(location);
     } catch (e) {
@@ -74,7 +74,7 @@ export const LocationController = {
     try {
       const location = await LocationService.createForProperty(
         req.user.id,
-        req.params.bienId,
+        req.params.id,
         req.body,
       );
       res.status(201).json(location);

--- a/backend/src/middlewares/validate.middleware.ts
+++ b/backend/src/middlewares/validate.middleware.ts
@@ -1,14 +1,13 @@
-import type { AnyZodObject } from 'zod';
+import type { ZodTypeAny } from 'zod';
 import type { Request, Response, NextFunction } from 'express';
 
 type Key = 'body' | 'params' | 'query';
 
-const makeValidator = (key: Key) => (schema: AnyZodObject) => (
+const makeValidator = (key: Key) => (schema: ZodTypeAny) => (
   req: Request,
   res: Response,
   next: NextFunction,
 ) => {
-  console.log(req[key]);
   const result = schema.safeParse(req[key]);
   if (!result.success) {
     res.status(400).json({

--- a/backend/src/schemas/bien.schema.ts
+++ b/backend/src/schemas/bien.schema.ts
@@ -33,7 +33,8 @@ export const createBienSchema = z.object({
 
 export const updateBienSchema = createBienSchema.partial();
 export const bienIdParam = z
-  .object({ bienId: z.string().uuid() })
-  .transform(({ bienId }) => ({
-    id: bienId,
-}));
+  .union([
+    z.object({ bienId: z.string().uuid() }),
+    z.object({ id: z.string().uuid() }),
+  ])
+  .transform((data) => ({ id: 'bienId' in data ? data.bienId : data.id }));

--- a/backend/tests/locataire.routes.test.ts
+++ b/backend/tests/locataire.routes.test.ts
@@ -37,3 +37,26 @@ describe('GET /api/v1/locataires/properties/:id/locataires', () => {
     expect(res.body).toHaveLength(1);
   });
 });
+
+describe('POST /api/v1/locataires', () => {
+  it('creates a locataire via service', async () => {
+    const payload = {
+      prenom: 'John',
+      nom: 'Doe',
+      civilite: 'MR',
+      dateNaissance: '1990-01-01',
+    };
+    (mockedService.create as jest.Mock).mockResolvedValueOnce({
+      id: '1',
+      ...payload,
+    } as LocataireStub);
+
+    const res = await request(app).post('/api/v1/locataires').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockedService.create).toHaveBeenCalledWith({
+      ...payload,
+      dateNaissance: new Date('1990-01-01'),
+    });
+  });
+});

--- a/backend/tests/location.routes.test.ts
+++ b/backend/tests/location.routes.test.ts
@@ -22,3 +22,25 @@ describe('GET /api/v1/locations', () => {
     expect(res.body).toHaveLength(1);
   });
 });
+
+describe('POST /api/v1/locations/properties/:id/location', () => {
+  it('creates a location via service', async () => {
+    const bienId = '00000000-0000-0000-0000-000000000000';
+    const payload = { baseRent: 600 };
+    (mockedService.createForProperty as jest.Mock).mockResolvedValueOnce({
+      id: '1',
+      baseRent: 600,
+    } as LocationStub);
+
+    const res = await request(app)
+      .post(`/api/v1/locations/properties/${bienId}/location`)
+      .send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockedService.createForProperty).toHaveBeenCalledWith(
+      'demo-user',
+      bienId,
+      payload,
+    );
+  });
+});

--- a/frontend/src/components/LocataireForm.tsx
+++ b/frontend/src/components/LocataireForm.tsx
@@ -14,6 +14,11 @@ export default function LocataireForm({ data, onChange }: Props) {
   return (
     <div className="space-y-2">
       <InputField
+        label="Civilité"
+        value={data.civilite ?? ''}
+        onChange={(v) => update('civilite', v)}
+      />
+      <InputField
         label="Prénom"
         value={data.prenom ?? ''}
         onChange={(v) => update('prenom', v)}
@@ -22,6 +27,12 @@ export default function LocataireForm({ data, onChange }: Props) {
         label="Nom"
         value={data.nom ?? ''}
         onChange={(v) => update('nom', v)}
+      />
+      <InputField
+        label="Date de naissance"
+        value={(data.dateNaissance as string) ?? ''}
+        onChange={(v) => update('dateNaissance', v)}
+        type="date"
       />
     </div>
   );

--- a/frontend/src/components/LocationForm1.tsx
+++ b/frontend/src/components/LocationForm1.tsx
@@ -8,7 +8,11 @@ interface Props {
 
 export default function LocationForm1({ data, onChange }: Props) {
   const update = (field: keyof NewLocation, value: string) => {
-    onChange({ ...data, [field]: value });
+    let parsed: string | number = value;
+    if (field === 'baseRent' || field === 'depositAmount') {
+      parsed = value === '' ? undefined : Number(value);
+    }
+    onChange({ ...data, [field]: parsed } as Partial<NewLocation>);
   };
 
   return (

--- a/frontend/src/components/LocationForm2.tsx
+++ b/frontend/src/components/LocationForm2.tsx
@@ -8,7 +8,11 @@ interface Props {
 
 export default function LocationForm2({ data, onChange }: Props) {
   const update = (field: keyof NewLocation, value: string | boolean) => {
-    onChange({ ...data, [field]: value });
+    let parsed: string | number | boolean = value;
+    if (field === 'montantTravaux' && typeof value === 'string') {
+      parsed = value === '' ? undefined : Number(value);
+    }
+    onChange({ ...data, [field]: parsed } as Partial<NewLocation>);
   };
 
   return (


### PR DESCRIPTION
## Summary
- parse numeric values in LocationForm1
- parse numeric values in LocationForm2
- collect all required fields in LocataireForm
- relax validator type for zod schemas
- support both `id` and `bienId` param names
- adjust controllers to use unified param
- test POST location creation
- test POST locataire creation

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_6853b7b82bdc83298e64271d2bc60b36