### PR TITLE
[backend] Support bailleur prenom in lease generation

### DIFF
--- a/backend/src/controllers/bail.controller.ts
+++ b/backend/src/controllers/bail.controller.ts
@@ -5,7 +5,8 @@ export const BailController = {
   async generate(req: Request, res: Response, next: NextFunction) {
     try {
       const bailleurNom = req.query.bailleurNom as string;
-      const doc = await BailService.generate({ bailleurNom });
+      const bailleurPrenom = req.query.bailleurPrenom as string;
+      const doc = await BailService.generate({ bailleurNom, bailleurPrenom });
       res
         .status(200)
         .set({

--- a/backend/src/schemas/bail.schema.ts
+++ b/backend/src/schemas/bail.schema.ts
@@ -2,4 +2,5 @@ import { z } from 'zod';
 
 export const bailQuerySchema = z.object({
   bailleurNom: z.string().min(1),
+  bailleurPrenom: z.string().min(1),
 });

--- a/backend/src/services/bail.service.ts
+++ b/backend/src/services/bail.service.ts
@@ -1,12 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
-import { createReport } from 'docx-templates';
+import createReport from 'docx-templates';
 
 interface Options {
   bailleurNom: string;
+  bailleurPrenom: string;
 }
 
 export const BailService = {
-  async generate({ bailleurNom }: Options): Promise<Buffer> {
+  async generate({ bailleurNom, bailleurPrenom }: Options): Promise<Buffer> {
     const supabase = createClient(
       process.env.SUPABASE_URL ?? 'http://localhost',
       process.env.SUPABASE_KEY ?? 'key',
@@ -19,7 +20,7 @@ export const BailService = {
     const content = await data.arrayBuffer();
     const buffer = await createReport({
       template: Buffer.from(content),
-      data: { bailleur: { nom: bailleurNom } },
+      data: { bailleur: { nom: bailleurNom, prenom: bailleurPrenom } },
     });
     return Buffer.from(buffer);
   },

--- a/backend/tests/bail.routes.test.ts
+++ b/backend/tests/bail.routes.test.ts
@@ -9,11 +9,11 @@ const mockedService = BailService as jest.Mocked<typeof BailService>;
 describe('GET /api/v1/bails/location-meublee', () => {
   it('returns docx from service', async () => {
     mockedService.generate.mockResolvedValueOnce(Buffer.from('docx'));
-    const res = await request(app).get('/api/v1/bails/location-meublee?bailleurNom=Test');
+    const res = await request(app).get('/api/v1/bails/location-meublee?bailleurNom=Test&bailleurPrenom=John');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toBe(
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     );
-    expect(mockedService.generate).toHaveBeenCalledWith({ bailleurNom: 'Test' });
+    expect(mockedService.generate).toHaveBeenCalledWith({ bailleurNom: 'Test', bailleurPrenom: 'John' });
   });
 });

--- a/backend/tests/bail.service.test.ts
+++ b/backend/tests/bail.service.test.ts
@@ -25,9 +25,12 @@ describe('BailService.generate', () => {
     const downloadMock = jest.fn().mockResolvedValue({ data: new Blob(['docx']), error: null });
     mockedCreate.mockReturnValue({ storage: { from: () => ({ download: downloadMock }) } });
 
-    const res = await BailService.generate({ bailleurNom: 'Test' });
+    const res = await BailService.generate({ bailleurNom: 'Test', bailleurPrenom: 'John' });
     expect(downloadMock).toHaveBeenCalled();
-    expect(mockedCreateReport).toHaveBeenCalled();
+    expect(mockedCreateReport).toHaveBeenCalledWith({
+      template: expect.any(Buffer),
+      data: { bailleur: { nom: 'Test', prenom: 'John' } },
+    });
     expect(Buffer.isBuffer(res)).toBe(true);
   });
 });

--- a/frontend/src/pages/NewLocation.tsx
+++ b/frontend/src/pages/NewLocation.tsx
@@ -52,7 +52,7 @@ export default function NewLocation() {
     if (!profile || !token) return;
     const res = await fetch(
       buildUrl(
-        `/api/v1/bails/location-meublee?bailleurNom=${encodeURIComponent(profile.nom)}`,
+        `/api/v1/bails/location-meublee?bailleurNom=${encodeURIComponent(profile.nom)}&bailleurPrenom=${encodeURIComponent(profile.prenom)}`,
       ),
       { headers: { Authorization: `Bearer ${token}` } },
     );


### PR DESCRIPTION
## Summary
- support bailleur first name in bail service and controller
- update bail schema
- update tests for bail service/routes
- pass first name from frontend when generating the lease

## Testing
- `pnpm --filter backend lint`
- `pnpm --filter frontend lint`
- `pnpm --filter backend test`
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_685989465bf4832993133f451af5ddd7