### PR TITLE
[frontend] add required fields to forms

### DIFF
--- a/frontend/src/components/LocataireForm.test.tsx
+++ b/frontend/src/components/LocataireForm.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import LocataireForm from './LocataireForm';
+import { describe, it, expect } from 'vitest';
+
+describe('LocataireForm', () => {
+  it('renders required fields', () => {
+    render(<LocataireForm data={{}} onChange={() => {}} />);
+    expect(screen.getByLabelText(/civilité/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Prénom$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Nom$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/date de naissance/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LocataireForm.tsx
+++ b/frontend/src/components/LocataireForm.tsx
@@ -17,22 +17,26 @@ export default function LocataireForm({ data, onChange }: Props) {
         label="Civilité"
         value={data.civilite ?? ''}
         onChange={(v) => update('civilite', v)}
+        required
       />
       <InputField
         label="Prénom"
         value={data.prenom ?? ''}
         onChange={(v) => update('prenom', v)}
+        required
       />
       <InputField
         label="Nom"
         value={data.nom ?? ''}
         onChange={(v) => update('nom', v)}
+        required
       />
       <InputField
         label="Date de naissance"
         value={(data.dateNaissance as string) ?? ''}
         onChange={(v) => update('dateNaissance', v)}
         type="date"
+        required
       />
     </div>
   );

--- a/frontend/src/components/LocationForm1.test.tsx
+++ b/frontend/src/components/LocationForm1.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import LocationForm1 from './LocationForm1';
+import { describe, it, expect } from 'vitest';
+
+describe('LocationForm1', () => {
+  it('renders required fields', () => {
+    render(<LocationForm1 data={{}} onChange={() => {}} />);
+    expect(screen.getByLabelText(/loyer hors charges/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/montant du dépôt de garantie/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/date début du bail/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/nombre d'exemplaires/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/situation locative précédente/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LocationForm1.tsx
+++ b/frontend/src/components/LocationForm1.tsx
@@ -8,9 +8,15 @@ interface Props {
 
 export default function LocationForm1({ data, onChange }: Props) {
   const update = (field: keyof NewLocation, value: string) => {
-    let parsed: string | number = value;
-    if (field === 'baseRent' || field === 'depositAmount') {
+    let parsed: string | number | string[] = value;
+    if (
+      field === 'baseRent' ||
+      field === 'depositAmount' ||
+      field === 'signatureCopies'
+    ) {
       parsed = value === '' ? undefined : Number(value);
+    } else if (field === 'typeBail') {
+      parsed = [value];
     }
     onChange({ ...data, [field]: parsed } as Partial<NewLocation>);
   };
@@ -29,14 +35,52 @@ export default function LocationForm1({ data, onChange }: Props) {
         value={data.depositAmount?.toString() ?? ''}
         onChange={(v) => update('depositAmount', v)}
         type="number"
+        required
       />
       <InputField
         label="Date début du bail"
         value={(data.leaseStartDate as string) ?? ''}
         onChange={(v) => update('leaseStartDate', v)}
         type="date"
-
+        required
       />
+      <InputField
+        label="Nombre d'exemplaires"
+        value={data.signatureCopies?.toString() ?? ''}
+        onChange={(v) => update('signatureCopies', v)}
+        type="number"
+        required
+      />
+      <label className="block space-y-1">
+        <span className="text-sm font-medium">
+          Situation locative précédente
+        </span>
+        <select
+          className="border rounded p-2 w-full"
+          value={data.previousSituation ?? ''}
+          onChange={(e) => update('previousSituation', e.target.value)}
+          required
+        >
+          <option value="">--</option>
+          <option value="FIRST_TIME">Première mise en location</option>
+          <option value="NO_CONTRACT_LAST_18_MONTH">
+            Pas de contrat ces 18 derniers mois
+          </option>
+          <option value="HAD_CONTRACT_LAST_18_MONTH">
+            Contrat ces 18 derniers mois
+          </option>
+        </select>
+      </label>
+      <label className="block space-y-1">
+        <span className="text-sm font-medium">Type de bail</span>
+        <select
+          className="border rounded p-2 w-full"
+          value={data.typeBail?.[0] ?? 'MEUBLE'}
+          onChange={(e) => update('typeBail', e.target.value)}
+        >
+          <option value="MEUBLE">Meublé</option>
+        </select>
+      </label>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- capture required locataire info
- handle more required location fields
- test new form fields

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_685422eeb4a88329bce365359718f7c6