### PR TITLE
[frontend] fix login redirect race on refresh

### DIFF
--- a/frontend/src/hooks/useRequireAuth.test.tsx
+++ b/frontend/src/hooks/useRequireAuth.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import { useAuth } from '../store/auth';
+import { useRequireAuth } from './useRequireAuth';
+
+function TestComponent() {
+  useRequireAuth();
+  return <div>home</div>;
+}
+
+describe('useRequireAuth', () => {
+  it('does not redirect while loading', () => {
+    useAuth.setState((s) => ({ ...s, user: null, loading: true }));
+    render(
+      <MemoryRouter initialEntries={['/']}> 
+        <Routes>
+          <Route path="/" element={<TestComponent />} />
+          <Route path="/login" element={<div>login</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('login')).not.toBeInTheDocument();
+  });
+
+  it('redirects to login when not authenticated', async () => {
+    useAuth.setState((s) => ({ ...s, user: null, loading: false }));
+    render(
+      <MemoryRouter initialEntries={['/']}> 
+        <Routes>
+          <Route path="/" element={<TestComponent />} />
+          <Route path="/login" element={<div>login</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByText('login')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useRequireAuth.tsx
+++ b/frontend/src/hooks/useRequireAuth.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../store/auth';
 
 export const useRequireAuth = () => {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const navigate = useNavigate();
   useEffect(() => {
-    if (!user) navigate('/login');
-  }, [user]);
+    if (!loading && !user) navigate('/login');
+  }, [user, loading]);
 };

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -7,6 +7,8 @@ export interface AuthState {
   token: string | null;
   session: Session | null;
   loading: boolean;
+  /** indicates whether the initial session check is in progress */
+  initialized: boolean;
   error: string | null;
   initialize: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<void>;
@@ -26,6 +28,8 @@ export const useAuth = create<AuthState>((set) => {
       user: session?.user ?? null,
       token: session?.access_token ?? null,
       session: session ?? null,
+      loading: false,
+      initialized: true,
     });
   });
 
@@ -35,6 +39,7 @@ export const useAuth = create<AuthState>((set) => {
       user: session?.user ?? null,
       token: session?.access_token ?? null,
       session: session ?? null,
+      initialized: true,
     });
   });
 
@@ -42,10 +47,12 @@ export const useAuth = create<AuthState>((set) => {
     user: null,
     token: null,
     session: null,
-    loading: false,
+    loading: true,
+    initialized: false,
     error: null,
 
     initialize: async () => {
+      set({ loading: true });
       const {
         data: { session },
       } = await auth.getSession();
@@ -53,6 +60,8 @@ export const useAuth = create<AuthState>((set) => {
         user: session?.user ?? null,
         token: session?.access_token ?? null,
         session: session ?? null,
+        loading: false,
+        initialized: true,
       });
     },
 
@@ -73,6 +82,7 @@ export const useAuth = create<AuthState>((set) => {
         token: session.access_token,
         session,
         loading: false,
+        initialized: true,
       });
     },
 
@@ -106,6 +116,7 @@ export const useAuth = create<AuthState>((set) => {
           token: session.access_token,
           session,
           loading: false,
+          initialized: true,
         });
       } else {
         set({ loading: false });
@@ -124,6 +135,7 @@ export const useAuth = create<AuthState>((set) => {
         token: null,
         session: null,
         loading: false,
+        initialized: true,
       });
     },
   };


### PR DESCRIPTION
## Summary
- avoid redirecting before auth initialization
- expose initialization state in auth store
- test new `useRequireAuth` behavior

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_685b91eef5848329ad43c7d3771bbdb1