### PR TITLE
[frontend] connect trame creation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Abonnement from './pages/Abonnement';
 import MonCompteV2 from './pages/MonCompte';
 import Patients from './pages/Patients';
 import Bibliotheque from './pages/Bibliothèque';
+import CreationTrame from './pages/CreationTrame';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import { usePageStore } from './store/pageContext';
@@ -128,6 +129,7 @@ export default function App() {
         <Route path="/biens/:id/dashboard" element={<PropertyDashboard />} />
         <Route path="/agenda" element={<Agenda />} />
         <Route path="/bibliotheque" element={<Bibliotheque />} />
+        <Route path="/creation-trame/:sectionId" element={<CreationTrame />} />
         <Route path="/abonnement" element={<Abonnement />} />
         <Route path="/compte" element={<MonCompteV2 />} />
       </Route>

--- a/frontend/src/components/ui/creer-trame-modale.tsx
+++ b/frontend/src/components/ui/creer-trame-modale.tsx
@@ -1,36 +1,52 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Plus, FileText, ClipboardList, Eye, Brain } from "lucide-react"
-import { useRouter } from "next/navigation"
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Plus, FileText, ClipboardList, Eye, Brain } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useSectionStore } from '@/store/sections';
 
 const categories = [
-  { id: "anamnese", title: "Anamnèse", icon: FileText },
-  { id: "tests_standards", title: "Tests standards", icon: ClipboardList },
-  { id: "observations", title: "Observations", icon: Eye },
-  { id: "profil_sensoriel", title: "Profil sensoriel", icon: Brain },
-]
+  { id: 'anamnese', title: 'Anamnèse', icon: FileText },
+  { id: 'tests_standards', title: 'Tests standards', icon: ClipboardList },
+  { id: 'observations', title: 'Observations', icon: Eye },
+  { id: 'profil_sensoriel', title: 'Profil sensoriel', icon: Brain },
+];
 
 export default function CreerTrameModal() {
-  const [open, setOpen] = useState(false)
-  const [nomTrame, setNomTrame] = useState("")
-  const [categorieSelectionnee, setCategorieSelectionnee] = useState("")
-  const router = useRouter()
+  const [open, setOpen] = useState(false);
+  const [nomTrame, setNomTrame] = useState('');
+  const [categorieSelectionnee, setCategorieSelectionnee] = useState('');
+  const navigate = useNavigate();
+  const createSection = useSectionStore((s) => s.create);
 
-  const handleCreerTrame = () => {
-    if (nomTrame && categorieSelectionnee) {
-      // Rediriger vers la page de création avec les paramètres
-      router.push(`/creation-trame?nom=${encodeURIComponent(nomTrame)}&categorie=${categorieSelectionnee}`)
-      setOpen(false)
-      setNomTrame("")
-      setCategorieSelectionnee("")
-    }
-  }
+  const handleCreerTrame = async () => {
+    if (!nomTrame || !categorieSelectionnee) return;
+    const section = await createSection({
+      title: nomTrame,
+      kind: categorieSelectionnee,
+    });
+    navigate(`/creation-trame/${section.id}`);
+    setOpen(false);
+    setNomTrame('');
+    setCategorieSelectionnee('');
+  };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -57,13 +73,16 @@ export default function CreerTrameModal() {
 
           <div className="space-y-2">
             <Label htmlFor="categorie">Catégorie</Label>
-            <Select value={categorieSelectionnee} onValueChange={setCategorieSelectionnee}>
+            <Select
+              value={categorieSelectionnee}
+              onValueChange={setCategorieSelectionnee}
+            >
               <SelectTrigger>
                 <SelectValue placeholder="Choisir une catégorie" />
               </SelectTrigger>
               <SelectContent>
                 {categories.map((category) => {
-                  const IconComponent = category.icon
+                  const IconComponent = category.icon;
                   return (
                     <SelectItem key={category.id} value={category.id}>
                       <div className="flex items-center gap-2">
@@ -71,7 +90,7 @@ export default function CreerTrameModal() {
                         {category.title}
                       </div>
                     </SelectItem>
-                  )
+                  );
                 })}
               </SelectContent>
             </Select>
@@ -92,5 +111,5 @@ export default function CreerTrameModal() {
         </div>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -1,110 +1,156 @@
-"use client"
+'use client';
 
-import { useState, useEffect } from "react"
-import { useSearchParams, useRouter } from "next/navigation"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { ArrowLeft, Plus, Trash2, FileText, CheckSquare, BarChart3 } from "lucide-react"
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useSectionStore } from '../store/sections';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  ArrowLeft,
+  Plus,
+  Trash2,
+  FileText,
+  CheckSquare,
+  BarChart3,
+} from 'lucide-react';
 
 interface Question {
-  id: string
-  type: "notes" | "choix-multiple" | "echelle"
-  titre: string
-  contenu?: string
-  options?: string[]
-  echelle?: { min: number; max: number; labels?: { min: string; max: string } }
+  id: string;
+  type: 'notes' | 'choix-multiple' | 'echelle';
+  titre: string;
+  contenu?: string;
+  options?: string[];
+  echelle?: { min: number; max: number; labels?: { min: string; max: string } };
 }
 
 const typesQuestions = [
-  { id: "notes", title: "Notes brutes", icon: FileText, description: "Zone de texte libre" },
   {
-    id: "choix-multiple",
-    title: "Choix multiples",
-    icon: CheckSquare,
-    description: "Question avec options prédéfinies",
+    id: 'notes',
+    title: 'Notes brutes',
+    icon: FileText,
+    description: 'Zone de texte libre',
   },
-  { id: "echelle", title: "Échelle chiffrée", icon: BarChart3, description: "Évaluation sur une échelle numérique" },
-]
+  {
+    id: 'choix-multiple',
+    title: 'Choix multiples',
+    icon: CheckSquare,
+    description: 'Question avec options prédéfinies',
+  },
+  {
+    id: 'echelle',
+    title: 'Échelle chiffrée',
+    icon: BarChart3,
+    description: 'Évaluation sur une échelle numérique',
+  },
+];
 
 export default function CreationTrame() {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const [nomTrame, setNomTrame] = useState("")
-  const [categorie, setCategorie] = useState("")
-  const [questions, setQuestions] = useState<Question[]>([])
-  const [typeQuestionSelectionnee, setTypeQuestionSelectionnee] = useState("")
+  const { sectionId } = useParams<{ sectionId: string }>();
+  const navigate = useNavigate();
+  const fetchOne = useSectionStore((s) => s.fetchOne);
+  const updateSection = useSectionStore((s) => s.update);
+  const [nomTrame, setNomTrame] = useState('');
+  const [categorie, setCategorie] = useState('');
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [typeQuestionSelectionnee, setTypeQuestionSelectionnee] = useState('');
 
   useEffect(() => {
-    const nom = searchParams.get("nom")
-    const cat = searchParams.get("categorie")
-    if (nom) setNomTrame(nom)
-    if (cat) setCategorie(cat)
-  }, [searchParams])
+    if (!sectionId) return;
+    fetchOne(sectionId).then((section) => {
+      setNomTrame(section.title);
+      setCategorie(section.kind);
+      if (Array.isArray(section.schema)) {
+        setQuestions(section.schema as Question[]);
+      }
+    });
+  }, [sectionId, fetchOne]);
 
   const ajouterQuestion = () => {
-    if (!typeQuestionSelectionnee) return
+    if (!typeQuestionSelectionnee) return;
 
     const nouvelleQuestion: Question = {
       id: Date.now().toString(),
-      type: typeQuestionSelectionnee as Question["type"],
-      titre: "",
+      type: typeQuestionSelectionnee as Question['type'],
+      titre: '',
+    };
+
+    if (typeQuestionSelectionnee === 'choix-multiple') {
+      nouvelleQuestion.options = ['Option 1', 'Option 2'];
+    } else if (typeQuestionSelectionnee === 'echelle') {
+      nouvelleQuestion.echelle = {
+        min: 1,
+        max: 5,
+        labels: { min: 'Faible', max: 'Élevé' },
+      };
     }
 
-    if (typeQuestionSelectionnee === "choix-multiple") {
-      nouvelleQuestion.options = ["Option 1", "Option 2"]
-    } else if (typeQuestionSelectionnee === "echelle") {
-      nouvelleQuestion.echelle = { min: 1, max: 5, labels: { min: "Faible", max: "Élevé" } }
-    }
-
-    setQuestions([...questions, nouvelleQuestion])
-    setTypeQuestionSelectionnee("")
-  }
+    setQuestions([...questions, nouvelleQuestion]);
+    setTypeQuestionSelectionnee('');
+  };
 
   const supprimerQuestion = (id: string) => {
-    setQuestions(questions.filter((q) => q.id !== id))
-  }
+    setQuestions(questions.filter((q) => q.id !== id));
+  };
 
-  const mettreAJourQuestion = (id: string, champ: string, valeur: any) => {
-    setQuestions(questions.map((q) => (q.id === id ? { ...q, [champ]: valeur } : q)))
-  }
+  const mettreAJourQuestion = (id: string, champ: string, valeur: unknown) => {
+    setQuestions(
+      questions.map((q) => (q.id === id ? { ...q, [champ]: valeur } : q)),
+    );
+  };
 
   const ajouterOption = (questionId: string) => {
     setQuestions(
       questions.map((q) =>
-        q.id === questionId && q.options ? { ...q, options: [...q.options, `Option ${q.options.length + 1}`] } : q,
+        q.id === questionId && q.options
+          ? { ...q, options: [...q.options, `Option ${q.options.length + 1}`] }
+          : q,
       ),
-    )
-  }
+    );
+  };
 
   const supprimerOption = (questionId: string, index: number) => {
     setQuestions(
       questions.map((q) =>
-        q.id === questionId && q.options ? { ...q, options: q.options.filter((_, i) => i !== index) } : q,
+        q.id === questionId && q.options
+          ? { ...q, options: q.options.filter((_, i) => i !== index) }
+          : q,
       ),
-    )
-  }
+    );
+  };
 
-  const sauvegarderTrame = () => {
-    // Ici on sauvegarderait la trame
-    console.log("Trame sauvegardée:", { nomTrame, categorie, questions })
-    router.push("/bibliotheque")
-  }
+  const sauvegarderTrame = async () => {
+    if (!sectionId) return;
+    await updateSection(sectionId, {
+      title: nomTrame,
+      kind: categorie,
+      schema: questions,
+    });
+    navigate('/bibliotheque');
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center gap-4 mb-6">
-          <Button variant="outline" onClick={() => router.back()}>
+          <Button variant="outline" onClick={() => navigate(-1)}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Retour
           </Button>
           <div>
             <h1 className="text-2xl font-bold text-gray-900">{nomTrame}</h1>
-            <p className="text-gray-600 capitalize">{categorie?.replace("-", " ")}</p>
+            <p className="text-gray-600 capitalize">
+              {categorie?.replace('-', ' ')}
+            </p>
           </div>
         </div>
 
@@ -116,28 +162,36 @@ export default function CreationTrame() {
             </CardHeader>
             <CardContent>
               <div className="flex gap-4">
-                <Select value={typeQuestionSelectionnee} onValueChange={setTypeQuestionSelectionnee}>
+                <Select
+                  value={typeQuestionSelectionnee}
+                  onValueChange={setTypeQuestionSelectionnee}
+                >
                   <SelectTrigger className="flex-1">
                     <SelectValue placeholder="Choisir le type de question" />
                   </SelectTrigger>
                   <SelectContent>
                     {typesQuestions.map((type) => {
-                      const IconComponent = type.icon
+                      const IconComponent = type.icon;
                       return (
                         <SelectItem key={type.id} value={type.id}>
                           <div className="flex items-center gap-2">
                             <IconComponent className="h-4 w-4" />
                             <div>
                               <div className="font-medium">{type.title}</div>
-                              <div className="text-xs text-gray-500">{type.description}</div>
+                              <div className="text-xs text-gray-500">
+                                {type.description}
+                              </div>
                             </div>
                           </div>
                         </SelectItem>
-                      )
+                      );
                     })}
                   </SelectContent>
                 </Select>
-                <Button onClick={ajouterQuestion} disabled={!typeQuestionSelectionnee}>
+                <Button
+                  onClick={ajouterQuestion}
+                  disabled={!typeQuestionSelectionnee}
+                >
                   <Plus className="h-4 w-4 mr-2" />
                   Ajouter
                 </Button>
@@ -151,37 +205,54 @@ export default function CreationTrame() {
               <CardHeader>
                 <div className="flex items-center justify-between">
                   <CardTitle className="text-base">
-                    Question {index + 1} - {typesQuestions.find((t) => t.id === question.type)?.title}
+                    Question {index + 1} -{' '}
+                    {typesQuestions.find((t) => t.id === question.type)?.title}
                   </CardTitle>
-                  <Button variant="outline" size="sm" onClick={() => supprimerQuestion(question.id)}>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => supprimerQuestion(question.id)}
+                  >
                     <Trash2 className="h-4 w-4" />
                   </Button>
                 </div>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div>
-                  <Label htmlFor={`titre-${question.id}`}>Titre de la question</Label>
+                  <Label htmlFor={`titre-${question.id}`}>
+                    Titre de la question
+                  </Label>
                   <Input
                     id={`titre-${question.id}`}
                     value={question.titre}
-                    onChange={(e) => mettreAJourQuestion(question.id, "titre", e.target.value)}
+                    onChange={(e) =>
+                      mettreAJourQuestion(question.id, 'titre', e.target.value)
+                    }
                     placeholder="Ex: Décrivez les difficultés observées..."
                   />
                 </div>
 
-                {question.type === "notes" && (
+                {question.type === 'notes' && (
                   <div>
-                    <Label htmlFor={`contenu-${question.id}`}>Instructions (optionnel)</Label>
+                    <Label htmlFor={`contenu-${question.id}`}>
+                      Instructions (optionnel)
+                    </Label>
                     <Textarea
                       id={`contenu-${question.id}`}
-                      value={question.contenu || ""}
-                      onChange={(e) => mettreAJourQuestion(question.id, "contenu", e.target.value)}
+                      value={question.contenu || ''}
+                      onChange={(e) =>
+                        mettreAJourQuestion(
+                          question.id,
+                          'contenu',
+                          e.target.value,
+                        )
+                      }
                       placeholder="Instructions pour remplir cette section..."
                     />
                   </div>
                 )}
 
-                {question.type === "choix-multiple" && (
+                {question.type === 'choix-multiple' && (
                   <div>
                     <Label>Options de réponse</Label>
                     <div className="space-y-2">
@@ -190,17 +261,33 @@ export default function CreationTrame() {
                           <Input
                             value={option}
                             onChange={(e) => {
-                              const nouvellesOptions = [...(question.options || [])]
-                              nouvellesOptions[optionIndex] = e.target.value
-                              mettreAJourQuestion(question.id, "options", nouvellesOptions)
+                              const nouvellesOptions = [
+                                ...(question.options || []),
+                              ];
+                              nouvellesOptions[optionIndex] = e.target.value;
+                              mettreAJourQuestion(
+                                question.id,
+                                'options',
+                                nouvellesOptions,
+                              );
                             }}
                           />
-                          <Button variant="outline" size="sm" onClick={() => supprimerOption(question.id, optionIndex)}>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              supprimerOption(question.id, optionIndex)
+                            }
+                          >
                             <Trash2 className="h-4 w-4" />
                           </Button>
                         </div>
                       ))}
-                      <Button variant="outline" size="sm" onClick={() => ajouterOption(question.id)}>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => ajouterOption(question.id)}
+                      >
                         <Plus className="h-4 w-4 mr-2" />
                         Ajouter une option
                       </Button>
@@ -208,16 +295,18 @@ export default function CreationTrame() {
                   </div>
                 )}
 
-                {question.type === "echelle" && (
+                {question.type === 'echelle' && (
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <Label htmlFor={`min-${question.id}`}>Valeur minimum</Label>
+                      <Label htmlFor={`min-${question.id}`}>
+                        Valeur minimum
+                      </Label>
                       <Input
                         id={`min-${question.id}`}
                         type="number"
                         value={question.echelle?.min || 1}
                         onChange={(e) =>
-                          mettreAJourQuestion(question.id, "echelle", {
+                          mettreAJourQuestion(question.id, 'echelle', {
                             ...question.echelle,
                             min: Number.parseInt(e.target.value),
                           })
@@ -225,13 +314,15 @@ export default function CreationTrame() {
                       />
                     </div>
                     <div>
-                      <Label htmlFor={`max-${question.id}`}>Valeur maximum</Label>
+                      <Label htmlFor={`max-${question.id}`}>
+                        Valeur maximum
+                      </Label>
                       <Input
                         id={`max-${question.id}`}
                         type="number"
                         value={question.echelle?.max || 5}
                         onChange={(e) =>
-                          mettreAJourQuestion(question.id, "echelle", {
+                          mettreAJourQuestion(question.id, 'echelle', {
                             ...question.echelle,
                             max: Number.parseInt(e.target.value),
                           })
@@ -246,15 +337,18 @@ export default function CreationTrame() {
 
           {/* Actions */}
           <div className="flex justify-end gap-4 pt-6">
-            <Button variant="outline" onClick={() => router.back()}>
+            <Button variant="outline" onClick={() => navigate(-1)}>
               Annuler
             </Button>
-            <Button onClick={sauvegarderTrame} className="bg-blue-600 hover:bg-blue-700">
+            <Button
+              onClick={sauvegarderTrame}
+              className="bg-blue-600 hover:bg-blue-700"
+            >
               Sauvegarder la trame
             </Button>
           </div>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/store/sections.test.ts
+++ b/frontend/src/store/sections.test.ts
@@ -1,0 +1,25 @@
+import { vi, describe, it, expect } from 'vitest';
+import { useSectionStore } from './sections';
+import { useAuth, type AuthState } from './auth';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('useSectionStore', () => {
+  it('adds a section with create()', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    useSectionStore.setState({ items: [] });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: '1', title: 'Sec', kind: 'anamnese' }),
+    });
+    const section = await useSectionStore.getState().create({
+      title: 'Sec',
+      kind: 'anamnese',
+    });
+    expect((fetch as unknown as vi.Mock).mock.calls[0][0]).toBe(
+      '/api/v1/sections',
+    );
+    expect(section.id).toBe('1');
+    expect(useSectionStore.getState().items[0].id).toBe('1');
+  });
+});

--- a/frontend/src/store/sections.ts
+++ b/frontend/src/store/sections.ts
@@ -1,0 +1,78 @@
+import { create } from 'zustand';
+import { apiFetch } from '../utils/api';
+import { useAuth } from './auth';
+
+export interface Section {
+  id: string;
+  title: string;
+  kind: string;
+  description?: string | null;
+  schema?: unknown;
+  defaultContent?: unknown;
+  isPublic?: boolean;
+}
+
+export type SectionInput = Omit<Section, 'id'>;
+
+interface SectionState {
+  items: Section[];
+  fetchAll: () => Promise<void>;
+  fetchOne: (id: string) => Promise<Section>;
+  create: (data: SectionInput) => Promise<Section>;
+  update: (id: string, data: Partial<SectionInput>) => Promise<Section>;
+}
+
+const endpoint = '/api/v1/sections';
+
+export const useSectionStore = create<SectionState>((set) => ({
+  items: [],
+
+  async fetchAll() {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const items = await apiFetch<Section[]>(endpoint, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set({ items });
+  },
+
+  async fetchOne(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const section = await apiFetch<Section>(`${endpoint}/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({
+      items: state.items.some((s) => s.id === id)
+        ? state.items.map((s) => (s.id === id ? section : s))
+        : [...state.items, section],
+    }));
+    return section;
+  },
+
+  async create(data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const section = await apiFetch<Section>(endpoint, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({ items: [...state.items, section] }));
+    return section;
+  },
+
+  async update(id, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const section = await apiFetch<Section>(`${endpoint}/${id}`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({
+      items: state.items.map((s) => (s.id === id ? section : s)),
+    }));
+    return section;
+  },
+}));


### PR DESCRIPTION
## Summary
- add section store to handle sections API calls
- link `CreerTrameModal` to backend create endpoint
- load a section in `CreationTrame` page and save updates
- add route for section editing
- test section store

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_688065753cc883298f265da7437c54cc