### PR TITLE
[backend] add user tables and supabase auth

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -45,6 +45,9 @@ class PrismaClient {
       updateMany: jest.fn(),
       deleteMany: jest.fn(),
     };
+    this.user = {
+      upsert: jest.fn(),
+    };
     this.patient = {
       create: jest.fn(),
       findMany: jest.fn(),

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,10 +20,41 @@ enum Civilite {
   @@schema("public")
 }
 
+enum UserRole {
+  THERAPIST
+
+  @@schema("public")
+}
+
+model User {
+  id          String        @id @default(uuid())
+  role        UserRole      @default(THERAPIST)
+  profile     Profile?
+  authAccounts AuthAccount[]
+  createdAt   DateTime      @default(now())
+  @@schema("public")
+}
+
+model AuthAccount {
+  id                Int      @id @default(autoincrement())
+  userId            String
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  provider          String
+  providerAccountId String
+  email             String?
+  accessToken       String?
+  refreshToken      String?
+  expiresAt         Int?
+
+  @@unique([provider, providerAccountId])
+  @@schema("public")
+}
+
 //Profile
 model Profile {
   id                  String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userId              String    @db.Uuid
+  userId              String    @unique @db.Uuid
+  user                User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   civilite            Civilite?
   nom                 String?   @db.VarChar(100)
   nomUsage            String?   @db.VarChar(100)
@@ -31,9 +62,11 @@ model Profile {
   email               String?   @db.VarChar(255)
   telephonePersoNum   String?   @db.VarChar(50)
   telephoneMobileNum  String?   @db.VarChar(50)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   patients      Patient[]
-  bilantypes    BilanType[] @relation("AuthorBilanTypes") 
+  bilantypes    BilanType[] @relation("AuthorBilanTypes")
   sections      Section[]    @relation("AuthorSections")
 
   @@map("profile")

--- a/backend/src/@types/prisma-client.d.ts
+++ b/backend/src/@types/prisma-client.d.ts
@@ -17,5 +17,8 @@ declare module '@prisma/client' {
       updateMany: (args: unknown) => { count: number };
       deleteMany: (args: unknown) => { count: number };
     };
+    user: {
+      upsert: (args: unknown) => unknown;
+    };
   }
 }

--- a/backend/src/@types/prisma.d.ts
+++ b/backend/src/@types/prisma.d.ts
@@ -18,5 +18,8 @@ declare module '@prisma/client' {
       updateMany: (...args: any[]) => { count: number };
       deleteMany: (...args: any[]) => { count: number };
     };
+    user: {
+      upsert: (...args: any[]) => any;
+    };
   }
 }


### PR DESCRIPTION
## Summary
- extend Prisma schema with `User` and `AuthAccount`
- link `Profile` to new `User` model and track timestamps
- upsert user on each request in `requireAuth`
- update Prisma typings and mocks for new user table

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_687e478a6638832987e7d8e383eded39