### PR TITLE
[frontend] support markdown insertion

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "dotenv": "^16.5.0",
     "lexical": "^0.33.1",
     "lucide-react": "^0.515.0",
+    "marked": "^16.1.1",
     "next": "^15.3.3",
     "react": "^19.1.0",
     "react-day-picker": "^9.7.0",

--- a/frontend/src/components/RichTextEditor.test.tsx
+++ b/frontend/src/components/RichTextEditor.test.tsx
@@ -1,0 +1,19 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import RichTextEditor, { type RichTextEditorHandle } from './RichTextEditor';
+
+describe('RichTextEditor', () => {
+  it('converts markdown to HTML when inserting', async () => {
+    const ref = React.createRef<RichTextEditorHandle>();
+    const { container } = render(
+      <RichTextEditor ref={ref} initialHtml="" onChange={() => {}} />,
+    );
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    ref.current!.insertHtml('**bold**');
+    await waitFor(() => {
+      const textbox = container.querySelector('[contenteditable="true"]');
+      expect(textbox?.innerHTML).toMatch(/<strong[^>]*>bold<\/strong>/);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       lucide-react:
         specifier: ^0.515.0
         version: 0.515.0(react@19.1.0)
+      marked:
+        specifier: ^16.1.1
+        version: 16.1.1
       next:
         specifier: ^15.3.3
         version: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3797,6 +3800,11 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  marked@16.1.1:
+    resolution: {integrity: sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -9150,6 +9158,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  marked@16.1.1: {}
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- add `marked` to parse markdown
- convert markdown to HTML in `insertHtml`
- test markdown insertion

## Testing
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_688722a2ac0883298d9a5cbbce0731ca