### PR TITLE
[backend] add Garage CRUD

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -22,6 +22,7 @@ import { locataireRouter } from './routes/locataire.routes';
 import { documentRouter } from './routes/document.routes';
 import { inventaireRouter } from './routes/inventaire.routes';
 import { bailRouter } from './routes/bail.routes';
+import { garageRouter } from './routes/garage.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -86,6 +87,7 @@ app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/locations', locationRouter);
 app.use('/api/v1/locataires', locataireRouter);
 app.use('/api/v1/documents', documentRouter);
+app.use('/api/v1/garages', garageRouter);
 app.use('/api/v1/inventaires', inventaireRouter);
 app.use('/api/v1/logements', logementRouter);
 app.use('/api/v1/profile/:profileId/biens', bienRouter);

--- a/backend/src/controllers/garage.controller.ts
+++ b/backend/src/controllers/garage.controller.ts
@@ -1,0 +1,54 @@
+import type { Request, Response, NextFunction } from 'express';
+import { GarageService } from '../services/garage.service';
+
+export const GarageController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const garage = await GarageService.create(req.body);
+      res.status(201).json(garage);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bienId = req.query.bienId as string | undefined;
+      const garages = await GarageService.list(bienId);
+      res.json(garages);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const garage = await GarageService.get(req.params.id);
+      if (!garage) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(garage);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const garage = await GarageService.update(req.params.id, req.body);
+      res.json(garage);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await GarageService.remove(req.params.id);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/garage.routes.ts
+++ b/backend/src/routes/garage.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { GarageController } from '../controllers/garage.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createGarageSchema,
+  updateGarageSchema,
+  garageIdParam,
+} from '../schemas/garage.schema';
+
+export const garageRouter = Router();
+
+garageRouter
+  .route('/')
+  .post(validateBody(createGarageSchema), GarageController.create)
+  .get(GarageController.list);
+
+garageRouter
+  .route('/:id')
+  .get(validateParams(garageIdParam), GarageController.get)
+  .patch(
+    validateParams(garageIdParam),
+    validateBody(updateGarageSchema),
+    GarageController.update,
+  )
+  .delete(validateParams(garageIdParam), GarageController.remove);

--- a/backend/src/schemas/garage.schema.ts
+++ b/backend/src/schemas/garage.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const createGarageSchema = z.object({
+  bienId: z.string().uuid(),
+  no: z.string(),
+  niveau: z.number().int(),
+});
+
+export const updateGarageSchema = createGarageSchema.partial();
+
+export const garageIdParam = z.object({ id: z.string().uuid() });

--- a/backend/src/services/garage.service.ts
+++ b/backend/src/services/garage.service.ts
@@ -1,0 +1,36 @@
+import { prisma } from '../prisma';
+import type { NewGarage, EditGarage } from '@monorepo/shared';
+
+interface PrismaWithGarage {
+  garage: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithGarage;
+
+export const GarageService = {
+  create(data: NewGarage) {
+    return db.garage.create({ data });
+  },
+
+  list(bienId?: string) {
+    return db.garage.findMany({ where: bienId ? { bienId } : undefined });
+  },
+
+  get(id: string) {
+    return db.garage.findUnique({ where: { id } });
+  },
+
+  update(id: string, data: EditGarage) {
+    return db.garage.update({ where: { id }, data });
+  },
+
+  remove(id: string) {
+    return db.garage.delete({ where: { id } });
+  },
+};

--- a/backend/tests/garage.routes.test.ts
+++ b/backend/tests/garage.routes.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import app from '../src/app';
+import { GarageService } from '../src/services/garage.service';
+
+interface GarageStub {
+  id: string;
+  no: string;
+}
+
+jest.mock('../src/services/garage.service');
+
+const mockedService = GarageService as jest.Mocked<typeof GarageService>;
+
+describe('GET /api/v1/garages', () => {
+  it('returns garages from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: '1', no: 'G1' } as GarageStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/garages');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('POST /api/v1/garages', () => {
+  it('creates a garage via service', async () => {
+    const payload = {
+      bienId: '00000000-0000-0000-0000-000000000000',
+      no: 'G1',
+      niveau: 1,
+    };
+    (mockedService.create as jest.Mock).mockResolvedValueOnce({
+      id: '1',
+      ...payload,
+    } as GarageStub);
+
+    const res = await request(app).post('/api/v1/garages').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockedService.create).toHaveBeenCalledWith(payload);
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -10,6 +10,8 @@ export type NewDocument = Prisma.DocumentCreateInput;
 export type EditDocument = Prisma.DocumentUpdateInput;
 export type NewInventaire = Prisma.InventaireCreateInput;
 export type EditInventaire = Prisma.InventaireUpdateInput;
+export type NewGarage = Prisma.GarageCreateInput;
+export type EditGarage = Prisma.GarageUpdateInput;
 
 export * from './types/UserProfile';
 export * from './types/ApiResponse';


### PR DESCRIPTION
## Summary
- add types for garages in shared
- implement `GarageService`, controller, schema and routes
- expose new `/api/v1/garages` endpoints in app
- test garage routes

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_68557db32f688329907b4cb4b239caae