### PR TITLE
[frontend] Connect property view to backend

### DIFF
--- a/frontend/src/pages/PropertyDashboard.test.tsx
+++ b/frontend/src/pages/PropertyDashboard.test.tsx
@@ -1,10 +1,35 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import PropertyDashboard from './PropertyDashboard';
+import { useAuth, type AuthState } from '../store/auth';
+import {
+  useUserProfileStore,
+  type UserProfileState,
+} from '../store/userProfile';
+
+vi.stubGlobal('fetch', vi.fn());
 
 describe('PropertyDashboard page', () => {
-  it('renders property info', () => {
+  it('renders property info', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    useUserProfileStore.setState(
+      (s) => ({ ...s, profileId: 'p1' }) as UserProfileState,
+    );
+
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: '1', typeBien: 'APT', adresse: 'a' }),
+    });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(null),
+    });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
     render(
       <MemoryRouter initialEntries={['/biens/1/dashboard']}>
         <Routes>
@@ -12,6 +37,6 @@ describe('PropertyDashboard page', () => {
         </Routes>
       </MemoryRouter>,
     );
-    expect(screen.getByText(/Bien Immobilier/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Bien Immobilier/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/store/biens.test.ts
+++ b/frontend/src/store/biens.test.ts
@@ -23,4 +23,23 @@ describe('useBienStore', () => {
     expect(useBienStore.getState().items).toHaveLength(1);
     expect(useBienStore.getState().items[0].id).toBe('1');
   });
+
+  it('fetches a bien with fetchOne()', async () => {
+    useAuth.setState((state) => ({ ...state, token: 'tok' }) as AuthState);
+    useUserProfileStore.setState(
+      (state) => ({ ...state, profileId: 'p1' }) as UserProfileState,
+    );
+    useBienStore.setState((state) => ({ ...state, items: [] }));
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: '1', typeBien: 'APT', adresse: 'a' }),
+    });
+    const bien = await useBienStore.getState().fetchOne('1');
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/profile/p1/biens/1',
+      expect.any(Object),
+    );
+    expect(bien.id).toBe('1');
+    expect(useBienStore.getState().items[0].id).toBe('1');
+  });
 });

--- a/frontend/src/store/biens.ts
+++ b/frontend/src/store/biens.ts
@@ -51,6 +51,7 @@ const endpoint = (profileId: string) => `/api/v1/profile/${profileId}/biens`;
 interface BienState {
   items: Bien[];
   fetchAll: () => Promise<void>;
+  fetchOne: (id: string) => Promise<Bien>;
   create: (data: BienInput) => Promise<void>;
   update: (id: string, data: Partial<BienInput>) => Promise<void>;
   remove: (id: string) => Promise<void>;
@@ -68,6 +69,22 @@ export const useBienStore = create<BienState>((set) => ({
       headers: { Authorization: `Bearer ${token}` },
     });
     set({ items });
+  },
+
+  fetchOne: async (id) => {
+    const token = useAuth.getState().token;
+    const profileId = useUserProfileStore.getState().profileId;
+    if (!token) throw new Error('Non authentifié');
+    if (!profileId) throw new Error('Profil introuvable');
+    const bien = await apiFetch<Bien>(`${endpoint(profileId)}/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({
+      items: state.items.some((b) => b.id === id)
+        ? state.items.map((b) => (b.id === id ? bien : b))
+        : [...state.items, bien],
+    }));
+    return bien;
   },
 
   create: async (data: NewBien) => {

--- a/frontend/src/store/locataires.ts
+++ b/frontend/src/store/locataires.ts
@@ -3,18 +3,68 @@ import { apiFetch } from '../utils/api';
 import { useAuth } from './auth';
 import type { NewLocataire } from '@monorepo/shared';
 
-interface LocataireState {
-  create: (data: NewLocataire) => Promise<void>;
+export interface Locataire {
+  id: string;
+  prenom: string;
+  nom: string;
+  profession?: string;
+  emailSecondaire?: string;
+  telephone?: string;
+  mobile?: string;
 }
 
-export const useLocataireStore = create<LocataireState>(() => ({
+interface LocataireState {
+  current: Locataire | null;
+  fetchForBien: (bienId: string) => Promise<Locataire | null>;
+  create: (data: NewLocataire) => Promise<void>;
+  update: (id: string, data: Partial<NewLocataire>) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+export const useLocataireStore = create<LocataireState>((set) => ({
+  current: null,
+
+  async fetchForBien(bienId) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const locs = await apiFetch<Locataire[]>(
+      `/api/v1/locataires/properties/${bienId}/locataires`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    const loc = locs[0] ?? null;
+    set({ current: loc });
+    return loc;
+  },
+
   async create(data) {
     const token = useAuth.getState().token;
     if (!token) throw new Error('Non authentifié');
-    await apiFetch('/api/v1/locataires', {
+    const loc = await apiFetch<Locataire>('/api/v1/locataires', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: JSON.stringify(data),
     });
+    set({ current: loc });
+  },
+
+  async update(id, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const loc = await apiFetch<Locataire>(`/api/v1/locataires/${id}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set({ current: loc });
+  },
+
+  async remove(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    await apiFetch(`/api/v1/locataires/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set({ current: null });
   },
 }));

--- a/frontend/src/store/locations.ts
+++ b/frontend/src/store/locations.ts
@@ -3,20 +3,69 @@ import { apiFetch } from '../utils/api';
 import { useAuth } from './auth';
 import type { NewLocation } from '@monorepo/shared';
 
-interface LocationState {
-  createForBien: (bienId: string, data: NewLocation) => Promise<void>;
+export interface Location {
+  id: string;
+  baseRent: number;
+  depositAmount?: number;
+  leaseStartDate: string;
+  leaseEndDate?: string;
+  bienId?: string;
 }
 
-export const useLocationStore = create<LocationState>(() => ({
+interface LocationState {
+  current: Location | null;
+  fetchForBien: (bienId: string) => Promise<Location | null>;
+  createForBien: (bienId: string, data: NewLocation) => Promise<void>;
+  update: (id: string, data: Partial<NewLocation>) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+export const useLocationStore = create<LocationState>((set) => ({
+  current: null,
+
+  async fetchForBien(bienId) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const loc = await apiFetch<Location | null>(
+      `/api/v1/locations/properties/${bienId}/location`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    set({ current: loc });
+    return loc;
+  },
+
   async createForBien(bienId, data) {
     const token = useAuth.getState().token;
     if (!token) throw new Error('Non authentifié');
-    await apiFetch(`/api/v1/locations/properties/${bienId}/location`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
+    const loc = await apiFetch<Location>(
+      `/api/v1/locations/properties/${bienId}/location`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify(data),
       },
+    );
+    set({ current: loc });
+  },
+
+  async update(id, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const loc = await apiFetch<Location>(`/api/v1/locations/${id}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}` },
       body: JSON.stringify(data),
     });
+    set({ current: loc });
+  },
+
+  async remove(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    await apiFetch(`/api/v1/locations/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set({ current: null });
   },
 }));


### PR DESCRIPTION
## Summary
- fetch property, location and tenant info from API
- show active lease or empty state on property view
- allow editing or deleting current lease and tenant
- add store helpers and tests

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_68540e30e1048329ab8613b1c327e815