### PR TITLE
[frontend] existing patient modal uses store

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { User } from '@supabase/supabase-js';
 import App from './App';
 import { PageProvider } from './store/pageContext';
-import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { useAuth } from './store/auth';
 import {
   useUserProfileStore,
@@ -22,7 +22,7 @@ describe('App navigation', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve({ id: '1' }) }),
     );
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={['/bilans']}>
         <PageProvider>
           <App />
         </PageProvider>
@@ -53,11 +53,11 @@ describe('App navigation', () => {
     ) as unknown as typeof fetch;
 
     render(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/bilans']}>
         <PageProvider>
           <App />
         </PageProvider>
-      </BrowserRouter>,
+      </MemoryRouter>,
     );
 
     await waitFor(() => expect(fetchProfileMock).toHaveBeenCalled());
@@ -75,13 +75,13 @@ describe('App navigation', () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
     ) as unknown as typeof fetch;
     render(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/bilans']}>
         <PageProvider>
           <App />
         </PageProvider>
-      </BrowserRouter>,
+      </MemoryRouter>,
     );
-    const btn = await screen.findByRole('button', { name: /mes\s?biens/i });
+    const btn = await screen.findByRole('button', { name: /mes\s?bilans/i });
     fireEvent.click(btn);
     expect(btn).toHaveAttribute('data-active', 'true');
   });

--- a/frontend/src/components/RichTextToolbar.tsx
+++ b/frontend/src/components/RichTextToolbar.tsx
@@ -4,10 +4,7 @@ import {
   INSERT_UNORDERED_LIST_COMMAND,
   INSERT_ORDERED_LIST_COMMAND,
 } from '@lexical/list';
-import {
-  TOGGLE_LINK_COMMAND,
-  $toggleLink
-} from '@lexical/link';
+import { TOGGLE_LINK_COMMAND } from '@lexical/link';
 import { useCallback } from 'react';
 import { Button } from './ui/button';
 

--- a/frontend/src/components/ui/existing-patient-modal.test.tsx
+++ b/frontend/src/components/ui/existing-patient-modal.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ExistingPatientModal } from './existing-patient-modal';
+import { usePatientStore, type PatientState } from '@/store/patients';
+
+describe('ExistingPatientModal', () => {
+  it('lists patients from the store and calls callback on select', () => {
+    const fetchAll = vi.fn().mockResolvedValue(undefined);
+    usePatientStore.setState({
+      items: [
+        { id: '1', firstName: 'Alice', lastName: 'Dupont' },
+        { id: '2', firstName: 'Bob', lastName: 'Martin' },
+      ],
+      fetchAll,
+    } as Partial<PatientState>);
+    const onSelect = vi.fn();
+    render(
+      <ExistingPatientModal
+        isOpen={true}
+        onClose={() => {}}
+        onPatientSelected={onSelect}
+      />,
+    );
+    expect(screen.getByText('Alice Dupont')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Bob Martin'));
+    expect(onSelect).toHaveBeenCalledWith('2');
+    expect(fetchAll).toHaveBeenCalled();
+    usePatientStore.setState({
+      items: [],
+      fetchAll: async () => {},
+    } as Partial<PatientState>);
+  });
+});

--- a/frontend/src/components/ui/existing-patient-modal.tsx
+++ b/frontend/src/components/ui/existing-patient-modal.tsx
@@ -1,66 +1,67 @@
-"use client"
+'use client';
 
-import { Button } from "@/components/ui/button"
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { ScrollArea } from "@/components/ui/scroll-area"
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { usePatientStore } from '@/store/patients';
 
 interface ExistingPatientModalProps {
-  isOpen: boolean
-  onClose: () => void
+  isOpen: boolean;
+  onClose: () => void;
+  onPatientSelected: (id: string) => void;
 }
 
-const dummyPatients = [
-  "Alice Dupont",
-  "Bob Martin",
-  "Claire Dubois",
-  "David Lefevre",
-  "Emma Garcia",
-  "François Petit",
-  "Sophie Leroy",
-  "Thomas Rousseau",
-  "Laura Bernard",
-  "Nicolas Durand",
-  "Manon Moreau",
-  "Antoine Laurent",
-  "Camille Simon",
-  "Julien Michel",
-  "Chloé Richard",
-  "Lucas David",
-  "Léa Robert",
-  "Maxime Thomas",
-  "Eva Dubois",
-  "Hugo Bertrand",
-]
+export function ExistingPatientModal({
+  isOpen,
+  onClose,
+  onPatientSelected,
+}: ExistingPatientModalProps) {
+  const { items, fetchAll } = usePatientStore();
 
-export function ExistingPatientModal({ isOpen, onClose }: ExistingPatientModalProps) {
-  const handleSelectPatient = (patientName: string) => {
-    console.log("Patient sélectionné:", patientName)
-    // Here you would typically navigate to the patient's profile or load their data
-    onClose()
-  }
+  useEffect(() => {
+    if (isOpen) {
+      fetchAll().catch(() => {
+        /* ignore */
+      });
+    }
+  }, [isOpen, fetchAll]);
+
+  const handleSelectPatient = (id: string) => {
+    onPatientSelected(id);
+    onClose();
+  };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[425px] bg-white">
         <DialogHeader>
           <DialogTitle>Patient existant</DialogTitle>
-          <DialogDescription>Choisissez un patient dans la liste.</DialogDescription>
+          <DialogDescription>
+            Choisissez un patient dans la liste.
+          </DialogDescription>
         </DialogHeader>
         <ScrollArea className="h-72 w-full rounded-md border p-4">
           <div className="grid gap-2">
-            {dummyPatients.map((patient, index) => (
+            {items.map((patient) => (
               <Button
-                key={index}
+                key={patient.id}
                 variant="ghost"
                 className="w-full justify-start"
-                onClick={() => handleSelectPatient(patient)}
+                onClick={() => handleSelectPatient(patient.id)}
               >
-                {patient}
+                {patient.firstName} {patient.lastName}
               </Button>
             ))}
           </div>
         </ScrollArea>
       </DialogContent>
     </Dialog>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- fetch and list real patients in `ExistingPatientModal`
- trigger bilan creation callback on patient select
- adjust App tests for `/bilans` route
- add tests for `ExistingPatientModal`
- fix unused import in `RichTextToolbar`

## Testing
- `pnpm --filter ./frontend run lint`
- `pnpm --filter ./frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_687f460b9420832988c8746c11869d38