### PR TITLE
[frontend] persist Supabase session

### DIFF
--- a/backend/src/services/bail.service.ts
+++ b/backend/src/services/bail.service.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { createReport, listCommands } from 'docx-templates';
+import { createReport } from 'docx-templates';
 
 interface Options {
   bailleurNom: string;
@@ -19,11 +19,6 @@ export const BailService = {
 
     const content = await data.arrayBuffer();
 
-    //Debug
-    const cmds = await listCommands(Buffer.from(content), ['{','}'])
-    console.log(cmds)
-
-    console.log("testbailleur",bailleurNom);
     const buffer = await createReport({
       template: Buffer.from(content),
       data: { bailleur: { nom: bailleurNom, prenom: bailleurPrenom } },

--- a/backend/tests/bail.service.test.ts
+++ b/backend/tests/bail.service.test.ts
@@ -1,4 +1,4 @@
-import createReport from 'docx-templates';
+import { createReport } from 'docx-templates';
 import { BailService } from '../src/services/bail.service';
 
 jest.mock('../src/prisma', () => ({ prisma: {} }));
@@ -11,7 +11,7 @@ jest.mock('@supabase/supabase-js', () => ({
 
 jest.mock('docx-templates', () => ({
   __esModule: true,
-  default: jest.fn().mockResolvedValue(Buffer.from('docx')),
+  createReport: jest.fn().mockResolvedValue(Buffer.from('docx')),
 }));
 
 const mockedCreateReport = createReport as jest.Mock;
@@ -25,12 +25,13 @@ describe('BailService.generate', () => {
     const downloadMock = jest.fn().mockResolvedValue({ data: new Blob(['docx']), error: null });
     mockedCreate.mockReturnValue({ storage: { from: () => ({ download: downloadMock }) } });
 
-    const res = await BailService.generate({ bailleurNom: 'Test', bailleurPrenom: 'John' });
-    expect(downloadMock).toHaveBeenCalled();
-    expect(mockedCreateReport).toHaveBeenCalledWith({
-      template: expect.any(Buffer),
-      data: { bailleur: { nom: 'Test', prenom: 'John' } },
-    });
-    expect(Buffer.isBuffer(res)).toBe(true);
+  const res = await BailService.generate({ bailleurNom: 'Test', bailleurPrenom: 'John' });
+  expect(downloadMock).toHaveBeenCalled();
+  expect(mockedCreateReport).toHaveBeenCalledWith({
+    template: expect.any(Buffer),
+    data: { bailleur: { nom: 'Test', prenom: 'John' } },
+    cmdDelimiter: ['{', '}'],
+  });
+  expect(Buffer.isBuffer(res)).toBe(true);
   });
 });

--- a/frontend/src/lib/auth.supabase.ts
+++ b/frontend/src/lib/auth.supabase.ts
@@ -1,12 +1,7 @@
-import { createClient } from '@supabase/supabase-js';
 import type { Session } from '@supabase/supabase-js';
+import { supabase } from './supabaseClient';
 
 export function createAuthProvider() {
-  const supabase = createClient(
-    import.meta.env.VITE_SUPABASE_URL!,
-    import.meta.env.VITE_SUPABASE_ANON_KEY!,
-  );
-
   return {
     getCurrentUser: async () => {
       const {

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -1,0 +1,11 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_ANON_KEY!,
+  {
+    auth: {
+      persistSession: true,
+    },
+  },
+);

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -5,6 +5,7 @@ import type { User, Session } from '@supabase/supabase-js';
 export interface AuthState {
   user: User | null;
   token: string | null;
+  session: Session | null;
   loading: boolean;
   error: string | null;
   initialize: () => Promise<void>;
@@ -24,6 +25,7 @@ export const useAuth = create<AuthState>((set) => {
     set({
       user: session?.user ?? null,
       token: session?.access_token ?? null,
+      session: session ?? null,
     });
   });
 
@@ -32,12 +34,14 @@ export const useAuth = create<AuthState>((set) => {
     set({
       user: session?.user ?? null,
       token: session?.access_token ?? null,
+      session: session ?? null,
     });
   });
 
   return {
     user: null,
     token: null,
+    session: null,
     loading: false,
     error: null,
 
@@ -48,6 +52,7 @@ export const useAuth = create<AuthState>((set) => {
       set({
         user: session?.user ?? null,
         token: session?.access_token ?? null,
+        session: session ?? null,
       });
     },
 
@@ -66,6 +71,7 @@ export const useAuth = create<AuthState>((set) => {
       set({
         user: session.user,
         token: session.access_token,
+        session,
         loading: false,
       });
     },
@@ -98,6 +104,7 @@ export const useAuth = create<AuthState>((set) => {
         set({
           user: session.user,
           token: session.access_token,
+          session,
           loading: false,
         });
       } else {
@@ -115,6 +122,7 @@ export const useAuth = create<AuthState>((set) => {
       set({
         user: null,
         token: null,
+        session: null,
         loading: false,
       });
     },


### PR DESCRIPTION
## Summary
- instantiate the Supabase client once with persisted sessions
- use the shared Supabase instance inside the auth provider
- store `session` in the global auth store
- fix backend bail service imports and tests so that all suites pass

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_685a7151fadc8329a0692177142e09ee