### PR TITLE
[frontend] Add bilan creation flow

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -13,14 +13,8 @@ import {
 // Tests simplifiés pour la navigation
 
 describe('App navigation', () => {
-  it('affiche le dashboard par défaut', async () => {
-    useAuth.setState({ user: { id: '1' } as unknown as User, loading: false });
-    useUserProfileStore.setState(
-      (state) => ({ ...state, profileId: 'p1' }) as UserProfileState,
-    );
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
-    ) as unknown as typeof fetch;
+  it('affiche la page d\u2019accueil', async () => {
+    useAuth.setState({ user: null, loading: false });
     render(
       <BrowserRouter>
         <PageProvider>
@@ -29,7 +23,7 @@ describe('App navigation', () => {
       </BrowserRouter>,
     );
     expect(
-      await screen.findByRole('heading', { name: /dashboard/i }),
+      await screen.findByRole('button', { name: /rédiger un nouveau bilan/i }),
     ).toBeInTheDocument();
   });
 
@@ -52,6 +46,7 @@ describe('App navigation', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
     ) as unknown as typeof fetch;
 
+    window.history.pushState({}, '', '/dashboard');
     render(
       <BrowserRouter>
         <PageProvider>
@@ -74,6 +69,7 @@ describe('App navigation', () => {
     global.fetch = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
     ) as unknown as typeof fetch;
+    window.history.pushState({}, '', '/dashboard');
     render(
       <BrowserRouter>
         <PageProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,6 @@ import MesBiens from './pages/MesBiens';
 import PropertyDashboard from './pages/PropertyDashboard';
 import NewLocation from './pages/NewLocation';
 import Agenda from './pages/Agenda';
-import Resultats from './pages/Resultats';
 import Abonnement from './pages/Abonnement';
 import MonCompteV2 from './pages/MonCompte';
 import Login from './pages/Login';
@@ -15,6 +14,8 @@ import SignUp from './pages/SignUp';
 import { usePageStore } from './store/pageContext';
 import { useUserProfileStore } from './store/userProfile';
 import { AppSidebar } from './components/AppSidebar';
+import Home from './pages/Home';
+import Bilan from './pages/Bilan';
 
 function useInitAuth() {
   const { loading, initialize } = useAuth();
@@ -80,13 +81,15 @@ function WizardLayout() {
 export default function App() {
   return (
     <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/bilan/:bilanId" element={<Bilan />} />
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<SignUp />} />
       <Route element={<WizardLayout />}>
         <Route path="/biens/:id/locations/new" element={<NewLocation />} />
       </Route>
       <Route element={<ProtectedLayout />}>
-        <Route path="/" element={<Dashboard />} />
+        <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/biens" element={<MesBiens />} />
         <Route path="/biens/:id/dashboard" element={<PropertyDashboard />} />
         <Route path="/agenda" element={<Agenda />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1,14 +1,6 @@
 import * as React from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
-import {
-  Home,
-  Calendar,
-  CreditCard,
-  FileText,
-  Crown,
-  User,
-  LogOut,
-} from 'lucide-react';
+import { Home, Calendar, CreditCard, Crown, User, LogOut } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import {
   Sidebar as UISidebar,

--- a/frontend/src/components/Inventory.tsx
+++ b/frontend/src/components/Inventory.tsx
@@ -27,7 +27,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { Search, Plus, Package, Edit, Trash2, X, Check } from 'lucide-react';
+import { Search, Plus, Edit, Trash2, X, Check } from 'lucide-react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -122,16 +122,16 @@ export default function InventoryPage() {
       editingData.mobilier &&
       editingData.etatEntree
     ) {
-    const data = {
+      const data = {
         piece: editingData.piece,
         mobilier: editingData.mobilier,
         quantite: editingData.quantite,
         marque: editingData.marque,
         etatEntree: editingData.etatEntree,
-        };
-    await update(editingId, data);      
-    setEditingId(null);
-    setEditingData({});
+      };
+      await update(editingId, data);
+      setEditingId(null);
+      setEditingData({});
     }
   };
 
@@ -203,11 +203,6 @@ export default function InventoryPage() {
         return 'bg-gray-100 text-gray-800';
     }
   };
-
-  const totalValue = inventory.reduce(
-    (sum, item) => sum + item.prix * item.quantite,
-    0,
-  );
 
   return (
     <div className="container mx-auto p-6 space-y-6">

--- a/frontend/src/pages/Bilan.tsx
+++ b/frontend/src/pages/Bilan.tsx
@@ -1,0 +1,6 @@
+import { useParams } from 'react-router-dom';
+
+export default function Bilan() {
+  const { bilanId } = useParams<{ bilanId: string }>();
+  return <div data-testid="bilan-page">Bilan {bilanId}</div>;
+}

--- a/frontend/src/pages/Home.test.tsx
+++ b/frontend/src/pages/Home.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import Home from './Home';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('Home page', () => {
+  it('creates a bilan and redirects', async () => {
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: '42' }),
+    });
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/bilan/:id" element={<div>bilan page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /rédiger un nouveau bilan/i }),
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(fetch).toHaveBeenCalledWith('/api/bilans', expect.any(Object));
+    expect(await screen.findByText(/bilan page/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '../components/ui/button';
+import { apiFetch } from '../utils/api';
+
+export default function Home() {
+  const navigate = useNavigate();
+
+  const handleClick = async () => {
+    const { id } = await apiFetch<{ id: string }>('/api/bilans', {
+      method: 'POST',
+    });
+    navigate(`/bilan/${id}`);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <Button onClick={handleClick}>Rédiger un nouveau bilan</Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -15,7 +15,7 @@ export default function Login() {
     setError(null);
     try {
       await signIn(email, password);
-      navigate('/');
+      navigate('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Erreur de connexion');
     } finally {

--- a/frontend/src/pages/PropertyDashboard.tsx
+++ b/frontend/src/pages/PropertyDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { AlertTriangle, Euro } from 'lucide-react';
+import { Euro } from 'lucide-react';
 import { PropertyTabList } from '../components/ui/PropertyTabList';
 import {
   PropertyInfoCard,
@@ -20,7 +20,6 @@ import type { NewLocation } from '@monorepo/shared';
 import { Button } from '../components/ui/button';
 import { ChargesCard } from '../components/ui/ChargesCard';
 import { RevenueCard } from '../components/ui/RevenueCard';
-import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
 import {
   Card,
   CardContent,
@@ -126,14 +125,6 @@ export default function PropertyDashboard() {
       { month: 'Fév', amount: 1800, status: 'En attente' },
     ],
   };
-  const alerts = [
-    {
-      type: 'warning',
-      title: 'Révision de loyer',
-      description: 'La révision annuelle du loyer est due',
-      date: '2024-01-15',
-    },
-  ];
 
   const changeTab = (t: 'view' | 'documents' | 'finances' | 'inventaire') => {
     setTab(t);

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -43,7 +43,7 @@ export default function SignUp() {
     setError(null);
     try {
       await signUp(email, password, firstName, lastName);
-      navigate('/');
+      navigate('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Erreur');
     } finally {


### PR DESCRIPTION
## Summary
- add Home page with button to create a bilan and redirect to `/bilan/:bilanId`
- stub Bilan page placeholder
- update routing and navigation after login/sign-up
- include basic tests for the new Home page

## Testing
- `pnpm run lint` in `frontend`
- `pnpm run test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_687e1d44f46083298295bcea4a3bb225