### PR TITLE
[frontend] ensure wizard generates with latest data

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -146,13 +146,13 @@ export default function AiRightPanel({
     remove(id).catch(() => {});
   };
 
-  const handleGenerate = async (section: SectionInfo) => {
+  const handleGenerate = async (section: SectionInfo, newAnswers?: Answers) => {
     setIsGenerating(true);
     setSelectedSection(section.id);
     try {
       const body = {
         section: kindMap[section.id],
-        answers: answers[section.id] || {},
+        answers: newAnswers || answers[section.id] || {},
         examples: examples
           .filter((e) => e.sectionId === selectedTrames[section.id])
           .map((e) => e.content),
@@ -190,7 +190,11 @@ export default function AiRightPanel({
 
               if (wizardSection === section.id) {
                 return (
-                  <Dialog open={true} onOpenChange={(open) => !open && setWizardSection(null)}>
+                  <Dialog
+                    key={section.id}
+                    open={true}
+                    onOpenChange={(open) => !open && setWizardSection(null)}
+                  >
                     <DialogContent className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[100vw] h-[80vh] max-w-none max-h-none overflow-auto bg-white rounded-lg shadow-lg">
                       <WizardAIRightPanel
                         sectionInfo={section}
@@ -221,7 +225,7 @@ export default function AiRightPanel({
                         onAnswersChange={(a) =>
                           setAnswers({ ...answers, [section.id]: a })
                         }
-                        onGenerate={() => handleGenerate(section)}
+                        onGenerate={(latest) => handleGenerate(section, latest)}
                         isGenerating={
                           isGenerating && selectedSection === section.id
                         }
@@ -283,7 +287,7 @@ export default function AiRightPanel({
                   onAnswersChange={(a) =>
                     setAnswers({ ...answers, [section.id]: a })
                   }
-                  onGenerate={() => handleGenerate(section)}
+                  onGenerate={(latest) => handleGenerate(section, latest)}
                   isGenerating={isGenerating && selectedSection === section.id}
                   active={selectedSection === section.id}
                 />

--- a/frontend/src/components/WizardAIRightPanel.tsx
+++ b/frontend/src/components/WizardAIRightPanel.tsx
@@ -1,14 +1,13 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
-import { WizardProgress } from './WizardProgress';
 import {
-DialogHeader,
-DialogTitle,
-DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
 } from '@/components/ui/dialog';
 import TrameCard from './TrameCard';
 import type { TrameOption, TrameExample } from './bilan/TrameSelector';
-import { DataEntry } from './bilan/DataEntry';
+import { DataEntry, type DataEntryHandle } from './bilan/DataEntry';
 import ExampleManager from './bilan/ExampleManager';
 import type { Answers, Question } from '@/types/question';
 import type { SectionInfo } from './bilan/SectionCard';
@@ -24,9 +23,8 @@ interface WizardAIRightPanelProps {
   questions: Question[];
   answers: Answers;
   onAnswersChange: (a: Answers) => void;
-  onGenerate: () => void;
+  onGenerate: (latest?: Answers) => void;
   isGenerating: boolean;
-  onCancel: () => void;
 }
 
 export default function WizardAIRightPanel({
@@ -42,9 +40,9 @@ export default function WizardAIRightPanel({
   onAnswersChange,
   onGenerate,
   isGenerating,
-  onCancel,
 }: WizardAIRightPanelProps) {
   const [step, setStep] = useState(1);
+  const dataEntryRef = useRef<DataEntryHandle>(null);
   const total = 3;
 
   const next = () => setStep((s) => Math.min(total, s + 1));
@@ -93,6 +91,7 @@ export default function WizardAIRightPanel({
       <div className="space-y-4">
         <h3 className="text-center font-medium">{stepTitles[2]}</h3>
         <DataEntry
+          ref={dataEntryRef}
           questions={questions}
           answers={answers}
           onChange={onAnswersChange}
@@ -107,13 +106,12 @@ export default function WizardAIRightPanel({
       <div className="flex-1 space-y-4">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            {sectionInfo?.icon && (
-              <sectionInfo.icon className="h-5 w-5" />
-            )}
+            {sectionInfo?.icon && <sectionInfo.icon className="h-5 w-5" />}
             {sectionInfo?.title} - Étape {step}/3
           </DialogTitle>
           <DialogDescription>
-            Configuration de la génération pour {sectionInfo?.title?.toLowerCase()}
+            Configuration de la génération pour{' '}
+            {sectionInfo?.title?.toLowerCase()}
           </DialogDescription>
         </DialogHeader>
 
@@ -147,7 +145,7 @@ export default function WizardAIRightPanel({
             <span>Données</span>
           </div>
         </div>
-        
+
         {content}
       </div>
       <div className="flex justify-between pt-4">
@@ -163,7 +161,14 @@ export default function WizardAIRightPanel({
             Suivant
           </Button>
         ) : (
-          <Button onClick={onGenerate} disabled={isGenerating} type="button">
+          <Button
+            onClick={() => {
+              const data = dataEntryRef.current?.save() as Answers | undefined;
+              onGenerate(data);
+            }}
+            disabled={isGenerating}
+            type="button"
+          >
             {isGenerating ? 'Génération...' : 'Générer'}
           </Button>
         )}

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import { DataEntry } from './DataEntry';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { DataEntry, type DataEntryHandle } from './DataEntry';
 import type { Question } from '@/types/question';
 
 const noop = () => {};
@@ -49,5 +50,22 @@ describe('DataEntry', () => {
     // buttons should be visible without clicking "Ajouter"
     expect(screen.getByRole('button', { name: 'Opt1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Opt2' })).toBeInTheDocument();
+  });
+
+  it('allows saving through ref', () => {
+    const handle = vi.fn();
+    const ref = React.createRef<DataEntryHandle>();
+    render(
+      <DataEntry
+        ref={ref}
+        questions={[mcQuestion]}
+        answers={{}}
+        onChange={handle}
+        inline
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Opt1' }));
+    ref.current?.save();
+    expect(handle).toHaveBeenCalledWith({ [mcQuestion.id]: 'Opt1' });
   });
 });

--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -22,199 +22,162 @@ interface DataEntryProps {
   inline?: boolean;
 }
 
-export function DataEntry({
-  questions,
-  answers,
-  onChange,
-  inline = false,
-}: DataEntryProps) {
-  const [open, setOpen] = useState(false);
-  const [local, setLocal] = useState<Answers>({});
-  const [errors, setErrors] = useState<Record<string, string>>({});
+export interface DataEntryHandle {
+  save: () => Answers | void;
+  getAnswers: () => Answers;
+}
 
-  useEffect(() => {
-    setLocal(answers);
-  }, [answers]);
+export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
+  function DataEntry(
+    { questions, answers, onChange, inline = false }: DataEntryProps,
+    ref,
+  ) {
+    const [open, setOpen] = useState(false);
+    const [local, setLocal] = useState<Answers>({});
+    const [errors, setErrors] = useState<Record<string, string>>({});
 
-  const answeredCount = Object.keys(answers).length;
+    useEffect(() => {
+      setLocal(answers);
+    }, [answers]);
 
-  const validateEchelle = (q: Question, v: string) => {
-    if (q.type !== 'echelle' || !q.echelle) return;
-    const num = Number(v);
-    if (v === '') {
-      setErrors((p) => ({ ...p, [q.id]: '' }));
-      return;
-    }
-    if (isNaN(num) || num < q.echelle.min || num > q.echelle.max) {
-      setErrors((p) => ({
-        ...p,
-        [q.id]: `Valeur entre ${q.echelle.min} et ${q.echelle.max}`,
-      }));
-    } else {
-      setErrors((p) => ({ ...p, [q.id]: '' }));
-    }
-  };
+    const answeredCount = Object.keys(answers).length;
 
-  const save = () => {
-    if (Object.values(errors).some((e) => e)) {
-      return;
-    }
-    onChange(local);
-    setOpen(false);
-  };
+    const validateEchelle = (q: Question, v: string) => {
+      if (q.type !== 'echelle' || !q.echelle) return;
+      const num = Number(v);
+      if (v === '') {
+        setErrors((p) => ({ ...p, [q.id]: '' }));
+        return;
+      }
+      if (isNaN(num) || num < q.echelle.min || num > q.echelle.max) {
+        setErrors((p) => ({
+          ...p,
+          [q.id]: `Valeur entre ${q.echelle.min} et ${q.echelle.max}`,
+        }));
+      } else {
+        setErrors((p) => ({ ...p, [q.id]: '' }));
+      }
+    };
 
-  const renderQuestion = (q: Question) => {
-    const value = local[q.id] ?? '';
-    switch (q.type) {
-      case 'notes':
-        return (
-          <Textarea
-            value={String(value)}
-            onChange={(e) => setLocal({ ...local, [q.id]: e.target.value })}
-            placeholder={q.contenu}
-            className="min-h-20"
-          />
-        );
-      case 'choix-multiple':
-        return (
-          <div className="flex flex-wrap gap-2">
-            {q.options?.map((opt) => (
-              <Button
-                key={opt}
-                size="sm"
-                variant={value === opt ? 'default' : 'outline'}
-                onClick={() => setLocal({ ...local, [q.id]: opt })}
-              >
-                {opt}
-              </Button>
-            ))}
-          </div>
-        );
-      case 'echelle':
-        return (
-          <div className="space-y-1">
-            <Input
-              type="number"
+    const save = () => {
+      if (Object.values(errors).some((e) => e)) {
+        return;
+      }
+      onChange(local);
+      setOpen(false);
+      return local;
+    };
+
+    useImperativeHandle(ref, () => ({
+      save,
+      getAnswers: () => local,
+    }));
+
+    const renderQuestion = (q: Question) => {
+      const value = local[q.id] ?? '';
+      switch (q.type) {
+        case 'notes':
+          return (
+            <Textarea
               value={String(value)}
-              min={q.echelle?.min}
-              max={q.echelle?.max}
-              onChange={(e) => {
-                setLocal({ ...local, [q.id]: e.target.value });
-                validateEchelle(q, e.target.value);
-              }}
+              onChange={(e) => setLocal({ ...local, [q.id]: e.target.value })}
+              placeholder={q.contenu}
+              className="min-h-20"
             />
-            {errors[q.id] && (
-              <p className="text-xs text-red-600">{errors[q.id]}</p>
-            )}
-          </div>
-        );
-      default:
-        return null;
-    }
-  };
-
-  const form = (
-    <div className="space-y-4">
-      {questions.map((q) => (
-        <div
-          key={q.id}
-          className={`space-y-2 p-2 rounded-md ${
-            q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
-          }`}
-        >
-          <Label className="text-sm font-medium">{q.titre}</Label>
-          {renderQuestion(q)}
-        </div>
-      ))}
-      <Button onClick={save} className="w-full mt-4">
-        Sauvegarder
-      </Button>
-    </div>
-  );
-
-  if (inline) {
-    return <div className="mb-4">{form}</div>;
-  }
-
-  return (
-    <div className="mb-4">
-      <div className="flex items-center justify-between mb-2">
-        <Label className="text-xs font-medium text-gray-700">Réponses</Label>
-        {answeredCount > 0 && (
-          <Badge variant="outline" className="text-xs">
-            {answeredCount}/{questions.length}
-          </Badge>
-        )}
-      </div>
-      {answeredCount === 0 ? (
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild>
-            <Button
-              size="sm"
-              variant="outline"
-              className="w-full text-xs border-2 border-dashed border-gray-300 text-gray-600 hover:border-blue-300 hover:text-blue-600 hover:bg-blue-50"
-            >
-              <Plus className="h-3 w-3 mr-2" /> Ajouter
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                Répondre
-              </DialogTitle>
-            </DialogHeader>
-            <div className="space-y-4">
-              {questions.map((q) => (
-                <div
-                  key={q.id}
-                  className={`space-y-2 p-2 rounded-md border ${
-                    q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
-                  }`}
+          );
+        case 'choix-multiple':
+          return (
+            <div className="flex flex-wrap gap-2">
+              {q.options?.map((opt) => (
+                <Button
+                  key={opt}
+                  size="sm"
+                  variant={value === opt ? 'default' : 'outline'}
+                  onClick={() => setLocal({ ...local, [q.id]: opt })}
                 >
-                  <Label className="text-sm font-medium">{q.titre}</Label>
-                  {renderQuestion(q)}
-                </div>
+                  {opt}
+                </Button>
               ))}
-              <Button onClick={save} className="w-full mt-4">
-                Sauvegarder
-              </Button>
             </div>
-          </DialogContent>
-        </Dialog>
-      ) : (
-        <div className="space-y-2">
-          <div className="p-3 bg-gray-50 rounded-lg border">
-            <div className="text-xs text-gray-600 mb-2">
-              Réponses enregistrées
+          );
+        case 'echelle':
+          return (
+            <div className="space-y-1">
+              <Input
+                type="number"
+                value={String(value)}
+                min={q.echelle?.min}
+                max={q.echelle?.max}
+                onChange={(e) => {
+                  setLocal({ ...local, [q.id]: e.target.value });
+                  validateEchelle(q, e.target.value);
+                }}
+              />
+              {errors[q.id] && (
+                <p className="text-xs text-red-600">{errors[q.id]}</p>
+              )}
             </div>
-            {questions.slice(0, 2).map((q) => (
-              <div key={q.id} className="text-xs text-gray-700 truncate">
-                • {q.titre}
-              </div>
-            ))}
-            {answeredCount > 2 && (
-              <div className="text-xs text-gray-500">
-                +{answeredCount - 2} autres...
-              </div>
-            )}
+          );
+        default:
+          return null;
+      }
+    };
+
+    const form = (
+      <div className="space-y-4">
+        {questions.map((q) => (
+          <div
+            key={q.id}
+            className={`space-y-2 p-2 rounded-md ${
+              q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
+            }`}
+          >
+            <Label className="text-sm font-medium">{q.titre}</Label>
+            {renderQuestion(q)}
           </div>
+        ))}
+        <Button onClick={save} className="w-full mt-4">
+          Sauvegarder
+        </Button>
+      </div>
+    );
+
+    if (inline) {
+      return <div className="mb-4">{form}</div>;
+    }
+
+    return (
+      <div className="mb-4">
+        <div className="flex items-center justify-between mb-2">
+          <Label className="text-xs font-medium text-gray-700">Réponses</Label>
+          {answeredCount > 0 && (
+            <Badge variant="outline" className="text-xs">
+              {answeredCount}/{questions.length}
+            </Badge>
+          )}
+        </div>
+        {answeredCount === 0 ? (
           <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
-              <Button size="sm" variant="outline" className="w-full text-xs">
-                <Edit2 className="h-3 w-3 mr-2" /> Modifier
+              <Button
+                size="sm"
+                variant="outline"
+                className="w-full text-xs border-2 border-dashed border-gray-300 text-gray-600 hover:border-blue-300 hover:text-blue-600 hover:bg-blue-50"
+              >
+                <Plus className="h-3 w-3 mr-2" /> Ajouter
               </Button>
             </DialogTrigger>
             <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
               <DialogHeader>
                 <DialogTitle className="flex items-center gap-2">
-                  Modifier les réponses
+                  Répondre
                 </DialogTitle>
               </DialogHeader>
               <div className="space-y-4">
                 {questions.map((q) => (
                   <div
                     key={q.id}
-                    className={`space-y-2 p-2 rounded-md border border-gray-200${
+                    className={`space-y-2 p-2 rounded-md border ${
                       q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
                     }`}
                   >
@@ -228,8 +191,56 @@ export function DataEntry({
               </div>
             </DialogContent>
           </Dialog>
-        </div>
-      )}
-    </div>
-  );
-}
+        ) : (
+          <div className="space-y-2">
+            <div className="p-3 bg-gray-50 rounded-lg border">
+              <div className="text-xs text-gray-600 mb-2">
+                Réponses enregistrées
+              </div>
+              {questions.slice(0, 2).map((q) => (
+                <div key={q.id} className="text-xs text-gray-700 truncate">
+                  • {q.titre}
+                </div>
+              ))}
+              {answeredCount > 2 && (
+                <div className="text-xs text-gray-500">
+                  +{answeredCount - 2} autres...
+                </div>
+              )}
+            </div>
+            <Dialog open={open} onOpenChange={setOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm" variant="outline" className="w-full text-xs">
+                  <Edit2 className="h-3 w-3 mr-2" /> Modifier
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+                <DialogHeader>
+                  <DialogTitle className="flex items-center gap-2">
+                    Modifier les réponses
+                  </DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  {questions.map((q) => (
+                    <div
+                      key={q.id}
+                      className={`space-y-2 p-2 rounded-md border border-gray-200${
+                        q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
+                      }`}
+                    >
+                      <Label className="text-sm font-medium">{q.titre}</Label>
+                      {renderQuestion(q)}
+                    </div>
+                  ))}
+                  <Button onClick={save} className="w-full mt-4">
+                    Sauvegarder
+                  </Button>
+                </div>
+              </DialogContent>
+            </Dialog>
+          </div>
+        )}
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/bilan/ExampleManager.tsx
+++ b/frontend/src/components/bilan/ExampleManager.tsx
@@ -2,13 +2,6 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Plus, X } from 'lucide-react';
 import type { TrameExample } from './TrameSelector';

--- a/frontend/src/components/bilan/SectionCard.tsx
+++ b/frontend/src/components/bilan/SectionCard.tsx
@@ -24,7 +24,7 @@ interface SectionCardProps {
   questions: Question[];
   answers: Answers;
   onAnswersChange: (a: Answers) => void;
-  onGenerate: () => void;
+  onGenerate: (latest?: Answers) => void;
   isGenerating: boolean;
   active: boolean;
 }
@@ -76,7 +76,7 @@ export function SectionCard({
             <Button
               size="sm"
               variant={active ? 'default' : 'outline'}
-              onClick={onGenerate}
+              onClick={() => onGenerate()}
               disabled={isGenerating}
               className="w-full text-xs"
             >


### PR DESCRIPTION
## Summary
- expose DataEntry imperative handle to fetch current answers
- ensure WizardAIRightPanel saves local answers when generating
- allow AiRightPanel.handleGenerate to accept latest answers
- adjust SectionCard and wizard signatures
- clean ExampleManager imports
- add regression test for DataEntry ref save

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6889bc6b5610832994d459949f47d545