### PR TITLE
[backend] add bail doc generation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -48,11 +48,13 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",
     "cors": "^2.8.5",
+    "docxtemplater": "^3.65.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",
     "pdf-lib": "^1.17.1",
+    "pizzip": "^3.2.0",
     "react-router-dom": "^7.6.2",
     "zod": "^3.25.63"
   }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,6 +21,7 @@ import { locationRouter } from './routes/location.routes';
 import { locataireRouter } from './routes/locataire.routes';
 import { documentRouter } from './routes/document.routes';
 import { inventaireRouter } from './routes/inventaire.routes';
+import { bailRouter } from './routes/bail.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -94,6 +95,7 @@ app.use('/api/v1/fec', fecRouter);
 app.use('/api/v1/amortissements', amortissementRouter);
 app.use('/api/v1/cerfa', cerfaRouter);
 app.use('/api/v1/reports', reportRouter);
+app.use('/api/v1/bails', bailRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/bail.controller.ts
+++ b/backend/src/controllers/bail.controller.ts
@@ -1,0 +1,20 @@
+import type { Request, Response, NextFunction } from 'express';
+import { BailService } from '../services/bail.service';
+
+export const BailController = {
+  async generate(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bailleurNom = req.query.bailleurNom as string;
+      const doc = await BailService.generate({ bailleurNom });
+      res
+        .status(200)
+        .set({
+          'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          'Content-Disposition': 'attachment; filename="bail.docx"',
+        })
+        .send(doc);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/bail.routes.ts
+++ b/backend/src/routes/bail.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { BailController } from '../controllers/bail.controller';
+import { validateQuery } from '../middlewares/validate.middleware';
+import { bailQuerySchema } from '../schemas/bail.schema';
+
+export const bailRouter = Router();
+
+bailRouter.get('/location-meublee', validateQuery(bailQuerySchema), BailController.generate);

--- a/backend/src/schemas/bail.schema.ts
+++ b/backend/src/schemas/bail.schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const bailQuerySchema = z.object({
+  bailleurNom: z.string().min(1),
+});

--- a/backend/src/services/bail.service.ts
+++ b/backend/src/services/bail.service.ts
@@ -1,0 +1,27 @@
+import { createClient } from '@supabase/supabase-js';
+import PizZip from 'pizzip';
+import Docxtemplater from 'docxtemplater';
+
+interface Options {
+  bailleurNom: string;
+}
+
+export const BailService = {
+  async generate({ bailleurNom }: Options): Promise<Buffer> {
+    const supabase = createClient(
+      process.env.SUPABASE_URL ?? 'http://localhost',
+      process.env.SUPABASE_KEY ?? 'key',
+    );
+    const { data, error } = await supabase.storage
+      .from('templates')
+      .download('bail-location-meublee.docx');
+    if (error || !data) throw new Error('Unable to download template');
+
+    const content = await data.arrayBuffer();
+    const zip = new PizZip(content);
+    const doc = new Docxtemplater(zip, { paragraphLoop: true, linebreaks: true });
+    doc.render({ bailleur: { nom: bailleurNom } });
+    const buffer = doc.getZip().generate({ type: 'nodebuffer' });
+    return Buffer.from(buffer);
+  },
+};

--- a/backend/tests/bail.routes.test.ts
+++ b/backend/tests/bail.routes.test.ts
@@ -1,0 +1,19 @@
+import request from 'supertest';
+import app from '../src/app';
+import { BailService } from '../src/services/bail.service';
+
+jest.mock('../src/services/bail.service');
+
+const mockedService = BailService as jest.Mocked<typeof BailService>;
+
+describe('GET /api/v1/bails/location-meublee', () => {
+  it('returns docx from service', async () => {
+    mockedService.generate.mockResolvedValueOnce(Buffer.from('docx'));
+    const res = await request(app).get('/api/v1/bails/location-meublee?bailleurNom=Test');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    );
+    expect(mockedService.generate).toHaveBeenCalledWith({ bailleurNom: 'Test' });
+  });
+});

--- a/backend/tests/bail.service.test.ts
+++ b/backend/tests/bail.service.test.ts
@@ -1,0 +1,38 @@
+import Docxtemplater from 'docxtemplater';
+import { BailService } from '../src/services/bail.service';
+
+jest.mock('../src/prisma', () => ({ prisma: {} }));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    storage: { from: () => ({ download: jest.fn() }) },
+  })),
+}));
+
+jest.mock('pizzip', () =>
+  jest.fn().mockImplementation(() => ({
+    // minimal api used by Docxtemplater
+  })),
+);
+
+jest.mock('docxtemplater', () =>
+  jest.fn().mockImplementation(() => ({
+    render: jest.fn(),
+    getZip: () => ({ generate: jest.fn(() => Buffer.from('docx')) }),
+  })),
+);
+
+import { createClient } from '@supabase/supabase-js';
+
+const mockedCreate = createClient as jest.Mock;
+
+describe('BailService.generate', () => {
+  it('downloads template and fills docx', async () => {
+    const downloadMock = jest.fn().mockResolvedValue({ data: new Blob(['docx']), error: null });
+    mockedCreate.mockReturnValue({ storage: { from: () => ({ download: downloadMock }) } });
+
+    const res = await BailService.generate({ bailleurNom: 'Test' });
+    expect(downloadMock).toHaveBeenCalled();
+    expect(Buffer.isBuffer(res)).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      docxtemplater:
+        specifier: ^3.65.0
+        version: 3.65.0
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -35,6 +38,9 @@ importers:
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
+      pizzip:
+        specifier: ^3.2.0
+        version: 3.2.0
       react-router-dom:
         specifier: ^7.6.2
         version: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2081,6 +2087,10 @@ packages:
   '@vitest/utils@3.2.3':
     resolution: {integrity: sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==}
 
+  '@xmldom/xmldom@0.9.8':
+    resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
+    engines: {node: '>=14.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2576,6 +2586,10 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  docxtemplater@3.65.0:
+    resolution: {integrity: sha512-8vh5bMluhtse7WLr95lU1aMMAirhNm+r8nFK3xjiXqzL1OHj1sPOO51yXbsGfUI1zMwFnjQ2wbCzXj1LYbjMjA==}
+    engines: {node: '>=0.10'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -3852,6 +3866,9 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3910,6 +3927,9 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pizzip@3.2.0:
+    resolution: {integrity: sha512-X4NPNICxCfIK8VYhF6wbksn81vTiziyLbvKuORVAmolvnUzl1A1xmz9DAWKxPRq9lZg84pJOOAMq3OE61bD8IQ==}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -6778,6 +6798,8 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@xmldom/xmldom@0.9.8': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
@@ -7301,6 +7323,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  docxtemplater@3.65.0:
+    dependencies:
+      '@xmldom/xmldom': 0.9.8
 
   dom-accessibility-api@0.5.16: {}
 
@@ -8905,6 +8931,8 @@ snapshots:
 
   pako@1.0.11: {}
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -8950,6 +8978,10 @@ snapshots:
   picomatch@4.0.2: {}
 
   pirates@4.0.7: {}
+
+  pizzip@3.2.0:
+    dependencies:
+      pako: 2.1.0
 
   pkg-dir@4.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- generate bail docx from Supabase template
- expose `/api/v1/bails/location-meublee` endpoint
- allow frontend to trigger lease document download

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_6855070986908329a5d1b730e6eba757