### PR TITLE
[frontend] connect AiRightPanel examples to backend

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -82,7 +82,12 @@ export default function AiRightPanel({
   onInsertText,
 }: AiRightPanelProps) {
   const trames = useTrames();
-  const { items: examples, fetchAll } = useSectionExampleStore();
+  const {
+    items: examples,
+    fetchAll,
+    create,
+    remove,
+  } = useSectionExampleStore();
   const token = useAuth((s) => s.token);
 
   useEffect(() => {
@@ -94,9 +99,6 @@ export default function AiRightPanel({
     {},
   );
   const [answers, setAnswers] = useState<Record<string, Answers>>({});
-  const [extraExamples, setExtraExamples] = useState<
-    Record<string, TrameExample[]>
-  >({});
   const [isGenerating, setIsGenerating] = useState(false);
 
   useEffect(() => {
@@ -111,8 +113,7 @@ export default function AiRightPanel({
     }
   }, [trames]);
 
-  const getExamples = (sectionId: string, trameId: string) => {
-    const key = `${sectionId}-${trameId}`;
+  const getExamples = (_sectionId: string, trameId: string) => {
     const base = examples
       .filter((e) => e.sectionId === trameId)
       .map((e) => ({
@@ -121,24 +122,22 @@ export default function AiRightPanel({
         content: e.content,
         category: '',
       }));
-    return [...base, ...(extraExamples[key] || [])];
+    return base;
   };
 
   const addExample = (
-    sectionId: string,
+    _sectionId: string,
     trameId: string,
     ex: Omit<TrameExample, 'id'>,
   ) => {
-    const key = `${sectionId}-${trameId}`;
-    const newEx = { ...ex, id: Date.now().toString() };
-    setExtraExamples((p) => ({ ...p, [key]: [...(p[key] || []), newEx] }));
+    create({
+      sectionId: trameId,
+      label: ex.title,
+      content: ex.content,
+    }).catch(() => {});
   };
-  const removeExample = (sectionId: string, trameId: string, id: string) => {
-    const key = `${sectionId}-${trameId}`;
-    setExtraExamples((p) => ({
-      ...p,
-      [key]: (p[key] || []).filter((e) => e.id !== id),
-    }));
+  const removeExample = (_sectionId: string, _trameId: string, id: string) => {
+    remove(id).catch(() => {});
   };
 
   const handleGenerate = async (section: SectionInfo) => {

--- a/frontend/src/store/sectionExamples.test.ts
+++ b/frontend/src/store/sectionExamples.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useSectionExampleStore } from './sectionExamples';
+import { useAuth, type AuthState } from './auth';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('useSectionExampleStore', () => {
+  it('creates a section example with create()', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    useSectionExampleStore.setState({ items: [] });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: '1',
+          sectionId: 's1',
+          label: 'ex',
+          content: 'c',
+        }),
+    });
+    await useSectionExampleStore
+      .getState()
+      .create({ sectionId: 's1', label: 'ex', content: 'c' });
+    expect((fetch as unknown as vi.Mock).mock.calls[0][0]).toBe(
+      '/api/v1/section-examples',
+    );
+    expect(useSectionExampleStore.getState().items[0].id).toBe('1');
+  });
+
+  it('removes a section example with remove()', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    useSectionExampleStore.setState({
+      items: [{ id: '1', sectionId: 's1', label: 'ex', content: 'c' }],
+    });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    await useSectionExampleStore.getState().remove('1');
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/section-examples/1',
+      expect.any(Object),
+    );
+    expect(useSectionExampleStore.getState().items).toHaveLength(0);
+  });
+});

--- a/frontend/src/store/sectionExamples.ts
+++ b/frontend/src/store/sectionExamples.ts
@@ -12,6 +12,12 @@ export interface SectionExample {
 interface SectionExampleState {
   items: SectionExample[];
   fetchAll: () => Promise<void>;
+  create: (data: Omit<SectionExample, 'id'>) => Promise<SectionExample>;
+  update: (
+    id: string,
+    data: Partial<Omit<SectionExample, 'id'>>,
+  ) => Promise<SectionExample>;
+  remove: (id: string) => Promise<void>;
 }
 
 const endpoint = '/api/v1/section-examples';
@@ -25,5 +31,38 @@ export const useSectionExampleStore = create<SectionExampleState>((set) => ({
       headers: { Authorization: `Bearer ${token}` },
     });
     set({ items });
+  },
+  async create(data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const item = await apiFetch<SectionExample>(endpoint, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({ items: [...state.items, item] }));
+    return item;
+  },
+  async update(id, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const item = await apiFetch<SectionExample>(`${endpoint}/${id}`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({
+      items: state.items.map((i) => (i.id === id ? item : i)),
+    }));
+    return item;
+  },
+  async remove(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    await apiFetch(`${endpoint}/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({ items: state.items.filter((i) => i.id !== id) }));
   },
 }));


### PR DESCRIPTION
## Summary
- save section examples to the API when adding/removing via `AiRightPanel`
- expose CRUD helpers in `useSectionExampleStore`
- cover new store actions with tests

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_688872bdd05483299024a2035736b359