### PR TITLE
[frontend] Generate text insertion

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -74,9 +74,13 @@ const useTrames = () => {
 
 interface AiRightPanelProps {
   bilanId: string;
+  onInsertText: (text: string) => void;
 }
 
-export default function AiRightPanel({ bilanId }: AiRightPanelProps) {
+export default function AiRightPanel({
+  bilanId,
+  onInsertText,
+}: AiRightPanelProps) {
   const trames = useTrames();
   const { items: examples, fetchAll } = useSectionExampleStore();
   const token = useAuth((s) => s.token);
@@ -145,11 +149,15 @@ export default function AiRightPanel({ bilanId }: AiRightPanelProps) {
         section: kindMap[section.id],
         answers: answers[section.id] || {},
       };
-      await apiFetch<{ text: string }>(`/api/v1/bilans/${bilanId}/generate`, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-        body: JSON.stringify(body),
-      });
+      const res = await apiFetch<{ text: string }>(
+        `/api/v1/bilans/${bilanId}/generate`,
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+          body: JSON.stringify(body),
+        },
+      );
+      onInsertText(res.text);
     } finally {
       setIsGenerating(false);
       setSelectedSection(null);

--- a/frontend/src/pages/Bilan.tsx
+++ b/frontend/src/pages/Bilan.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useParams } from 'react-router-dom';
-import { useEffect, useState, Suspense, lazy } from 'react';
+import { useEffect, useState, Suspense, lazy, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { Button } from '../components/ui/button';
 import { apiFetch } from '../utils/api';
@@ -14,12 +14,15 @@ interface BilanData {
   descriptionHtml: string | null;
 }
 
+import type { RichTextEditorHandle } from '../components/RichTextEditor';
+
 export default function Bilan() {
   const { bilanId } = useParams<{ bilanId: string }>();
   const navigate = useNavigate();
   const token = useAuth((s) => s.token);
   const [bilan, setBilan] = useState<BilanData | null>(null);
   const { descriptionHtml, setHtml, reset } = useBilanDraft();
+  const editorRef = useRef<RichTextEditorHandle>(null);
 
   useEffect(() => {
     if (!bilanId) return;
@@ -66,6 +69,7 @@ export default function Bilan() {
           <div className="flex-1 overflow-auto space-y-4 p-4">
             <Suspense fallback="Chargement...">
               <RichTextEditor
+                ref={editorRef}
                 initialHtml={descriptionHtml ?? ''}
                 onChange={setHtml}
               />
@@ -76,7 +80,12 @@ export default function Bilan() {
           </div>
           <div className="block w-96 border-l overflow-auto">
             <Suspense fallback="Chargement...">
-              {bilanId && <AiRightPanel bilanId={bilanId} />}
+              {bilanId && (
+                <AiRightPanel
+                  bilanId={bilanId}
+                  onInsertText={(text) => editorRef.current?.insertHtml(text)}
+                />
+              )}
             </Suspense>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- expose a `insertHtml` method from `RichTextEditor`
- use the new method from `Bilan` page
- call `onInsertText` when generating text in `AiRightPanel`

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_6880a6f343c48329a10c892f5e328b3b