### PR TITLE
[backend] Add SectionExample CRUD API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,6 +10,7 @@ import { profileRouter } from './routes/profile.routes';
 import { patientRouter } from './routes/patient.routes';
 import { bilanRouter } from './routes/bilan.routes';
 import { sectionRouter } from './routes/section.routes';
+import { sectionExampleRouter } from './routes/sectionExample.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -72,6 +73,7 @@ app.use('/api/v1/patients', patientRouter);
 app.use('/api/v1/bilans', bilanRouter);
 app.use('/api/v1/profile', profileRouter);
 app.use('/api/v1/sections', sectionRouter);
+app.use('/api/v1/section-examples', sectionExampleRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/sectionExample.controller.ts
+++ b/backend/src/controllers/sectionExample.controller.ts
@@ -1,0 +1,59 @@
+import type { Request, Response, NextFunction } from 'express';
+import { SectionExampleService } from '../services/sectionExample.service';
+
+export const SectionExampleController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const example = await SectionExampleService.create(req.user.id, req.body);
+      res.status(201).json(example);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await SectionExampleService.list(req.user.id));
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const example = await SectionExampleService.get(
+        req.user.id,
+        req.params.sectionExampleId,
+      );
+      if (!example) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(example);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const example = await SectionExampleService.update(
+        req.user.id,
+        req.params.sectionExampleId,
+        req.body,
+      );
+      res.json(example);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await SectionExampleService.remove(req.user.id, req.params.sectionExampleId);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/sectionExample.routes.ts
+++ b/backend/src/routes/sectionExample.routes.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { SectionExampleController } from '../controllers/sectionExample.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createSectionExampleSchema,
+  updateSectionExampleSchema,
+  sectionExampleIdParam,
+} from '../schemas/sectionExample.schema';
+
+export const sectionExampleRouter = Router();
+
+sectionExampleRouter
+  .route('/')
+  .post(validateBody(createSectionExampleSchema), SectionExampleController.create)
+  .get(SectionExampleController.list);
+
+sectionExampleRouter
+  .route('/:sectionExampleId')
+  .get(validateParams(sectionExampleIdParam), SectionExampleController.get)
+  .put(
+    validateParams(sectionExampleIdParam),
+    validateBody(updateSectionExampleSchema),
+    SectionExampleController.update,
+  )
+  .delete(
+    validateParams(sectionExampleIdParam),
+    SectionExampleController.remove,
+  );

--- a/backend/src/schemas/sectionExample.schema.ts
+++ b/backend/src/schemas/sectionExample.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const createSectionExampleSchema = z.object({
+  sectionId: z.string().uuid(),
+  label: z.string().optional(),
+  content: z.string(),
+});
+
+export const updateSectionExampleSchema = createSectionExampleSchema.partial();
+export const sectionExampleIdParam = z.object({ sectionExampleId: z.string().uuid() });

--- a/backend/src/services/sectionExample.service.ts
+++ b/backend/src/services/sectionExample.service.ts
@@ -1,0 +1,65 @@
+import { prisma } from '../prisma';
+import { NotFoundError } from './profile.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any;
+
+export type SectionExampleData = {
+  sectionId: string;
+  label?: string | null;
+  content: string;
+};
+
+export const SectionExampleService = {
+  async create(userId: string, data: SectionExampleData) {
+    const section = await db.section.findFirst({
+      where: { id: data.sectionId, author: { userId } },
+    });
+    if (!section) throw new NotFoundError('Section not found for user');
+    return db.sectionExample.create({ data });
+  },
+
+  list(userId: string) {
+    return db.sectionExample.findMany({
+      where: {
+        section: {
+          OR: [
+            { isPublic: true },
+            { author: { userId } },
+          ],
+        },
+      },
+      orderBy: { label: 'asc' },
+    });
+  },
+
+  get(userId: string, id: string) {
+    return db.sectionExample.findFirst({
+      where: {
+        id,
+        section: {
+          OR: [
+            { isPublic: true },
+            { author: { userId } },
+          ],
+        },
+      },
+    });
+  },
+
+  async update(userId: string, id: string, data: Partial<SectionExampleData>) {
+    const { count } = await db.sectionExample.updateMany({
+      where: { id, section: { author: { userId } } },
+      data,
+    });
+    if (count === 0) throw new NotFoundError();
+    return db.sectionExample.findUnique({ where: { id } });
+  },
+
+  async remove(userId: string, id: string) {
+    const { count } = await db.sectionExample.deleteMany({
+      where: { id, section: { author: { userId } } },
+    });
+    if (count === 0) throw new NotFoundError();
+  },
+};

--- a/backend/tests/sectionExample.routes.test.ts
+++ b/backend/tests/sectionExample.routes.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import app from '../src/app';
+import { SectionExampleService } from '../src/services/sectionExample.service';
+
+jest.mock('../src/services/sectionExample.service');
+
+interface ExampleStub {
+  id: string;
+  content: string;
+}
+
+const mockedService = SectionExampleService as jest.Mocked<typeof SectionExampleService>;
+
+describe('GET /api/v1/section-examples', () => {
+  it('returns examples from service', async () => {
+    mockedService.list.mockResolvedValueOnce([
+      { id: '1', content: 'demo' } as ExampleStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/section-examples');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith('demo-user');
+  });
+});


### PR DESCRIPTION
## Summary
- add SectionExample service, controller, router, schema
- expose section example routes in the app
- include simple route test

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68805c7b45808329915c1b08b685a51f