### PR TITLE
[backend] add Section CRUD

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -64,6 +64,14 @@ class PrismaClient {
       updateMany: jest.fn(),
       deleteMany: jest.fn(),
     };
+    this.section = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
+      deleteMany: jest.fn(),
+    };
     this.logement = {
       create: jest.fn(),
       findMany: jest.fn(),

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import dotenv from 'dotenv';
 import { profileRouter } from './routes/profile.routes';
 import { patientRouter } from './routes/patient.routes';
 import { bilanRouter } from './routes/bilan.routes';
+import { sectionRouter } from './routes/section.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -70,6 +71,7 @@ app.use(requireAuth);
 app.use('/api/v1/patients', patientRouter);
 app.use('/api/v1/bilans', bilanRouter);
 app.use('/api/v1/profile', profileRouter);
+app.use('/api/v1/sections', sectionRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/section.controller.ts
+++ b/backend/src/controllers/section.controller.ts
@@ -1,0 +1,56 @@
+import type { Request, Response, NextFunction } from 'express';
+import { SectionService } from '../services/section.service';
+
+export const SectionController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const section = await SectionService.create(req.user.id, req.body);
+      res.status(201).json(section);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await SectionService.list(req.user.id));
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const section = await SectionService.get(req.user.id, req.params.sectionId);
+      if (!section) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(section);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const section = await SectionService.update(
+        req.user.id,
+        req.params.sectionId,
+        req.body,
+      );
+      res.json(section);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await SectionService.remove(req.user.id, req.params.sectionId);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/middlewares/requireAuth.ts
+++ b/backend/src/middlewares/requireAuth.ts
@@ -1,6 +1,8 @@
 import { RequestHandler } from 'express'
 import jwt from 'jsonwebtoken'
 import { prisma } from '../prisma'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any
 
 interface SupabasePayload extends jwt.JwtPayload {
   sub: string
@@ -32,7 +34,7 @@ export const requireAuth: RequestHandler = async (
     const providerAccountId = payload.sub
 
     // Cherche un AuthAccount existant
-    let authAccount = await prisma.authAccount.findUnique({
+    let authAccount = await db.authAccount.findUnique({
       where: {
         provider_providerAccountId: {
           provider,
@@ -47,7 +49,7 @@ export const requireAuth: RequestHandler = async (
       user = authAccount.user
     } else {
       // Crée un User interne et un AuthAccount lié
-      user = await prisma.user.create({
+      user = await db.user.create({
         data: {
           authAccounts: {
             create: {
@@ -59,7 +61,7 @@ export const requireAuth: RequestHandler = async (
         },
       });
         // ===> Ajoute ce bloc pour créer le profil automatiquement
-      await prisma.profile.create({
+      await db.profile.create({
         data: {
           userId: user.id,
           prenom: payload.user_metadata?.firstName ?? null, // si tu as ces infos dans le JWT

--- a/backend/src/routes/section.routes.ts
+++ b/backend/src/routes/section.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { SectionController } from '../controllers/section.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createSectionSchema,
+  updateSectionSchema,
+  sectionIdParam,
+} from '../schemas/section.schema';
+
+export const sectionRouter = Router();
+
+sectionRouter
+  .route('/')
+  .post(validateBody(createSectionSchema), SectionController.create)
+  .get(SectionController.list);
+
+sectionRouter
+  .route('/:sectionId')
+  .get(validateParams(sectionIdParam), SectionController.get)
+  .put(
+    validateParams(sectionIdParam),
+    validateBody(updateSectionSchema),
+    SectionController.update,
+  )
+  .delete(validateParams(sectionIdParam), SectionController.remove);

--- a/backend/src/schemas/section.schema.ts
+++ b/backend/src/schemas/section.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const createSectionSchema = z.object({
+  title: z.string(),
+  kind: z.enum(['NARRATIVE', 'STANDARD_TEST', 'SENSOR_PROFILE', 'CUSTOM_FORM']),
+  description: z.string().optional(),
+  schema: z.any().optional(),
+  defaultContent: z.any().optional(),
+  isPublic: z.boolean().optional(),
+});
+
+export const updateSectionSchema = createSectionSchema.partial();
+export const sectionIdParam = z.object({ sectionId: z.string().uuid() });

--- a/backend/src/services/section.service.ts
+++ b/backend/src/services/section.service.ts
@@ -1,0 +1,62 @@
+import { prisma } from '../prisma';
+import { NotFoundError } from './profile.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any;
+
+export type SectionData = {
+  title: string;
+  kind: string;
+  description?: string | null;
+  schema?: unknown;
+  defaultContent?: unknown;
+  isPublic?: boolean;
+};
+
+export const SectionService = {
+  async create(userId: string, data: SectionData) {
+    const profile = await db.profile.findUnique({ where: { userId } });
+    if (!profile) throw new Error('Profile not found for user');
+    return db.section.create({ data: { ...data, authorId: profile.id } });
+  },
+
+  list(userId: string) {
+    return db.section.findMany({
+      where: {
+        OR: [
+          { isPublic: true },
+          { author: { userId } },
+        ],
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  },
+
+  get(userId: string, id: string) {
+    return db.section.findFirst({
+      where: {
+        id,
+        OR: [
+          { isPublic: true },
+          { author: { userId } },
+        ],
+      },
+    });
+  },
+
+  async update(userId: string, id: string, data: Partial<SectionData>) {
+    const { count } = await db.section.updateMany({
+      where: { id, author: { userId } },
+      data,
+    });
+    if (count === 0) throw new NotFoundError();
+    return db.section.findUnique({ where: { id } });
+  },
+
+  async remove(userId: string, id: string) {
+    const { count } = await db.section.deleteMany({
+      where: { id, author: { userId } },
+    });
+    if (count === 0) throw new NotFoundError();
+  },
+};

--- a/backend/tests/section.routes.test.ts
+++ b/backend/tests/section.routes.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import app from '../src/app';
+import { SectionService } from '../src/services/section.service';
+
+jest.mock('../src/services/section.service');
+
+interface SectionStub {
+  id: string;
+  title: string;
+}
+
+const mockedService = SectionService as jest.Mocked<typeof SectionService>;
+
+describe('GET /api/v1/sections', () => {
+  it('returns sections from service', async () => {
+    mockedService.list.mockResolvedValueOnce([
+      { id: '1', title: 'Sec' } as SectionStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/sections');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith('demo-user');
+  });
+});


### PR DESCRIPTION
## Summary
- implement CRUD endpoints for `Section`
- wire section routes into Express app
- add section service and schema
- support section operations in Prisma mock
- create tests for section routes
- relax type usage in `requireAuth`

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`

------
https://chatgpt.com/codex/tasks/task_e_687fae04edec83299a813db6c1902c22