### PR TITLE
[frontend] add patient CRUD page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,9 +8,9 @@ import PropertyDashboard from './pages/PropertyDashboard';
 import NewLocation from './pages/NewLocation';
 import Bilan from './pages/Bilan';
 import Agenda from './pages/Agenda';
-import Resultats from './pages/Resultats';
 import Abonnement from './pages/Abonnement';
 import MonCompteV2 from './pages/MonCompte';
+import Patients from './pages/Patients';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import { usePageStore } from './store/pageContext';
@@ -125,6 +125,7 @@ export default function App() {
       <Route element={<ProtectedLayout />}>
         <Route path="/" element={<Dashboard />} />
         <Route path="/biens" element={<MesBiens />} />
+        <Route path="/patients" element={<Patients />} />
         <Route path="/biens/:id/dashboard" element={<PropertyDashboard />} />
         <Route path="/agenda" element={<Agenda />} />
         <Route path="/abonnement" element={<Abonnement />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -4,7 +4,6 @@ import {
   Home,
   Calendar,
   CreditCard,
-  FileText,
   Crown,
   User,
   LogOut,
@@ -54,6 +53,7 @@ const items: {
   }, */
   { title: 'Accueil', page: 'Dashboard', path: '/', icon: LayoutDashboard },
   { title: 'Mes Biens', page: 'MesBiens', path: '/biens', icon: Home },
+  { title: 'Mes Patients', page: 'Patients', path: '/patients', icon: User },
   { title: 'Mon Agenda', page: 'Agenda', path: '/agenda', icon: Calendar },
   {
     title: 'Abonnement',

--- a/frontend/src/components/Inventory.tsx
+++ b/frontend/src/components/Inventory.tsx
@@ -27,7 +27,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { Search, Plus, Package, Edit, Trash2, X, Check } from 'lucide-react';
+import { Search, Plus, Edit, Trash2, X, Check } from 'lucide-react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -122,16 +122,16 @@ export default function InventoryPage() {
       editingData.mobilier &&
       editingData.etatEntree
     ) {
-    const data = {
+      const data = {
         piece: editingData.piece,
         mobilier: editingData.mobilier,
         quantite: editingData.quantite,
         marque: editingData.marque,
         etatEntree: editingData.etatEntree,
-        };
-    await update(editingId, data);      
-    setEditingId(null);
-    setEditingData({});
+      };
+      await update(editingId, data);
+      setEditingId(null);
+      setEditingData({});
     }
   };
 
@@ -203,11 +203,6 @@ export default function InventoryPage() {
         return 'bg-gray-100 text-gray-800';
     }
   };
-
-  const totalValue = inventory.reduce(
-    (sum, item) => sum + item.prix * item.quantite,
-    0,
-  );
 
   return (
     <div className="container mx-auto p-6 space-y-6">

--- a/frontend/src/components/PatientForm.test.tsx
+++ b/frontend/src/components/PatientForm.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PatientForm from './PatientForm';
+
+describe('PatientForm', () => {
+  it('renders fields', () => {
+    render(<PatientForm onCancel={() => {}} />);
+    expect(screen.getByLabelText(/prénom/i)).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/nom/i)[0]).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PatientForm.tsx
+++ b/frontend/src/components/PatientForm.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { InputField } from './ui/input-field';
+import { Button } from './ui/button';
+import { usePatientStore, Patient, PatientInput } from '../store/patients';
+
+interface PatientFormProps {
+  patient?: Patient | null;
+  onCancel: () => void;
+}
+
+export default function PatientForm({ patient, onCancel }: PatientFormProps) {
+  const isEdit = Boolean(patient);
+  const [firstName, setFirstName] = useState(patient?.firstName ?? '');
+  const [lastName, setLastName] = useState(patient?.lastName ?? '');
+  const [dob, setDob] = useState(patient?.dob ? patient.dob.slice(0, 10) : '');
+  const [notes, setNotes] = useState(patient?.notes ?? '');
+  const { create, update } = usePatientStore();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload: PatientInput = {
+      firstName,
+      lastName,
+      dob: dob ? new Date(dob).toISOString() : undefined,
+      notes: notes || undefined,
+    };
+    if (isEdit && patient) {
+      await update(patient.id, payload);
+    } else {
+      await create(payload);
+    }
+    onCancel();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 border p-4 rounded">
+      <InputField
+        label="Prénom"
+        value={firstName}
+        onChange={setFirstName}
+        required
+      />
+      <InputField
+        label="Nom"
+        value={lastName}
+        onChange={setLastName}
+        required
+      />
+      <InputField
+        label="Date de naissance"
+        value={dob}
+        onChange={setDob}
+        type="date"
+      />
+      <InputField label="Notes" value={notes} onChange={setNotes} />
+      <div className="space-x-2">
+        <Button variant="primary" type="submit">
+          Valider
+        </Button>
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Annuler
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/Patients.tsx
+++ b/frontend/src/pages/Patients.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { Button } from '../components/ui/button';
+import PatientForm from '../components/PatientForm';
+import { usePatientStore, Patient } from '../store/patients';
+
+export default function Patients() {
+  const { items, fetchAll, remove } = usePatientStore();
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<Patient | null>(null);
+
+  useEffect(() => {
+    fetchAll().catch(() => {
+      /* ignore */
+    });
+  }, [fetchAll]);
+
+  return (
+    <div className="space-y-4">
+      {showForm && (
+        <PatientForm
+          patient={editing}
+          onCancel={() => {
+            setEditing(null);
+            setShowForm(false);
+          }}
+        />
+      )}
+      <div className="flex justify-between items-center">
+        <h1>Mes patients</h1>
+        <Button
+          variant="primary"
+          onClick={() => {
+            setEditing(null);
+            setShowForm(true);
+          }}
+        >
+          Nouveau patient
+        </Button>
+      </div>
+      <ul className="space-y-2">
+        {items.map((p) => (
+          <li key={p.id} className="border p-2 rounded flex justify-between">
+            <span>
+              {p.firstName} {p.lastName}
+            </span>
+            <span className="space-x-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  setEditing(p);
+                  setShowForm(true);
+                }}
+              >
+                Modifier
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => remove(p.id)}
+              >
+                Supprimer
+              </Button>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/PropertyDashboard.tsx
+++ b/frontend/src/pages/PropertyDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { AlertTriangle, Euro } from 'lucide-react';
+import { Euro } from 'lucide-react';
 import { PropertyTabList } from '../components/ui/PropertyTabList';
 import {
   PropertyInfoCard,
@@ -20,7 +20,6 @@ import type { NewLocation } from '@monorepo/shared';
 import { Button } from '../components/ui/button';
 import { ChargesCard } from '../components/ui/ChargesCard';
 import { RevenueCard } from '../components/ui/RevenueCard';
-import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
 import {
   Card,
   CardContent,
@@ -126,14 +125,6 @@ export default function PropertyDashboard() {
       { month: 'Fév', amount: 1800, status: 'En attente' },
     ],
   };
-  const alerts = [
-    {
-      type: 'warning',
-      title: 'Révision de loyer',
-      description: 'La révision annuelle du loyer est due',
-      date: '2024-01-15',
-    },
-  ];
 
   const changeTab = (t: 'view' | 'documents' | 'finances' | 'inventaire') => {
     setTab(t);

--- a/frontend/src/store/pageContext.tsx
+++ b/frontend/src/store/pageContext.tsx
@@ -5,6 +5,7 @@ import { StoreApi, useStore } from 'zustand';
 export type Page =
   | 'Dashboard'
   | 'MesBiens'
+  | 'Patients'
   | 'Agenda'
   | 'Resultats'
   | 'Abonnement'

--- a/frontend/src/store/patients.ts
+++ b/frontend/src/store/patients.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+import { apiFetch } from '../utils/api';
+import { useAuth } from './auth';
+
+export interface Patient {
+  id: string;
+  firstName: string;
+  lastName: string;
+  dob?: string;
+  notes?: string;
+}
+
+export type PatientInput = Omit<Patient, 'id'>;
+
+interface PatientState {
+  items: Patient[];
+  fetchAll: () => Promise<void>;
+  create: (data: PatientInput) => Promise<Patient>;
+  update: (id: string, data: Partial<PatientInput>) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+export const usePatientStore = create<PatientState>((set) => ({
+  items: [],
+
+  async fetchAll() {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifi\u00e9');
+    const items = await apiFetch<Patient[]>('/api/v1/patients', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set({ items });
+  },
+
+  async create(data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifi\u00e9');
+    const patient = await apiFetch<Patient>('/api/v1/patients', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({ items: [...state.items, patient] }));
+    return patient;
+  },
+
+  async update(id, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifi\u00e9');
+    const patient = await apiFetch<Patient>(`/api/v1/patients/${id}`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({
+      items: state.items.map((p) => (p.id === id ? patient : p)),
+    }));
+  },
+
+  async remove(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifi\u00e9');
+    await apiFetch(`/api/v1/patients/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({ items: state.items.filter((p) => p.id !== id) }));
+  },
+}));


### PR DESCRIPTION
## Summary
- add patients store and CRUD methods
- add PatientForm component with tests
- add Patients page and navigation entry
- wire up route in App and page context

## Testing
- `pnpm run lint` in frontend
- `pnpm run test` in frontend
- `pnpm run lint` in backend
- `pnpm run test` in backend

------
https://chatgpt.com/codex/tasks/task_e_687e3524e6188329a8dfb15b10e6ce05