### PR TITLE
[frontend] add mobilier options in inventory form

### DIFF
--- a/frontend/src/components/InventaireForm.test.tsx
+++ b/frontend/src/components/InventaireForm.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import InventaireForm from './InventaireForm';
+import { describe, it, expect } from 'vitest';
+
+describe('InventaireForm', () => {
+  it('renders required fields and mobilier options', () => {
+    render(<InventaireForm data={{}} onChange={() => {}} />);
+    expect(screen.getByLabelText(/pièce/i)).toBeInTheDocument();
+    const select = screen.getByLabelText(/mobilier/i);
+    expect(select.tagName).toBe('SELECT');
+    expect(
+      screen.getByRole('option', { name: 'BOUILLOIRE' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/InventaireForm.tsx
+++ b/frontend/src/components/InventaireForm.tsx
@@ -1,6 +1,47 @@
 import { InputField } from './ui/input-field';
 import type { NewInventaire } from '@monorepo/shared';
 
+const MOBILIER_OPTIONS = [
+  'BOUILLOIRE',
+  'PORTE_SERVIETTES',
+  'POUBELLE_SDB',
+  'POUBELLE_WC',
+  'ETENDOIR_A_LINGE',
+  'SERVIETTES_TOILETTE',
+  'ASPIRATEUR',
+  'LAVE_LINGE',
+  'SECHE_LINGE',
+  'PLANCHE_A_REPASSER',
+  'CAFETIERE',
+  'THEIERE',
+  'TELEVISION',
+  'LECTEUR_DVD',
+  'CHAINE_HIFI',
+  'RADIO',
+  'FER_A_REPASSER',
+  'TABLE_BASSE',
+  'TABLE_DE_CHEVET',
+  'BUREAU',
+  'FAUTEUIL_DE_BUREAU',
+  'FAUTEUIL',
+  'ARMOIRE',
+  'PENDERIE',
+  'COMMODE',
+  'ETAGERE_DE_RANGEMENT',
+  'TAIE_D_OREILLER',
+  'VOLET',
+  'RIDEAU',
+  'STORE_OCCULTANT',
+  'STORE',
+  'AUTRE_OCCULTATION',
+  'LUMINAIRE',
+  'ALESE',
+  'DRAP_HOUSSE',
+  'DRAP',
+  'COUETTE',
+  'COUVERTURE',
+] as const;
+
 interface Props {
   data: Partial<NewInventaire>;
   onChange: (data: Partial<NewInventaire>) => void;
@@ -19,12 +60,22 @@ export default function InventaireForm({ data, onChange }: Props) {
         onChange={(v) => update('piece', v)}
         required
       />
-      <InputField
-        label="Mobilier"
-        value={(data.mobilier as string) || ''}
-        onChange={(v) => update('mobilier', v)}
-        required
-      />
+      <label className="block space-y-1">
+        <span className="text-sm font-medium">Mobilier</span>
+        <select
+          className="border rounded p-2 w-full"
+          value={(data.mobilier as string) || ''}
+          onChange={(e) => update('mobilier', e.target.value)}
+          required
+        >
+          <option value="">--</option>
+          {MOBILIER_OPTIONS.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </label>
       <InputField
         label="Quantité"
         type="number"


### PR DESCRIPTION
## Summary
- show furniture options in `InventaireForm`
- test for required fields and select options

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6854623ca5008329b0dcfebaf3de0ca0