### PR TITLE
[backend] add document CRUD

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import { fecRouter } from './routes/fec.routes';
 import { reportRouter } from './routes/report.routes';
 import { locationRouter } from './routes/location.routes';
 import { locataireRouter } from './routes/locataire.routes';
+import { documentRouter } from './routes/document.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -82,6 +83,7 @@ app.use('/api/v1/operations', operationRouter);
 app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/locations', locationRouter);
 app.use('/api/v1/locataires', locataireRouter);
+app.use('/api/v1/documents', documentRouter);
 app.use('/api/v1/logements', logementRouter);
 app.use('/api/v1/profile/:profileId/biens', bienRouter);
 app.use('/api/v1/profile', profileRouter);

--- a/backend/src/controllers/document.controller.ts
+++ b/backend/src/controllers/document.controller.ts
@@ -1,0 +1,52 @@
+import type { Request, Response, NextFunction } from 'express';
+import { DocumentService } from '../services/document.service';
+
+export const DocumentController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const doc = await DocumentService.create(req.body);
+      res.status(201).json(doc);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await DocumentService.list());
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const doc = await DocumentService.get(req.params.id);
+      if (!doc) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(doc);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const doc = await DocumentService.update(req.params.id, req.body);
+      res.json(doc);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await DocumentService.remove(req.params.id);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/document.routes.ts
+++ b/backend/src/routes/document.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { DocumentController } from '../controllers/document.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createDocumentSchema,
+  updateDocumentSchema,
+  documentIdParam,
+} from '../schemas/document.schema';
+
+export const documentRouter = Router();
+
+documentRouter
+  .route('/')
+  .post(validateBody(createDocumentSchema), DocumentController.create)
+  .get(DocumentController.list);
+
+documentRouter
+  .route('/:id')
+  .get(validateParams(documentIdParam), DocumentController.get)
+  .patch(
+    validateParams(documentIdParam),
+    validateBody(updateDocumentSchema),
+    DocumentController.update,
+  )
+  .delete(validateParams(documentIdParam), DocumentController.remove);

--- a/backend/src/schemas/document.schema.ts
+++ b/backend/src/schemas/document.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const createDocumentSchema = z.object({
+  type: z.string(),
+  fileName: z.string(),
+  fileUrl: z.string(),
+  description: z.string().optional(),
+  bienId: z.string().uuid().optional(),
+  locataireId: z.string().uuid().optional(),
+});
+
+export const updateDocumentSchema = createDocumentSchema.partial();
+export const documentIdParam = z.object({ id: z.string().uuid() });

--- a/backend/src/services/document.service.ts
+++ b/backend/src/services/document.service.ts
@@ -1,0 +1,36 @@
+import { prisma } from '../prisma';
+import type { NewDocument, EditDocument } from '@monorepo/shared';
+
+interface PrismaWithDocument {
+  document: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithDocument;
+
+export const DocumentService = {
+  create(data: NewDocument) {
+    return db.document.create({ data });
+  },
+
+  list() {
+    return db.document.findMany();
+  },
+
+  get(id: string) {
+    return db.document.findUnique({ where: { id } });
+  },
+
+  update(id: string, data: EditDocument) {
+    return db.document.update({ where: { id }, data });
+  },
+
+  remove(id: string) {
+    return db.document.delete({ where: { id } });
+  },
+};

--- a/backend/tests/document.routes.test.ts
+++ b/backend/tests/document.routes.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import app from '../src/app';
+import { DocumentService } from '../src/services/document.service';
+
+interface DocumentStub {
+  id: string;
+  fileName: string;
+}
+
+jest.mock('../src/services/document.service');
+
+const mockedService = DocumentService as jest.Mocked<typeof DocumentService>;
+
+describe('GET /api/v1/documents', () => {
+  it('returns documents from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: '1', fileName: 'file.pdf' } as DocumentStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/documents');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+});
+
+describe('POST /api/v1/documents', () => {
+  it('creates a document via service', async () => {
+    const payload = {
+      type: 'PHOTO',
+      fileName: 'photo.jpg',
+      fileUrl: '/tmp/photo.jpg',
+      bienId: '00000000-0000-0000-0000-000000000000',
+    };
+    (mockedService.create as jest.Mock).mockResolvedValueOnce({
+      id: '1',
+      ...payload,
+    } as DocumentStub);
+
+    const res = await request(app).post('/api/v1/documents').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockedService.create).toHaveBeenCalledWith(payload);
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,6 +6,8 @@ export type NewLocation = Prisma.LocationCreateInput;
 export type EditLocation = Prisma.LocationUpdateInput;
 export type NewLocataire = Prisma.LocataireCreateInput;
 export type EditLocataire = Prisma.LocataireUpdateInput;
+export type NewDocument = Prisma.DocumentCreateInput;
+export type EditDocument = Prisma.DocumentUpdateInput;
 
 export * from './types/UserProfile';
 export * from './types/ApiResponse';


### PR DESCRIPTION
## Summary
- implement new Document service, controller and router
- wire Document routes into Express app
- expose Document types in shared package
- add tests for new Document routes

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_6853ddd6c0c88329bff374c2862aef88