### PR TITLE
[backend] add garant CRUD

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,6 +24,7 @@ import { inventaireRouter } from './routes/inventaire.routes';
 import { bailRouter } from './routes/bail.routes';
 import { garageRouter } from './routes/garage.routes';
 import { caveRouter } from './routes/cave.routes';
+import { garantRouter } from './routes/garant.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -88,6 +89,7 @@ app.use('/api/v1/activities', activityRouter);
 app.use('/api/v1/locations', locationRouter);
 app.use('/api/v1/locataires', locataireRouter);
 app.use('/api/v1/documents', documentRouter);
+app.use('/api/v1/garants', garantRouter);
 app.use('/api/v1/garages', garageRouter);
 app.use('/api/v1/caves', caveRouter);
 app.use('/api/v1/inventaires', inventaireRouter);

--- a/backend/src/controllers/garant.controller.ts
+++ b/backend/src/controllers/garant.controller.ts
@@ -1,0 +1,54 @@
+import type { Request, Response, NextFunction } from 'express';
+import { GarantService } from '../services/garant.service';
+
+export const GarantController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { locataireId, ...data } = req.body;
+      const garant = await GarantService.create(locataireId, data);
+      res.status(201).json(garant);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const garants = await GarantService.list();
+      res.json(garants);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const garant = await GarantService.get(Number(req.params.id));
+      if (!garant) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(garant);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const garant = await GarantService.update(Number(req.params.id), req.body);
+      res.json(garant);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await GarantService.remove(Number(req.params.id));
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/garant.routes.ts
+++ b/backend/src/routes/garant.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { GarantController } from '../controllers/garant.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createGarantSchema,
+  updateGarantSchema,
+  garantIdParam,
+} from '../schemas/garant.schema';
+
+export const garantRouter = Router();
+
+garantRouter
+  .route('/')
+  .post(validateBody(createGarantSchema), GarantController.create)
+  .get(GarantController.list);
+
+garantRouter
+  .route('/:id')
+  .get(validateParams(garantIdParam), GarantController.get)
+  .patch(
+    validateParams(garantIdParam),
+    validateBody(updateGarantSchema),
+    GarantController.update,
+  )
+  .delete(validateParams(garantIdParam), GarantController.remove);

--- a/backend/src/schemas/garant.schema.ts
+++ b/backend/src/schemas/garant.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const createGarantSchema = z.object({
+  locataireId: z.string().uuid(),
+  type: z.enum([
+    'PERSONNE_PHYSIQUE',
+    'SOCIETE',
+    'GARANTIE_BANCAIRE',
+    'GARANTIE_VISALE',
+    'GARANTIE_GARANTME',
+    'AUTRE',
+    'AUCUN',
+  ]),
+});
+
+export const updateGarantSchema = createGarantSchema
+  .omit({ locataireId: true })
+  .partial();
+
+export const garantIdParam = z.object({ id: z.coerce.number().int() });

--- a/backend/src/services/garant.service.ts
+++ b/backend/src/services/garant.service.ts
@@ -1,0 +1,58 @@
+import { prisma } from '../prisma';
+import type { NewGarant, EditGarant } from '@monorepo/shared';
+
+interface PrismaWithGarant {
+  garant: {
+    create: (...args: unknown[]) => unknown;
+    findMany: (...args: unknown[]) => unknown;
+    findUnique: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+    delete: (...args: unknown[]) => unknown;
+  };
+  locataire: {
+    findUnique: (...args: unknown[]) => unknown;
+    findFirst: (...args: unknown[]) => unknown;
+    update: (...args: unknown[]) => unknown;
+  };
+}
+
+const db = prisma as unknown as PrismaWithGarant;
+
+export const GarantService = {
+  async create(locataireId: string, data: NewGarant) {
+    const loc = (await db.locataire.findUnique({
+      where: { id: locataireId },
+    })) as unknown as { garantId: number | null } | null;
+    if (!loc) throw new Error('locataire not found');
+    if (loc.garantId) throw new Error('locataire already has a garant');
+
+    const garant = (await db.garant.create({ data })) as unknown as { id: number };
+    await db.locataire.update({
+      where: { id: locataireId },
+      data: { garantId: garant.id },
+    });
+    return garant;
+  },
+
+  list() {
+    return db.garant.findMany();
+  },
+
+  get(id: number) {
+    return db.garant.findUnique({ where: { id } });
+  },
+
+  update(id: number, data: EditGarant) {
+    return db.garant.update({ where: { id }, data });
+  },
+
+  async remove(id: number) {
+    const loc = (await db.locataire.findFirst({
+      where: { garantId: id },
+    })) as unknown as { id: string } | null;
+    if (loc) {
+      await db.locataire.update({ where: { id: loc.id }, data: { garantId: null } });
+    }
+    return db.garant.delete({ where: { id } });
+  },
+};

--- a/backend/tests/garant.routes.test.ts
+++ b/backend/tests/garant.routes.test.ts
@@ -1,0 +1,43 @@
+import request from 'supertest';
+import app from '../src/app';
+import { GarantService } from '../src/services/garant.service';
+
+interface GarantStub {
+  id: number;
+  type: string;
+}
+
+jest.mock('../src/services/garant.service');
+
+const mockedService = GarantService as jest.Mocked<typeof GarantService>;
+
+describe('GET /api/v1/garants', () => {
+  it('returns garants from service', async () => {
+    (mockedService.list as jest.Mock).mockResolvedValueOnce([
+      { id: 1, type: 'AUTRE' } as GarantStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/garants');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/garants', () => {
+  it('creates a garant via service', async () => {
+    const payload = {
+      locataireId: '00000000-0000-0000-0000-000000000000',
+      type: 'AUTRE',
+    };
+    (mockedService.create as jest.Mock).mockResolvedValueOnce({
+      id: 1,
+      type: 'AUTRE',
+    } as GarantStub);
+
+    const res = await request(app).post('/api/v1/garants').send(payload);
+
+    expect(res.status).toBe(201);
+    expect(mockedService.create).toHaveBeenCalledWith(payload.locataireId, { type: 'AUTRE' });
+  });
+});

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -14,6 +14,8 @@ export type NewGarage = Prisma.GarageCreateInput;
 export type EditGarage = Prisma.GarageUpdateInput;
 export type NewCave = Prisma.CaveCreateInput;
 export type EditCave = Prisma.CaveUpdateInput;
+export type NewGarant = Prisma.GarantCreateInput;
+export type EditGarant = Prisma.GarantUpdateInput;
 
 export * from './types/UserProfile';
 export * from './types/ApiResponse';


### PR DESCRIPTION
## Summary
- implement guarant crud backend
- expose guarant types in shared package
- test garant routes

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_68558b08de5883298cd2052f1436d0da