### PR TITLE
[backend] include examples in prompt via API

### DIFF
--- a/backend/src/controllers/bilan.controller.ts
+++ b/backend/src/controllers/bilan.controller.ts
@@ -56,6 +56,7 @@ export const BilanController = {
     try {
       const section = req.body.section as keyof typeof promptConfigs;
       const answers = req.body.answers ?? {};
+      const examples = Array.isArray(req.body.examples) ? req.body.examples : [];
       const cfg = promptConfigs[section];
       if (!cfg) {
         res.status(400).json({ error: 'invalid section' });
@@ -64,6 +65,7 @@ export const BilanController = {
       const text = await generateText({
         instructions: cfg.instructions,
         userContent: JSON.stringify(answers),
+        examples,
       });
       res.json({ text });
     } catch (e) {

--- a/backend/src/middlewares/requireAuth.ts
+++ b/backend/src/middlewares/requireAuth.ts
@@ -28,7 +28,7 @@ export const requireAuth: RequestHandler = async (
 
   try {
     const decoded = jwt.decode(token, { complete: true });
-    console.log(' decoded header:', (decoded as any)?.header);
+    console.log(' decoded header:', (decoded as jwt.Jwt | null)?.header);
     console.log('key', process.env.SUPABASE_JWT_SECRET);
   
     const payload = jwt.verify(token, process.env.SUPABASE_JWT_SECRET as string, {

--- a/backend/src/services/ai/generate.service.ts
+++ b/backend/src/services/ai/generate.service.ts
@@ -1,7 +1,7 @@
 
 import { openaiProvider } from "./providers/openai.provider";
 import { buildSinglePrompt, type PromptParams } from "./prompts/promptbuilder";
-import { ChatCompletionMessageParam } from "openai/resources/index";
+import { ChatCompletionMessageParam, ChatCompletionCreateParams } from "openai/resources/index";
 import * as guardrails from "./guardrails";
 
 export async function generateText(
@@ -19,12 +19,12 @@ export async function generateText(
   // 3. Appel modèle (avec ou sans streaming)
   if (stream) {
     return openaiProvider.chat(
-      { messages } as any,
+      { messages } as ChatCompletionCreateParams,
       chunk => process.stdout.write(chunk) // ici on renvoie vers stdout, à toi de brancher SSE/WS
     );
   }
 
-  const result = await openaiProvider.chat({ messages } as any);
+  const result = await openaiProvider.chat({ messages } as ChatCompletionCreateParams);
   // 4. Post-traitement
-  return guardrails.post(result);
+  return guardrails.post(result || "");
 }

--- a/backend/src/services/ai/prompts/promptbuilder.ts
+++ b/backend/src/services/ai/prompts/promptbuilder.ts
@@ -11,6 +11,8 @@ export interface PromptParams {
   instructions: string;
   /** Les données brutes / notes / question de l’utilisateur */
   userContent: string;
+  /** Exemples de textes pour guider la génération */
+  examples?: string[];
 }
 
 /** Valeur par défaut pour ton system prompt */
@@ -43,8 +45,12 @@ export function buildSinglePrompt(params: PromptParams): readonly SingleMessage[
   // 4. Données utilisateur
   const user = params.userContent.trim();
 
+  const examples = params.examples && params.examples.length > 0
+    ? `### Exemples\n${params.examples.join("\n")}`
+    : "";
+
   // On assemble tous les blocs, en saut de ligne entre chacun
-  const content = [system, ctx, instr, user]
+  const content = [system, ctx, instr, user, examples]
     .filter((blk) => blk.length > 0)
     .join("\n\n");
 

--- a/backend/src/services/ai/providers/openai.provider.ts
+++ b/backend/src/services/ai/providers/openai.provider.ts
@@ -23,11 +23,13 @@ export class OpenAIProvider {
         });
 
         if (onChunk) {
-          for await (const chunk of res as any)
+          for await (const chunk of res as AsyncIterable<{ choices: { delta: { content?: string } }[] }>) {
             onChunk(chunk.choices[0].delta.content ?? "");
+          }
           return ""; // le flux est déjà renvoyé au caller
         }
-        return (res as any).choices[0].message.content ?? "";
+        const full = res as { choices: { message: { content?: string } }[] };
+        return full.choices[0].message.content ?? "";
       } catch (err) {
         if (attempt >= 3) throw err;
         await new Promise(r => setTimeout(r, attempt * 500)); // back-off

--- a/backend/tests/bilan.routes.test.ts
+++ b/backend/tests/bilan.routes.test.ts
@@ -56,7 +56,11 @@ describe("POST /api/v1/bilans/:id/generate", () => {
   it("calls ai service with prompt params", async () => {
     mockedGenerate.mockResolvedValueOnce("texte");
     const id = "11111111-1111-1111-1111-111111111111";
-    const body = { section: "anamnesis", answers: { foo: "bar" } };
+    const body = {
+      section: "anamnese",
+      answers: { foo: "bar" },
+      examples: ["demo"],
+    };
 
     const res = await request(app)
       .post(`/api/v1/bilans/${id}/generate`)
@@ -65,8 +69,9 @@ describe("POST /api/v1/bilans/:id/generate", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ text: "texte" });
     expect(mockedGenerate).toHaveBeenCalledWith({
-      instructions: promptConfigs.anamnesis.instructions,
+      instructions: promptConfigs.anamnese.instructions,
       userContent: JSON.stringify(body.answers),
+      examples: ["demo"],
     });
   });
 });

--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -147,6 +147,9 @@ export default function AiRightPanel({
       const body = {
         section: kindMap[section.id],
         answers: answers[section.id] || {},
+        examples: examples
+          .filter((e) => e.sectionId === selectedTrames[section.id])
+          .map((e) => e.content),
       };
       const res = await apiFetch<{ text: string }>(
         `/api/v1/bilans/${bilanId}/generate`,


### PR DESCRIPTION
## Summary
- accept `examples` in BilanController instead of fetching them
- remove unused `listForSection` service
- adjust AiRightPanel to send example texts
- update generation test

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6888758172188329b47b0fd10862c911