### PR TITLE
[backend] add Cave CRUD routes

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -23,6 +23,7 @@ import { documentRouter } from './routes/document.routes';
 import { inventaireRouter } from './routes/inventaire.routes';
 import { bailRouter } from './routes/bail.routes';
 import { garageRouter } from './routes/garage.routes';
+import { caveRouter } from './routes/cave.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -88,6 +89,7 @@ app.use('/api/v1/locations', locationRouter);
 app.use('/api/v1/locataires', locataireRouter);
 app.use('/api/v1/documents', documentRouter);
 app.use('/api/v1/garages', garageRouter);
+app.use('/api/v1/caves', caveRouter);
 app.use('/api/v1/inventaires', inventaireRouter);
 app.use('/api/v1/logements', logementRouter);
 app.use('/api/v1/profile/:profileId/biens', bienRouter);

--- a/backend/src/controllers/cave.controller.ts
+++ b/backend/src/controllers/cave.controller.ts
@@ -1,0 +1,54 @@
+import type { Request, Response, NextFunction } from 'express';
+import { CaveService } from '../services/cave.service';
+
+export const CaveController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cave = await CaveService.create(req.body);
+      res.status(201).json(cave);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bienId = req.query.bienId as string | undefined;
+      const caves = await CaveService.list(bienId);
+      res.json(caves);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cave = await CaveService.get(req.params.id);
+      if (!cave) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(cave);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const cave = await CaveService.update(req.params.id, req.body);
+      res.json(cave);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await CaveService.remove(req.params.id);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/cave.routes.ts
+++ b/backend/src/routes/cave.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { CaveController } from '../controllers/cave.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createCaveSchema,
+  updateCaveSchema,
+  caveIdParam,
+} from '../schemas/cave.schema';
+
+export const caveRouter = Router();
+
+caveRouter
+  .route('/')
+  .post(validateBody(createCaveSchema), CaveController.create)
+  .get(CaveController.list);
+
+caveRouter
+  .route('/:id')
+  .get(validateParams(caveIdParam), CaveController.get)
+  .patch(
+    validateParams(caveIdParam),
+    validateBody(updateCaveSchema),
+    CaveController.update,
+  )
+  .delete(validateParams(caveIdParam), CaveController.remove);

--- a/backend/src/schemas/cave.schema.ts
+++ b/backend/src/schemas/cave.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const createCaveSchema = z.object({
+  bienId: z.string().uuid(),
+  no: z.string(),
+  niveau: z.number().int(),
+});
+
+export const updateCaveSchema = createCaveSchema.partial();
+
+export const caveIdParam = z.object({ id: z.string().uuid() });

--- a/backend/src/services/cave.service.ts
+++ b/backend/src/services/cave.service.ts
@@ -1,0 +1,36 @@
+import { prisma } from '../prisma';
+import type { NewCave, EditCave } from '@monorepo/shared';
+
+interface PrismaWithCave {
+  cave: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithCave;
+
+export const CaveService = {
+  create(data: NewCave) {
+    return db.cave.create({ data });
+  },
+
+  list(bienId?: string) {
+    return db.cave.findMany({ where: bienId ? { bienId } : undefined });
+  },
+
+  get(id: string) {
+    return db.cave.findUnique({ where: { id } });
+  },
+
+  update(id: string, data: EditCave) {
+    return db.cave.update({ where: { id }, data });
+  },
+
+  remove(id: string) {
+    return db.cave.delete({ where: { id } });
+  },
+};

--- a/backend/tests/cave.routes.test.ts
+++ b/backend/tests/cave.routes.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import app from '../src/app';
+import { CaveService } from '../src/services/cave.service';
+
+interface CaveStub {
+  id: string;
+  no: string;
+}
+
+jest.mock('../src/services/cave.service');
+
+const mockedService = CaveService as jest.Mocked<typeof CaveService>;
+
+describe('GET /api/v1/caves', () => {
+  it('returns caves from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: '1', no: 'C1' } as CaveStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/caves');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('POST /api/v1/caves', () => {
+  it('creates a cave via service', async () => {
+    const payload = {
+      bienId: '00000000-0000-0000-0000-000000000000',
+      no: 'C1',
+      niveau: 1,
+    };
+    (mockedService.create as jest.Mock).mockResolvedValueOnce({
+      id: '1',
+      ...payload,
+    } as CaveStub);
+
+    const res = await request(app).post('/api/v1/caves').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockedService.create).toHaveBeenCalledWith(payload);
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -12,6 +12,8 @@ export type NewInventaire = Prisma.InventaireCreateInput;
 export type EditInventaire = Prisma.InventaireUpdateInput;
 export type NewGarage = Prisma.GarageCreateInput;
 export type EditGarage = Prisma.GarageUpdateInput;
+export type NewCave = Prisma.CaveCreateInput;
+export type EditCave = Prisma.CaveUpdateInput;
 
 export * from './types/UserProfile';
 export * from './types/ApiResponse';


### PR DESCRIPTION
## Summary
- create Cave types in shared package
- add Cave service, controller, schema, and routes
- expose `/api/v1/caves` in the backend API
- test new Cave routes

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_6855814a63d083299913ac0bc8f70697