### PR TITLE
[backend] Add CRUD for Inventaire

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -20,6 +20,7 @@ import { reportRouter } from './routes/report.routes';
 import { locationRouter } from './routes/location.routes';
 import { locataireRouter } from './routes/locataire.routes';
 import { documentRouter } from './routes/document.routes';
+import { inventaireRouter } from './routes/inventaire.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -84,6 +85,7 @@ app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/locations', locationRouter);
 app.use('/api/v1/locataires', locataireRouter);
 app.use('/api/v1/documents', documentRouter);
+app.use('/api/v1/inventaires', inventaireRouter);
 app.use('/api/v1/logements', logementRouter);
 app.use('/api/v1/profile/:profileId/biens', bienRouter);
 app.use('/api/v1/profile', profileRouter);

--- a/backend/src/controllers/inventaire.controller.ts
+++ b/backend/src/controllers/inventaire.controller.ts
@@ -1,0 +1,54 @@
+import type { Request, Response, NextFunction } from 'express';
+import { InventaireService } from '../services/inventaire.service';
+
+export const InventaireController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const inv = await InventaireService.create(req.body);
+      res.status(201).json(inv);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bienId = req.query.bienId as string | undefined;
+      const invs = await InventaireService.list(bienId);
+      res.json(invs);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const inv = await InventaireService.get(req.params.id);
+      if (!inv) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(inv);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const inv = await InventaireService.update(req.params.id, req.body);
+      res.json(inv);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await InventaireService.remove(req.params.id);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/inventaire.routes.ts
+++ b/backend/src/routes/inventaire.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { InventaireController } from '../controllers/inventaire.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createInventaireSchema,
+  updateInventaireSchema,
+  inventaireIdParam,
+} from '../schemas/inventaire.schema';
+
+export const inventaireRouter = Router();
+
+inventaireRouter
+  .route('/')
+  .post(validateBody(createInventaireSchema), InventaireController.create)
+  .get(InventaireController.list);
+
+inventaireRouter
+  .route('/:id')
+  .get(validateParams(inventaireIdParam), InventaireController.get)
+  .patch(
+    validateParams(inventaireIdParam),
+    validateBody(updateInventaireSchema),
+    InventaireController.update,
+  )
+  .delete(validateParams(inventaireIdParam), InventaireController.remove);

--- a/backend/src/schemas/inventaire.schema.ts
+++ b/backend/src/schemas/inventaire.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const createInventaireSchema = z.object({
+  bienId: z.string().uuid(),
+  piece: z.string(),
+  mobilier: z.string(),
+  quantite: z.number().int().optional(),
+  marque: z.string().optional(),
+  etatEntree: z.string().optional(),
+});
+
+export const updateInventaireSchema = createInventaireSchema.partial();
+
+export const inventaireIdParam = z.object({ id: z.string().uuid() });

--- a/backend/src/services/inventaire.service.ts
+++ b/backend/src/services/inventaire.service.ts
@@ -1,0 +1,36 @@
+import { prisma } from '../prisma';
+import type { NewInventaire, EditInventaire } from '@monorepo/shared';
+
+interface PrismaWithInventaire {
+  inventaire: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithInventaire;
+
+export const InventaireService = {
+  create(data: NewInventaire) {
+    return db.inventaire.create({ data });
+  },
+
+  list(bienId?: string) {
+    return db.inventaire.findMany({ where: bienId ? { bienId } : undefined });
+  },
+
+  get(id: string) {
+    return db.inventaire.findUnique({ where: { id } });
+  },
+
+  update(id: string, data: EditInventaire) {
+    return db.inventaire.update({ where: { id }, data });
+  },
+
+  remove(id: string) {
+    return db.inventaire.delete({ where: { id } });
+  },
+};

--- a/backend/tests/inventaire.routes.test.ts
+++ b/backend/tests/inventaire.routes.test.ts
@@ -1,0 +1,46 @@
+import request from 'supertest';
+import app from '../src/app';
+import { InventaireService } from '../src/services/inventaire.service';
+
+interface InventaireStub {
+  id: string;
+  bienId: string;
+  piece: string;
+  mobilier: string;
+}
+
+jest.mock('../src/services/inventaire.service');
+
+const mockedService = InventaireService as jest.Mocked<typeof InventaireService>;
+
+describe('GET /api/v1/inventaires', () => {
+  it('returns inventaires from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: '1', bienId: 'b1', piece: 'Salon', mobilier: 'TABLE' } as InventaireStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/inventaires');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('POST /api/v1/inventaires', () => {
+  it('creates an inventaire via service', async () => {
+    const payload = {
+      bienId: '00000000-0000-0000-0000-000000000000',
+      piece: 'Chambre',
+      mobilier: 'LIT',
+    };
+    (mockedService.create as jest.Mock).mockResolvedValueOnce({
+      id: '1',
+      ...payload,
+    } as InventaireStub);
+
+    const res = await request(app).post('/api/v1/inventaires').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockedService.create).toHaveBeenCalledWith(payload);
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -8,6 +8,8 @@ export type NewLocataire = Prisma.LocataireCreateInput;
 export type EditLocataire = Prisma.LocataireUpdateInput;
 export type NewDocument = Prisma.DocumentCreateInput;
 export type EditDocument = Prisma.DocumentUpdateInput;
+export type NewInventaire = Prisma.InventaireCreateInput;
+export type EditInventaire = Prisma.InventaireUpdateInput;
 
 export * from './types/UserProfile';
 export * from './types/ApiResponse';


### PR DESCRIPTION
## Summary
- implement `InventaireService` and controller
- add routes and schemas for inventaires
- expose new endpoint in `app.ts`
- include types in shared package
- test new routes

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`

------
https://chatgpt.com/codex/tasks/task_e_68545b0540608329ae97336bfb0c58ae