### PR TITLE
[frontend] Add Inventaire tab

### DIFF
--- a/frontend/src/components/InventaireForm.tsx
+++ b/frontend/src/components/InventaireForm.tsx
@@ -1,0 +1,46 @@
+import { InputField } from './ui/input-field';
+import type { NewInventaire } from '@monorepo/shared';
+
+interface Props {
+  data: Partial<NewInventaire>;
+  onChange: (data: Partial<NewInventaire>) => void;
+}
+
+export default function InventaireForm({ data, onChange }: Props) {
+  const update = (field: keyof NewInventaire, value: string | number) => {
+    onChange({ ...data, [field]: value });
+  };
+
+  return (
+    <div className="space-y-2">
+      <InputField
+        label="Pièce"
+        value={(data.piece as string) || ''}
+        onChange={(v) => update('piece', v)}
+        required
+      />
+      <InputField
+        label="Mobilier"
+        value={(data.mobilier as string) || ''}
+        onChange={(v) => update('mobilier', v)}
+        required
+      />
+      <InputField
+        label="Quantité"
+        type="number"
+        value={data.quantite?.toString() || ''}
+        onChange={(v) => update('quantite', Number(v))}
+      />
+      <InputField
+        label="Marque"
+        value={(data.marque as string) || ''}
+        onChange={(v) => update('marque', v)}
+      />
+      <InputField
+        label="État à l'entrée"
+        value={(data.etatEntree as string) || ''}
+        onChange={(v) => update('etatEntree', v)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/InventaireTable.tsx
+++ b/frontend/src/components/InventaireTable.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Button } from './ui/button';
+import InventaireForm from './InventaireForm';
+import type { Inventaire } from '../store/inventaires';
+import type { NewInventaire } from '@monorepo/shared';
+
+interface Props {
+  items: Inventaire[];
+  bienId: string;
+  onCreate: (data: NewInventaire) => Promise<void>;
+  onUpdate: (id: string, data: Partial<NewInventaire>) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+}
+
+export default function InventaireTable({
+  items,
+  bienId,
+  onCreate,
+  onUpdate,
+  onDelete,
+}: Props) {
+  const [adding, setAdding] = useState(false);
+  const [newData, setNewData] = useState<Partial<NewInventaire>>({});
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editData, setEditData] = useState<Partial<NewInventaire>>({});
+
+  return (
+    <div className="space-y-4">
+      {adding ? (
+        <Card>
+          <CardContent className="space-y-2 pt-4">
+            <InventaireForm data={newData} onChange={setNewData} />
+            <div className="flex justify-end space-x-2 mt-2">
+              <Button
+                onClick={async () => {
+                  await onCreate({ bienId, ...(newData as NewInventaire) });
+                  setNewData({});
+                  setAdding(false);
+                }}
+              >
+                Valider
+              </Button>
+              <Button variant="secondary" onClick={() => setAdding(false)}>
+                Annuler
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="text-right">
+          <Button onClick={() => setAdding(true)}>Ajouter</Button>
+        </div>
+      )}
+
+      {items.map((inv) => (
+        <Card key={inv.id}>
+          {editingId === inv.id ? (
+            <CardContent className="space-y-2 pt-4">
+              <InventaireForm data={editData} onChange={setEditData} />
+              <div className="flex justify-end space-x-2 mt-2">
+                <Button
+                  onClick={async () => {
+                    await onUpdate(inv.id, editData);
+                    setEditingId(null);
+                  }}
+                >
+                  Valider
+                </Button>
+                <Button variant="secondary" onClick={() => setEditingId(null)}>
+                  Annuler
+                </Button>
+              </div>
+            </CardContent>
+          ) : (
+            <>
+              <CardHeader>
+                <CardTitle>
+                  {inv.piece} - {inv.mobilier}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p>Quantité: {inv.quantite ?? '-'}</p>
+                <p>Marque: {inv.marque ?? '-'}</p>
+                <p>État: {inv.etatEntree ?? '-'}</p>
+                <div className="space-x-2 mt-2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => {
+                      setEditingId(inv.id);
+                      setEditData(inv);
+                    }}
+                  >
+                    Modifier
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => onDelete(inv.id)}
+                  >
+                    Supprimer
+                  </Button>
+                </div>
+              </CardContent>
+            </>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/PropertyTabList.test.tsx
+++ b/frontend/src/components/ui/PropertyTabList.test.tsx
@@ -14,12 +14,16 @@ describe('PropertyTabList', () => {
     expect(screen.getByRole('button', { name: /documents/i })).toHaveClass(
       'border-b-2',
     );
+    rerender(<PropertyTabList value="inventaire" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /inventaire/i })).toHaveClass(
+      'border-b-2',
+    );
   });
 
   it('calls onChange when clicking', () => {
     const onChange = vi.fn();
     render(<PropertyTabList value="view" onChange={onChange} />);
-    fireEvent.click(screen.getByRole('button', { name: /finances/i }));
-    expect(onChange).toHaveBeenCalledWith('finances');
+    fireEvent.click(screen.getByRole('button', { name: /inventaire/i }));
+    expect(onChange).toHaveBeenCalledWith('inventaire');
   });
 });

--- a/frontend/src/components/ui/PropertyTabList.tsx
+++ b/frontend/src/components/ui/PropertyTabList.tsx
@@ -1,6 +1,6 @@
 import { cn } from '../../lib/utils';
 
-type Tab = 'view' | 'documents' | 'finances';
+type Tab = 'view' | 'documents' | 'finances' | 'inventaire';
 
 interface PropertyTabListProps {
   value: Tab;
@@ -8,8 +8,13 @@ interface PropertyTabListProps {
 }
 
 export function PropertyTabList({ value, onChange }: PropertyTabListProps) {
-  const tabs: Tab[] = ['view', 'documents', 'finances'];
-  const labels = { view: 'Vue', documents: 'Documents', finances: 'Finances' };
+  const tabs: Tab[] = ['view', 'documents', 'finances', 'inventaire'];
+  const labels = {
+    view: 'Vue',
+    documents: 'Documents',
+    finances: 'Finances',
+    inventaire: 'Inventaire',
+  };
   return (
     <div className="mb-4 flex border-b">
       {tabs.map((tab) => (

--- a/frontend/src/pages/PropertyDashboard.tsx
+++ b/frontend/src/pages/PropertyDashboard.tsx
@@ -11,6 +11,8 @@ import { LeaseInfoCard, LeaseInfo } from '../components/ui/LeaseInfoCard';
 import { TenantInfoCard, TenantInfo } from '../components/ui/TenantInfoCard';
 import { DocumentList } from '../components/ui/DocumentList';
 import { useDocumentStore } from '../store/documents';
+import { useInventaireStore } from '../store/inventaires';
+import InventaireTable from '../components/InventaireTable';
 import LocationForm1 from '../components/LocationForm1';
 import LocataireForm from '../components/LocataireForm';
 import { useBienStore, type Bien } from '../store/biens';
@@ -31,9 +33,18 @@ import { Progress } from '../components/ui/progress';
 import { Separator } from '../components/ui/separator';
 
 export default function PropertyDashboard() {
-  const [tab, setTab] = useState<'view' | 'documents' | 'finances'>('view');
+  const [tab, setTab] = useState<
+    'view' | 'documents' | 'finances' | 'inventaire'
+  >('view');
   const { id } = useParams<{ id: string }>();
   const { items: documents, fetchAll, create, remove } = useDocumentStore();
+  const {
+    items: inventaires,
+    fetchForBien: fetchInventaires,
+    create: createInventaire,
+    update: updateInventaire,
+    remove: removeInventaire,
+  } = useInventaireStore();
   const fetchBien = useBienStore((s) => s.fetchOne);
   const [bien, setBien] = useState<Bien | null>(null);
   const {
@@ -56,6 +67,10 @@ export default function PropertyDashboard() {
   useEffect(() => {
     if (tab === 'documents' && id) fetchAll(id);
   }, [tab, id, fetchAll]);
+
+  useEffect(() => {
+    if (tab === 'inventaire' && id) fetchInventaires(id);
+  }, [tab, id, fetchInventaires]);
 
   useEffect(() => {
     if (!id) return;
@@ -88,7 +103,6 @@ export default function PropertyDashboard() {
       }
     : null;
 
-  
   const leaseData: LeaseInfo | null = location
     ? {
         tenant: locataire ? `${locataire.prenom} ${locataire.nom}` : 'N/A',
@@ -104,7 +118,7 @@ export default function PropertyDashboard() {
       }
     : null;
 
-  console.log("locatare", locataire);
+  console.log('locatare', locataire);
   const tenantInfo: TenantInfo | null = locataire
     ? {
         name: `${locataire.prenom} ${locataire.nom}`,
@@ -241,6 +255,15 @@ export default function PropertyDashboard() {
           documents={documents}
           onUpload={(file, type) => id && create(id, file, type)}
           onDelete={remove}
+        />
+      )}
+      {tab === 'inventaire' && id && (
+        <InventaireTable
+          items={inventaires}
+          bienId={id}
+          onCreate={createInventaire}
+          onUpdate={updateInventaire}
+          onDelete={removeInventaire}
         />
       )}
       {tab === 'finances' && (

--- a/frontend/src/store/inventaires.test.ts
+++ b/frontend/src/store/inventaires.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useInventaireStore } from './inventaires';
+import { useAuth, type AuthState } from './auth';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('useInventaireStore', () => {
+  it('adds an inventaire with create()', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    useInventaireStore.setState({ items: [] });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: '1',
+          bienId: 'b1',
+          piece: 'Salon',
+          mobilier: 'TABLE',
+        }),
+    });
+    await useInventaireStore
+      .getState()
+      .create({ bienId: 'b1', piece: 'Salon', mobilier: 'TABLE' });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/inventaires',
+      expect.any(Object),
+    );
+    expect(useInventaireStore.getState().items).toHaveLength(1);
+  });
+});

--- a/frontend/src/store/inventaires.ts
+++ b/frontend/src/store/inventaires.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand';
+import { apiFetch } from '../utils/api';
+import { useAuth } from './auth';
+import type { NewInventaire } from '@monorepo/shared';
+
+export interface Inventaire {
+  id: string;
+  bienId: string;
+  piece: string;
+  mobilier: string;
+  quantite?: number;
+  marque?: string;
+  etatEntree?: string;
+}
+
+interface InventaireState {
+  items: Inventaire[];
+  fetchForBien: (bienId: string) => Promise<void>;
+  create: (data: NewInventaire) => Promise<void>;
+  update: (id: string, data: Partial<NewInventaire>) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+export const useInventaireStore = create<InventaireState>((set) => ({
+  items: [],
+
+  async fetchForBien(bienId) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const items = await apiFetch<Inventaire[]>(
+      `/api/v1/inventaires?bienId=${bienId}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    set({ items });
+  },
+
+  async create(data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const inv = await apiFetch<Inventaire>('/api/v1/inventaires', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({ items: [...state.items, inv] }));
+  },
+
+  async update(id, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const inv = await apiFetch<Inventaire>(`/api/v1/inventaires/${id}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({
+      items: state.items.map((i) => (i.id === id ? inv : i)),
+    }));
+  },
+
+  async remove(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    await apiFetch(`/api/v1/inventaires/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({ items: state.items.filter((i) => i.id !== id) }));
+  },
+}));


### PR DESCRIPTION
## Summary
- add Inventory store with CRUD functions
- create `InventaireForm` and `InventaireTable` components
- extend `PropertyTabList` with an Inventaire tab
- show `InventaireTable` on PropertyDashboard
- add unit tests for inventory store and updated tab list

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_68545e5a51448329bb502f10e611d608