### PR TITLE
[frontend] add bilan creation flow

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { User } from '@supabase/supabase-js';
 import App from './App';
 import { PageProvider } from './store/pageContext';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import { useAuth } from './store/auth';
 import {
   useUserProfileStore,
@@ -13,23 +13,23 @@ import {
 // Tests simplifiés pour la navigation
 
 describe('App navigation', () => {
-  it('affiche le dashboard par défaut', async () => {
+  it('affiche le bouton nouveau bilan', async () => {
     useAuth.setState({ user: { id: '1' } as unknown as User, loading: false });
     useUserProfileStore.setState(
       (state) => ({ ...state, profileId: 'p1' }) as UserProfileState,
     );
     global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
-    ) as unknown as typeof fetch;
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ id: '1' }) }),
+    );
     render(
-      <BrowserRouter>
+      <MemoryRouter>
         <PageProvider>
           <App />
         </PageProvider>
-      </BrowserRouter>,
+      </MemoryRouter>,
     );
     expect(
-      await screen.findByRole('heading', { name: /dashboard/i }),
+      await screen.findByRole('button', { name: /rédiger un nouveau bilan/i }),
     ).toBeInTheDocument();
   });
 
@@ -84,5 +84,28 @@ describe('App navigation', () => {
     const btn = await screen.findByRole('button', { name: /mes\s?biens/i });
     fireEvent.click(btn);
     expect(btn).toHaveAttribute('data-active', 'true');
+  });
+
+  it('cache la sidebar sur la page bilan', async () => {
+    useAuth.setState({ user: { id: '1' } as unknown as User, loading: false });
+    useUserProfileStore.setState(
+      (state) => ({ ...state, profileId: 'p1' }) as UserProfileState,
+    );
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
+    ) as unknown as typeof fetch;
+    render(
+      <MemoryRouter initialEntries={['/bilan/123']}>
+        <PageProvider>
+          <App />
+        </PageProvider>
+      </MemoryRouter>,
+    );
+    expect(
+      screen.queryByRole('button', { name: /mes\s?biens/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: /retour/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Dashboard from './pages/Dashboard';
 import MesBiens from './pages/MesBiens';
 import PropertyDashboard from './pages/PropertyDashboard';
 import NewLocation from './pages/NewLocation';
+import Bilan from './pages/Bilan';
 import Agenda from './pages/Agenda';
 import Resultats from './pages/Resultats';
 import Abonnement from './pages/Abonnement';
@@ -58,6 +59,39 @@ function ProtectedLayout() {
 }
 
 function WizardLayout() {
+  const setCurrentPage = usePageStore((s) => s.setCurrentPage);
+  const { user } = useAuth();
+  const { profileId, fetchProfile } = useUserProfileStore();
+  const loading = useInitAuth();
+  useRequireAuth();
+
+  useEffect(() => {
+    if (user && !profileId) {
+      fetchProfile().catch(() => {
+        /* ignore */
+      });
+    }
+  }, [user, profileId, fetchProfile]);
+
+  if (loading) {
+    return <div>Chargement...</div>;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return (
+    <div className="flex">
+      <AppSidebar onNavigate={setCurrentPage} />
+      <main className="flex-1 p-4">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+function BilanLayout() {
   const { user } = useAuth();
   const loading = useInitAuth();
   useRequireAuth();
@@ -84,6 +118,9 @@ export default function App() {
       <Route path="/signup" element={<SignUp />} />
       <Route element={<WizardLayout />}>
         <Route path="/biens/:id/locations/new" element={<NewLocation />} />
+      </Route>
+      <Route element={<BilanLayout />}>
+        <Route path="/bilan/:bilanId" element={<Bilan />} />
       </Route>
       <Route element={<ProtectedLayout />}>
         <Route path="/" element={<Dashboard />} />

--- a/frontend/src/pages/Bilan.test.tsx
+++ b/frontend/src/pages/Bilan.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Bilan from './Bilan';
+
+describe('Bilan page', () => {
+  it('renders return button', () => {
+    render(
+      <MemoryRouter initialEntries={['/bilan/1']}>
+        <Routes>
+          <Route path="/bilan/:bilanId" element={<Bilan />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: /retour/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Bilan.tsx
+++ b/frontend/src/pages/Bilan.tsx
@@ -1,0 +1,15 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button } from '../components/ui/button';
+
+export default function Bilan() {
+  const { bilanId } = useParams<{ bilanId: string }>();
+  const navigate = useNavigate();
+  return (
+    <div className="space-y-4">
+      <p className="text-gray-500">Bilan {bilanId}</p>
+      <Button variant="secondary" onClick={() => navigate('/')}>
+        Retour
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,10 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../store/auth';
+import { apiFetch } from '../utils/api';
+import { Button } from '../components/ui/button';
+
 export default function Dashboard() {
+  const navigate = useNavigate();
+  const token = useAuth((s) => s.token);
+  const createBilan = async () => {
+    const res = await apiFetch<{ id: string }>('/api/bilans', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    navigate(`/bilan/${res.id}`);
+  };
+
   return (
-    <>
-      <h1>Dashboard</h1>
-      <button className="bg-blue-500 text-white transition-colors hover:bg-blue-700">
-        Test Hover
-      </button>
-    </>
+    <div className="flex h-full items-center justify-center">
+      <Button onClick={createBilan}>Rédiger un nouveau bilan</Button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow creating a new `bilan` from the dashboard
- add dedicated bilan page with return button
- show sidebar on wizard pages
- hide sidebar on bilan page
- test new behaviour

## Testing
- `pnpm --filter frontend run lint` *(fails: FileText is defined but never used ...)*
- `pnpm --filter frontend run test`
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_687e226edd0083298a23b0de28fb14fe