### PR TITLE
[frontend] integrate AI section wizard

### DIFF
--- a/frontend/src/components/WizardAIRightPanel.tsx
+++ b/frontend/src/components/WizardAIRightPanel.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { WizardProgress } from './WizardProgress';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { TrameOption, TrameExample } from './bilan/TrameSelector';
+import { DataEntry } from './bilan/DataEntry';
+import ExampleManager from './bilan/ExampleManager';
+import type { Answers, Question } from '@/types/question';
+
+interface WizardAIRightPanelProps {
+  trameOptions: TrameOption[];
+  selectedTrame: TrameOption | undefined;
+  onTrameChange: (value: string) => void;
+  examples: TrameExample[];
+  onAddExample: (ex: Omit<TrameExample, 'id'>) => void;
+  onRemoveExample: (id: string) => void;
+  questions: Question[];
+  answers: Answers;
+  onAnswersChange: (a: Answers) => void;
+  onGenerate: () => void;
+  isGenerating: boolean;
+  onCancel: () => void;
+}
+
+export default function WizardAIRightPanel({
+  trameOptions,
+  selectedTrame,
+  onTrameChange,
+  examples,
+  onAddExample,
+  onRemoveExample,
+  questions,
+  answers,
+  onAnswersChange,
+  onGenerate,
+  isGenerating,
+  onCancel,
+}: WizardAIRightPanelProps) {
+  const [step, setStep] = useState(1);
+  const total = 3;
+
+  const next = () => setStep((s) => Math.min(total, s + 1));
+  const prev = () => setStep((s) => Math.max(1, s - 1));
+
+  let content: JSX.Element | null = null;
+
+  if (step === 1) {
+    content = (
+      <div className="space-y-4">
+        <p className="text-sm">Choisissez une trame parmi la bibliothèque :</p>
+        <Select
+          value={selectedTrame?.value || ''}
+          onValueChange={onTrameChange}
+        >
+          <SelectTrigger className="h-8">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {trameOptions.map((trame) => (
+              <SelectItem key={trame.value} value={trame.value}>
+                {trame.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  } else if (step === 2) {
+    content = (
+      <ExampleManager
+        examples={examples}
+        onAddExample={onAddExample}
+        onRemoveExample={onRemoveExample}
+      />
+    );
+  } else {
+    content = (
+      <DataEntry
+        questions={questions}
+        answers={answers}
+        onChange={onAnswersChange}
+      />
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <WizardProgress step={step} total={total} />
+      {content}
+      <div className="flex justify-between pt-2">
+        {step > 1 ? (
+          <Button variant="secondary" onClick={prev} type="button">
+            Précédent
+          </Button>
+        ) : (
+          <span />
+        )}
+        {step < total ? (
+          <Button onClick={next} type="button">
+            Suivant
+          </Button>
+        ) : (
+          <Button onClick={onGenerate} disabled={isGenerating} type="button">
+            {isGenerating ? 'Génération...' : 'Générer'}
+          </Button>
+        )}
+      </div>
+      <div className="pt-2">
+        <Button
+          variant="ghost"
+          onClick={onCancel}
+          type="button"
+          className="w-full text-xs"
+        >
+          Annuler
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/bilan/ExampleManager.tsx
+++ b/frontend/src/components/bilan/ExampleManager.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { Plus, X } from 'lucide-react';
+import type { TrameExample } from './TrameSelector';
+
+interface ExampleManagerProps {
+  examples: TrameExample[];
+  onAddExample: (example: Omit<TrameExample, 'id'>) => void;
+  onRemoveExample: (id: string) => void;
+}
+
+export function ExampleManager({
+  examples,
+  onAddExample,
+  onRemoveExample,
+}: ExampleManagerProps) {
+  const [newExample, setNewExample] = useState({
+    title: '',
+    content: '',
+    category: 'general',
+  });
+
+  const addExample = () => {
+    if (!newExample.title || !newExample.content) return;
+    onAddExample(newExample);
+    setNewExample({ title: '', content: '', category: 'general' });
+  };
+
+  return (
+    <div className="space-y-4">
+      {examples.length > 0 && (
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Exemples existants :</Label>
+          <div className="max-h-60 overflow-y-auto space-y-2">
+            {examples.map((example) => (
+              <div
+                key={example.id}
+                className="p-3 bg-gray-50 rounded-lg border"
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="font-medium text-sm">{example.title}</div>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => onRemoveExample(example.id)}
+                    className="h-5 w-5 p-0 text-gray-400 hover:text-red-500"
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
+                <p className="text-sm text-gray-700">{example.content}</p>
+                <Badge variant="outline" className="text-xs mt-2">
+                  {example.category}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="space-y-3">
+        <Label className="text-sm font-medium">
+          Ajouter un nouvel exemple :
+        </Label>
+        <div>
+          <Label className="text-xs">Titre de l&apos;exemple</Label>
+          <Textarea
+            value={newExample.title}
+            onChange={(e) =>
+              setNewExample({ ...newExample, title: e.target.value })
+            }
+            placeholder="Ex: Questions sur le développement moteur"
+            className="h-8"
+          />
+        </div>
+        <div>
+          <Label className="text-xs">Contenu de l&apos;exemple</Label>
+          <Textarea
+            value={newExample.content}
+            onChange={(e) =>
+              setNewExample({ ...newExample, content: e.target.value })
+            }
+            placeholder="Décrivez l'exemple..."
+            className="min-h-20"
+          />
+        </div>
+        <div>
+          <Label className="text-xs">Catégorie</Label>
+          <Select
+            value={newExample.category}
+            onValueChange={(v) => setNewExample({ ...newExample, category: v })}
+          >
+            <SelectTrigger className="h-8">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="general">Général</SelectItem>
+              <SelectItem value="motricite">Motricité</SelectItem>
+              <SelectItem value="cognitif">Cognitif</SelectItem>
+              <SelectItem value="social">Social</SelectItem>
+              <SelectItem value="sensoriel">Sensoriel</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button
+          onClick={addExample}
+          disabled={!newExample.title || !newExample.content}
+          className="w-full"
+        >
+          <Plus className="h-4 w-4 mr-2" /> Ajouter l&apos;exemple
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default ExampleManager;


### PR DESCRIPTION
## Summary
- add ExampleManager component to manage section examples
- implement WizardAIRightPanel wizard with 3 steps
- refactor AiRightPanel to display start CTA, wizard and generated sections

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6888dea198bc8329be6942a03fccd9aa