### PR TITLE
[frontend] link tenant to property and lease

### DIFF
--- a/backend/src/schemas/locataire.schema.ts
+++ b/backend/src/schemas/locataire.schema.ts
@@ -5,6 +5,8 @@ export const createLocataireSchema = z.object({
   prenom: z.string(),
   nom: z.string(),
   dateNaissance: z.coerce.date(),
+  bienId: z.string().uuid().optional(),
+  locationId: z.string().uuid().optional(),
 });
 
 export const updateLocataireSchema = createLocataireSchema.partial();

--- a/backend/src/schemas/location.schema.ts
+++ b/backend/src/schemas/location.schema.ts
@@ -1,4 +1,3 @@
-import { PreviousRentalSituation } from '@prisma/client';
 import { z } from 'zod';
 
 export const createLocationSchema = z.object({

--- a/backend/src/types/multer.d.ts
+++ b/backend/src/types/multer.d.ts
@@ -1,0 +1,1 @@
+declare module 'multer';

--- a/backend/tests/locataire.routes.test.ts
+++ b/backend/tests/locataire.routes.test.ts
@@ -45,6 +45,8 @@ describe('POST /api/v1/locataires', () => {
       nom: 'Doe',
       civilite: 'MR',
       dateNaissance: '1990-01-01',
+      bienId: '00000000-0000-0000-0000-000000000000',
+      locationId: '11111111-1111-1111-1111-111111111111',
     };
     (mockedService.create as jest.Mock).mockResolvedValueOnce({
       id: '1',

--- a/backend/tests/location.routes.test.ts
+++ b/backend/tests/location.routes.test.ts
@@ -26,7 +26,12 @@ describe('GET /api/v1/locations', () => {
 describe('POST /api/v1/locations/properties/:id/location', () => {
   it('creates a location via service', async () => {
     const bienId = '00000000-0000-0000-0000-000000000000';
-    const payload = { baseRent: 600 };
+    const payload = {
+      baseRent: 600,
+      leaseStartDate: '2024-01-01',
+      signatureCopies: 1,
+      previousSituation: 'FIRST_TIME',
+    };
     (mockedService.createForProperty as jest.Mock).mockResolvedValueOnce({
       id: '1',
       baseRent: 600,
@@ -40,7 +45,10 @@ describe('POST /api/v1/locations/properties/:id/location', () => {
     expect(mockedService.createForProperty).toHaveBeenCalledWith(
       'demo-user',
       bienId,
-      payload,
+      {
+        ...payload,
+        leaseStartDate: new Date('2024-01-01'),
+      },
     );
   });
 });

--- a/frontend/src/pages/NewLocation.tsx
+++ b/frontend/src/pages/NewLocation.tsx
@@ -25,8 +25,15 @@ export default function NewLocation() {
   const prev = () => setStep((s) => Math.max(1, s - 1));
 
   const submit = async () => {
-    await createLocation(id, { ...locationData, ...clauseData } as NewLocation);
-    await createLocataire(locataireData as NewLocataire);
+    const location = await createLocation(id, {
+      ...locationData,
+      ...clauseData,
+    } as NewLocation);
+    await createLocataire({
+      ...locataireData,
+      bienId: id,
+      locationId: location.id,
+    } as NewLocataire);
     navigate('/biens');
   };
 

--- a/frontend/src/store/locataires.ts
+++ b/frontend/src/store/locataires.ts
@@ -11,12 +11,14 @@ export interface Locataire {
   emailSecondaire?: string;
   telephone?: string;
   mobile?: string;
+  bienId?: string;
+  locationId?: string;
 }
 
 interface LocataireState {
   current: Locataire | null;
   fetchForBien: (bienId: string) => Promise<Locataire | null>;
-  create: (data: NewLocataire) => Promise<void>;
+  create: (data: NewLocataire) => Promise<Locataire>;
   update: (id: string, data: Partial<NewLocataire>) => Promise<void>;
   remove: (id: string) => Promise<void>;
 }
@@ -45,6 +47,7 @@ export const useLocataireStore = create<LocataireState>((set) => ({
       body: JSON.stringify(data),
     });
     set({ current: loc });
+    return loc;
   },
 
   async update(id, data) {

--- a/frontend/src/store/locations.ts
+++ b/frontend/src/store/locations.ts
@@ -15,7 +15,7 @@ export interface Location {
 interface LocationState {
   current: Location | null;
   fetchForBien: (bienId: string) => Promise<Location | null>;
-  createForBien: (bienId: string, data: NewLocation) => Promise<void>;
+  createForBien: (bienId: string, data: NewLocation) => Promise<Location>;
   update: (id: string, data: Partial<NewLocation>) => Promise<void>;
   remove: (id: string) => Promise<void>;
 }
@@ -46,6 +46,7 @@ export const useLocationStore = create<LocationState>((set) => ({
       },
     );
     set({ current: loc });
+    return loc;
   },
 
   async update(id, data) {


### PR DESCRIPTION
## Summary
- allow bienId and locationId in locataire schema
- return created location from createForBien
- wire tenant form submission to send property and lease IDs
- return created locataire in store
- fix backend unit tests

## Testing
- `pnpm --filter ./backend lint`
- `pnpm --filter ./backend test`
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test`


------
https://chatgpt.com/codex/tasks/task_e_685446da74cc8329b4286b21fb9976a5