### PR TITLE
[frontend] Enhance wizard layout

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -189,35 +189,47 @@ export default function AiRightPanel({
 
               if (wizardSection === section.id) {
                 return (
-                  <WizardAIRightPanel
+                  <div
                     key={section.id}
-                    section={section}
-                    trameOptions={trameOpts}
-                    selectedTrame={selected}
-                    onTrameChange={(v) =>
-                      setSelectedTrames({ ...selectedTrames, [section.id]: v })
-                    }
-                    examples={getExamples(
-                      section.id,
-                      selectedTrames[section.id],
-                    )}
-                    onAddExample={(ex) =>
-                      addExample(section.id, selectedTrames[section.id], ex)
-                    }
-                    onRemoveExample={(id) =>
-                      removeExample(section.id, selectedTrames[section.id], id)
-                    }
-                    questions={(selected?.schema as Question[]) || []}
-                    answers={answers[section.id] || {}}
-                    onAnswersChange={(a) =>
-                      setAnswers({ ...answers, [section.id]: a })
-                    }
-                    onGenerate={() => handleGenerate(section)}
-                    isGenerating={
-                      isGenerating && selectedSection === section.id
-                    }
-                    onCancel={() => setWizardSection(null)}
-                  />
+                    className="fixed inset-0 z-50 overflow-y-auto bg-white p-4"
+                  >
+                    <div className="max-w-2xl mx-auto">
+                      <WizardAIRightPanel
+                        trameOptions={trameOpts}
+                        selectedTrame={selected}
+                        onTrameChange={(v) =>
+                          setSelectedTrames({
+                            ...selectedTrames,
+                            [section.id]: v,
+                          })
+                        }
+                        examples={getExamples(
+                          section.id,
+                          selectedTrames[section.id],
+                        )}
+                        onAddExample={(ex) =>
+                          addExample(section.id, selectedTrames[section.id], ex)
+                        }
+                        onRemoveExample={(id) =>
+                          removeExample(
+                            section.id,
+                            selectedTrames[section.id],
+                            id,
+                          )
+                        }
+                        questions={(selected?.schema as Question[]) || []}
+                        answers={answers[section.id] || {}}
+                        onAnswersChange={(a) =>
+                          setAnswers({ ...answers, [section.id]: a })
+                        }
+                        onGenerate={() => handleGenerate(section)}
+                        isGenerating={
+                          isGenerating && selectedSection === section.id
+                        }
+                        onCancel={() => setWizardSection(null)}
+                      />
+                    </div>
+                  </div>
                 );
               }
 

--- a/frontend/src/components/WizardAIRightPanel.tsx
+++ b/frontend/src/components/WizardAIRightPanel.tsx
@@ -85,6 +85,7 @@ export default function WizardAIRightPanel({
         questions={questions}
         answers={answers}
         onChange={onAnswersChange}
+        inline
       />
     );
   }

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -36,4 +36,18 @@ describe('DataEntry', () => {
     fireEvent.change(input, { target: { value: '10' } });
     expect(screen.getByText(/Valeur entre 1 et 5/)).toBeInTheDocument();
   });
+
+  it('shows fields inline when inline prop is true', () => {
+    render(
+      <DataEntry
+        questions={[mcQuestion]}
+        answers={{}}
+        onChange={noop}
+        inline
+      />,
+    );
+    // buttons should be visible without clicking "Ajouter"
+    expect(screen.getByRole('button', { name: 'Opt1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Opt2' })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -19,9 +19,15 @@ interface DataEntryProps {
   questions: Question[];
   answers: Answers;
   onChange: (answers: Answers) => void;
+  inline?: boolean;
 }
 
-export function DataEntry({ questions, answers, onChange }: DataEntryProps) {
+export function DataEntry({
+  questions,
+  answers,
+  onChange,
+  inline = false,
+}: DataEntryProps) {
   const [open, setOpen] = useState(false);
   const [local, setLocal] = useState<Answers>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -106,6 +112,29 @@ export function DataEntry({ questions, answers, onChange }: DataEntryProps) {
         return null;
     }
   };
+
+  const form = (
+    <div className="space-y-4">
+      {questions.map((q) => (
+        <div
+          key={q.id}
+          className={`space-y-2 p-2 rounded-md border ${
+            q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
+          }`}
+        >
+          <Label className="text-sm font-medium">{q.titre}</Label>
+          {renderQuestion(q)}
+        </div>
+      ))}
+      <Button onClick={save} className="w-full mt-4">
+        Sauvegarder
+      </Button>
+    </div>
+  );
+
+  if (inline) {
+    return <div className="mb-4">{form}</div>;
+  }
 
   return (
     <div className="mb-4">


### PR DESCRIPTION
## Summary
- overlay WizardAIRightPanel fullscreen in AiRightPanel
- allow inline answers entry for DataEntry and use it in the wizard
- update DataEntry tests for inline mode

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_6888f2c7a88c8329840ce5445bc7b9bf