### PR TITLE
[frontend] Connect Document page to backend

### DIFF
--- a/backend/src/controllers/document.controller.ts
+++ b/backend/src/controllers/document.controller.ts
@@ -1,19 +1,48 @@
 import type { Request, Response, NextFunction } from 'express';
 import { DocumentService } from '../services/document.service';
+import { createClient } from '@supabase/supabase-js';
 
 export const DocumentController = {
   async create(req: Request, res: Response, next: NextFunction) {
     try {
-      const doc = await DocumentService.create(req.body);
+      const fileReq = req as Request & { file?: { originalname: string; buffer: Buffer; mimetype: string } };
+      let fileUrl = req.body.fileUrl as string | undefined;
+      let fileName = req.body.fileName as string | undefined;
+
+      if (fileReq.file) {
+        const supabase = createClient(
+          process.env.SUPABASE_URL ?? 'http://localhost',
+          process.env.SUPABASE_KEY ?? 'key',
+        );
+        const path = `${Date.now()}_${fileReq.file.originalname}`;
+        const { error } = await supabase.storage
+          .from('documents')
+          .upload(path, fileReq.file.buffer, {
+            contentType: fileReq.file.mimetype,
+          });
+        if (error) throw error;
+        const {
+          data: { publicUrl },
+        } = supabase.storage.from('documents').getPublicUrl(path);
+        fileUrl = publicUrl;
+        fileName = fileReq.file.originalname;
+      }
+
+      const doc = await DocumentService.create({
+        ...req.body,
+        fileUrl,
+        fileName,
+      });
       res.status(201).json(doc);
     } catch (e) {
       next(e);
     }
   },
 
-  async list(_req: Request, res: Response, next: NextFunction) {
+  async list(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await DocumentService.list());
+      const bienId = req.query.bienId as string | undefined;
+      res.json(await DocumentService.list(bienId));
     } catch (e) {
       next(e);
     }

--- a/backend/src/middlewares/upload.middleware.ts
+++ b/backend/src/middlewares/upload.middleware.ts
@@ -1,0 +1,3 @@
+import multer from 'multer';
+
+export const upload = multer();

--- a/backend/src/routes/document.routes.ts
+++ b/backend/src/routes/document.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { DocumentController } from '../controllers/document.controller';
 import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import { upload } from '../middlewares/upload.middleware';
 import {
   createDocumentSchema,
   updateDocumentSchema,
@@ -11,7 +12,7 @@ export const documentRouter = Router();
 
 documentRouter
   .route('/')
-  .post(validateBody(createDocumentSchema), DocumentController.create)
+  .post(upload.single('file'), validateBody(createDocumentSchema.partial()), DocumentController.create)
   .get(DocumentController.list);
 
 documentRouter

--- a/backend/src/schemas/document.schema.ts
+++ b/backend/src/schemas/document.schema.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const createDocumentSchema = z.object({
   type: z.string(),
-  fileName: z.string(),
-  fileUrl: z.string(),
+  fileName: z.string().optional(),
+  fileUrl: z.string().optional(),
   description: z.string().optional(),
   bienId: z.string().uuid().optional(),
   locataireId: z.string().uuid().optional(),

--- a/backend/src/services/document.service.ts
+++ b/backend/src/services/document.service.ts
@@ -18,8 +18,8 @@ export const DocumentService = {
     return db.document.create({ data });
   },
 
-  list() {
-    return db.document.findMany();
+  list(bienId?: string) {
+    return db.document.findMany({ where: bienId ? { bienId } : undefined });
   },
 
   get(id: string) {

--- a/backend/tests/document.routes.test.ts
+++ b/backend/tests/document.routes.test.ts
@@ -20,6 +20,7 @@ describe('GET /api/v1/documents', () => {
     const res = await request(app).get('/api/v1/documents');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith(undefined);
   });
 });
 

--- a/frontend/src/components/DocumentUploadDialog.tsx
+++ b/frontend/src/components/DocumentUploadDialog.tsx
@@ -1,0 +1,72 @@
+import { useState, useRef } from 'react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Dialog, DialogContent, DialogTrigger } from './ui/dialog';
+
+const TYPES = [
+  'BAIL',
+  'DPE',
+  'ETAT_DES_LIEUX',
+  'FACTURE',
+  'PHOTO',
+  'LOCATAIRE_ID',
+  'JUSTIF_DOMICILE',
+  'AUTRE',
+];
+
+interface Props {
+  onUpload: (file: File, type: string) => void;
+}
+
+export function DocumentUploadDialog({ onUpload }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const [type, setType] = useState('AUTRE');
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button size="sm">Ajouter</Button>
+      </DialogTrigger>
+      <DialogContent className="space-y-4">
+        <div
+          className="border-2 border-dashed p-4 text-center cursor-pointer"
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            e.preventDefault();
+            setFile(e.dataTransfer.files[0]);
+          }}
+          onClick={() => inputRef.current?.click()}
+        >
+          {file ? file.name : 'Déposez un fichier ou cliquez pour sélectionner'}
+        </div>
+        <Input
+          ref={inputRef}
+          type="file"
+          className="hidden"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <select
+          className="border rounded p-2 w-full"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+        >
+          {TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        <div className="text-right">
+          <Button
+            type="button"
+            onClick={() => {
+              if (file) onUpload(file, type);
+            }}
+          >
+            Upload
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ui/DocumentCard.tsx
+++ b/frontend/src/components/ui/DocumentCard.tsx
@@ -4,36 +4,43 @@ import { Button } from './button';
 import { TableRow, TableCell } from './table';
 
 export interface DocumentInfo {
-  id: number;
-  name: string;
+  id: string;
+  fileName: string;
   type: string;
-  date: string;
-  size: string;
+  fileUrl: string;
+  uploadedAt: string;
 }
 
 interface Props {
   doc: DocumentInfo;
+  onDelete?: (id: string) => void;
 }
 
-export function DocumentCard({ doc }: Props) {
+export function DocumentCard({ doc, onDelete }: Props) {
   return (
     <TableRow key={doc.id}>
       <TableCell>
         <div>
-          <p className="font-medium text-sm">{doc.name}</p>
-          <p className="text-xs text-gray-500">{doc.size}</p>
+          <p className="font-medium text-sm">{doc.fileName}</p>
         </div>
       </TableCell>
       <TableCell>
         <Badge variant="outline">{doc.type}</Badge>
       </TableCell>
-      <TableCell className="text-sm">{doc.date}</TableCell>
+      <TableCell className="text-sm">{doc.uploadedAt.slice(0, 10)}</TableCell>
       <TableCell>
         <div className="flex space-x-2">
-          <Button size="sm" variant="ghost">
-            <Download className="h-4 w-4" />
+          <Button size="sm" variant="ghost" asChild>
+            <a href={doc.fileUrl} target="_blank" rel="noopener noreferrer">
+              <Download className="h-4 w-4" />
+            </a>
           </Button>
-          <Button size="sm" variant="ghost" className="text-red-600">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-red-600"
+            onClick={() => onDelete?.(doc.id)}
+          >
             <Trash2 className="h-4 w-4" />
           </Button>
         </div>

--- a/frontend/src/components/ui/DocumentList.tsx
+++ b/frontend/src/components/ui/DocumentList.tsx
@@ -1,17 +1,16 @@
 import { Upload } from 'lucide-react';
-import { Button } from './button';
 import { Card, CardContent, CardHeader, CardTitle } from './card';
 import { DocumentCard, DocumentInfo } from './DocumentCard';
-import { Input } from './input';
-import { Label } from './label';
+import { DocumentUploadDialog } from '../DocumentUploadDialog';
 import { Table, TableBody, TableHead, TableHeader, TableRow } from './table';
 
 interface Props {
   documents: DocumentInfo[];
-  onUpload?: (file: File) => void;
+  onUpload?: (file: File, type: string) => void;
+  onDelete?: (id: string) => void;
 }
 
-export function DocumentList({ documents, onUpload }: Props) {
+export function DocumentList({ documents, onUpload, onDelete }: Props) {
   return (
     <Card>
       <CardHeader>
@@ -20,19 +19,9 @@ export function DocumentList({ documents, onUpload }: Props) {
             <Upload className="h-5 w-5 mr-2" />
             Documents
           </span>
-          <div className="flex space-x-2">
-            <Label htmlFor="file-upload" className="cursor-pointer">
-              <Button size="sm" asChild>
-                <span>Ajouter</span>
-              </Button>
-            </Label>
-            <Input
-              id="file-upload"
-              type="file"
-              className="hidden"
-              onChange={(e) => onUpload?.(e.target.files?.[0] as File)}
-            />
-          </div>
+          <DocumentUploadDialog
+            onUpload={(file, type) => onUpload?.(file, type)}
+          />
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -47,7 +36,7 @@ export function DocumentList({ documents, onUpload }: Props) {
           </TableHeader>
           <TableBody>
             {documents.map((doc) => (
-              <DocumentCard key={doc.id} doc={doc} />
+              <DocumentCard key={doc.id} doc={doc} onDelete={onDelete} />
             ))}
           </TableBody>
         </Table>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50 backdrop-blur-sm', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-96 -translate-x-1/2 -translate-y-1/2 gap-4 bg-white p-6 shadow-lg rounded',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-2 top-2 rounded-sm opacity-70 hover:opacity-100">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export { Dialog, DialogTrigger, DialogContent };

--- a/frontend/src/pages/PropertyDashboard.tsx
+++ b/frontend/src/pages/PropertyDashboard.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { AlertTriangle, Euro } from 'lucide-react';
 import { PropertyTabList } from '../components/ui/PropertyTabList';
 import {
@@ -9,6 +10,7 @@ import {
 import { LeaseInfoCard, LeaseInfo } from '../components/ui/LeaseInfoCard';
 import { TenantInfoCard, TenantInfo } from '../components/ui/TenantInfoCard';
 import { DocumentList } from '../components/ui/DocumentList';
+import { useDocumentStore } from '../store/documents';
 import { ChargesCard } from '../components/ui/ChargesCard';
 import { RevenueCard } from '../components/ui/RevenueCard';
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
@@ -23,6 +25,12 @@ import { Separator } from '../components/ui/separator';
 
 export default function PropertyDashboard() {
   const [tab, setTab] = useState<'view' | 'documents' | 'finances'>('view');
+  const { id } = useParams<{ id: string }>();
+  const { items: documents, fetchAll, create, remove } = useDocumentStore();
+
+  useEffect(() => {
+    if (tab === 'documents' && id) fetchAll(id);
+  }, [tab, id, fetchAll]);
 
   // fake data
   const propertyData: PropertyInfo = {
@@ -47,22 +55,6 @@ export default function PropertyDashboard() {
     profession: 'Ingénieure',
     avatar: '/placeholder.svg?height=40&width=40',
   };
-  const documents = [
-    {
-      id: 1,
-      name: 'Contrat de bail.pdf',
-      type: 'Bail',
-      date: '2023-01-01',
-      size: '2.4 MB',
-    },
-    {
-      id: 2,
-      name: 'État des lieux.pdf',
-      type: 'État des lieux',
-      date: '2023-01-01',
-      size: '1.8 MB',
-    },
-  ];
   const financialData = {
     monthlyRent: 1800,
     yearlyIncome: 21600,
@@ -92,7 +84,13 @@ export default function PropertyDashboard() {
           <TenantInfoCard tenant={tenantData} />
         </div>
       )}
-      {tab === 'documents' && <DocumentList documents={documents} />}
+      {tab === 'documents' && (
+        <DocumentList
+          documents={documents}
+          onUpload={(file, type) => id && create(id, file, type)}
+          onDelete={remove}
+        />
+      )}
       {tab === 'finances' && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           <Card>

--- a/frontend/src/store/documents.ts
+++ b/frontend/src/store/documents.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand';
+import { buildUrl, apiFetch } from '../utils/api';
+import { useAuth } from './auth';
+
+export interface Document {
+  id: string;
+  type: string;
+  fileName: string;
+  fileUrl: string;
+  description?: string;
+  bienId?: string;
+  locataireId?: string;
+  uploadedAt: string;
+}
+
+interface DocumentState {
+  items: Document[];
+  fetchAll: (bienId: string) => Promise<void>;
+  create: (bienId: string, file: File, type: string) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+const endpoint = '/api/v1/documents';
+
+export const useDocumentStore = create<DocumentState>((set) => ({
+  items: [],
+  fetchAll: async (bienId) => {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const docs = await apiFetch<Document[]>(`${endpoint}?bienId=${bienId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set({ items: docs });
+  },
+  create: async (bienId, file, type) => {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('type', type);
+    formData.append('bienId', bienId);
+    const res = await fetch(buildUrl(endpoint), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const doc: Document = await res.json();
+    set((state) => ({ items: [...state.items, doc] }));
+  },
+  remove: async (id) => {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    await apiFetch<void>(`${endpoint}/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({ items: state.items.filter((d) => d.id !== id) }));
+  },
+}));


### PR DESCRIPTION
## Summary
- wire documents page to the API
- support Supabase storage upload in the backend
- enable listing documents of a property
- allow uploading and deleting documents in the UI

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_685405e09f08832980a9f961f73a8099