### PR TITLE
[frontend] add create trame card in AI wizard

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -79,11 +79,15 @@ const useTrames = () => {
 interface AiRightPanelProps {
   bilanId: string;
   onInsertText: (text: string) => void;
+  initialWizardSection?: string;
+  initialTrameId?: string;
 }
 
 export default function AiRightPanel({
   bilanId,
   onInsertText,
+  initialWizardSection,
+  initialTrameId,
 }: AiRightPanelProps) {
   const trames = useTrames();
   const {
@@ -100,12 +104,16 @@ export default function AiRightPanel({
 
   const [selectedSection, setSelectedSection] = useState<string | null>(null);
   const [selectedTrames, setSelectedTrames] = useState<Record<string, string>>(
-    {},
+    initialWizardSection && initialTrameId
+      ? { [initialWizardSection]: initialTrameId }
+      : {},
   );
   const [answers, setAnswers] = useState<Record<string, Answers>>({});
   const [isGenerating, setIsGenerating] = useState(false);
   const [generated, setGenerated] = useState<Record<string, boolean>>({});
-  const [wizardSection, setWizardSection] = useState<string | null>(null);
+  const [wizardSection, setWizardSection] = useState<string | null>(
+    initialWizardSection || null,
+  );
 
   useEffect(() => {
     const defaults: Record<string, string> = {};
@@ -230,6 +238,7 @@ export default function AiRightPanel({
                           isGenerating && selectedSection === section.id
                         }
                         onCancel={() => setWizardSection(null)}
+                        bilanId={bilanId}
                       />
                     </DialogContent>
                   </Dialog>

--- a/frontend/src/components/WizardAIRightPanel.tsx
+++ b/frontend/src/components/WizardAIRightPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import {
   DialogHeader,
@@ -6,6 +7,14 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog';
 import TrameCard from './TrameCard';
+import CreerTrameModal from './ui/creer-trame-modale';
+import { Plus } from 'lucide-react';
+const kindMap: Record<string, string> = {
+  anamnese: 'anamnese',
+  'profil-sensoriel': 'profil_sensoriel',
+  'observations-cliniques': 'observations',
+  'tests-mabc': 'tests_standards',
+};
 import type { TrameOption, TrameExample } from './bilan/TrameSelector';
 import { DataEntry, type DataEntryHandle } from './bilan/DataEntry';
 import ExampleManager from './bilan/ExampleManager';
@@ -25,6 +34,7 @@ interface WizardAIRightPanelProps {
   onAnswersChange: (a: Answers) => void;
   onGenerate: (latest?: Answers) => void;
   isGenerating: boolean;
+  bilanId: string;
 }
 
 export default function WizardAIRightPanel({
@@ -40,9 +50,11 @@ export default function WizardAIRightPanel({
   onAnswersChange,
   onGenerate,
   isGenerating,
+  bilanId,
 }: WizardAIRightPanelProps) {
   const [step, setStep] = useState(1);
   const dataEntryRef = useRef<DataEntryHandle>(null);
+  const navigate = useNavigate();
   const total = 3;
 
   const next = () => setStep((s) => Math.min(total, s + 1));
@@ -57,9 +69,10 @@ export default function WizardAIRightPanel({
       <div className="space-y-4">
         <h3 className="text-center font-medium">{stepTitles[0]}</h3>
         <p className="text-sm text-center">
-        Choisissez une trame parmi la bibliothèque. 
-        <br />
-        Pour personnaliser les questions ou les résultats que vous souhaitez entrer vous pouvez créer votre propre trame
+          Choisissez une trame parmi la bibliothèque.
+          <br />
+          Pour personnaliser les questions ou les résultats que vous souhaitez
+          entrer vous pouvez créer votre propre trame
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-h-60 overflow-y-auto">
           {trameOptions.map((trame) => (
@@ -74,6 +87,23 @@ export default function WizardAIRightPanel({
               onSelect={() => onTrameChange(trame.value)}
             />
           ))}
+          <CreerTrameModal
+            trigger={
+              <div className="border border-dashed rounded-lg p-4 flex flex-col items-center justify-center cursor-pointer text-gray-600 hover:bg-gray-50">
+                <Plus className="h-6 w-6 mb-2" />
+                Créer sa trame
+              </div>
+            }
+            initialCategory={kindMap[sectionInfo.id]}
+            onCreated={(id) =>
+              navigate(`/creation-trame/${id}`, {
+                state: {
+                  returnTo: `/bilan/${bilanId}`,
+                  wizardSection: sectionInfo.id,
+                },
+              })
+            }
+          />
         </div>
       </div>
     );
@@ -82,9 +112,10 @@ export default function WizardAIRightPanel({
       <div className="space-y-4">
         <h3 className="text-center font-medium">{stepTitles[1]}</h3>
         <p className="text-sm text-center">
-        Ajoutez un exemple de rédaction d’un bilan déjà rédigé pour aider l'IA à mieux coller à votre style de rédaction
-        <br />
-        Important: veuillez anonymiser les données (pas de nom et de prénom)
+          Ajoutez un exemple de rédaction d’un bilan déjà rédigé pour aider
+          l&apos;IA à mieux coller à votre style de rédaction
+          <br />
+          Important: veuillez anonymiser les données (pas de nom et de prénom)
         </p>
         <ExampleManager
           examples={examples}
@@ -98,9 +129,11 @@ export default function WizardAIRightPanel({
       <div className="space-y-4">
         <h3 className="text-center font-medium">{stepTitles[2]}</h3>
         <p className="text-sm text-center">
-        Entrez les notes, les résultats chiffrés que vous avez sur la patient. C’est le coeur de la matière qui est utilisé par l’IA pour générer le bilan.
-        <br />
-        Important: veuillez anonymiser les données (pas de nom et de prénom)
+          Entrez les notes, les résultats chiffrés que vous avez sur la patient.
+          C’est le coeur de la matière qui est utilisé par l’IA pour générer le
+          bilan.
+          <br />
+          Important: veuillez anonymiser les données (pas de nom et de prénom)
         </p>
         <DataEntry
           ref={dataEntryRef}

--- a/frontend/src/components/ui/creer-trame-modale.tsx
+++ b/frontend/src/components/ui/creer-trame-modale.tsx
@@ -29,10 +29,21 @@ const categories = [
   { id: 'profil_sensoriel', title: 'Profil sensoriel', icon: Brain },
 ];
 
-export default function CreerTrameModal() {
+interface CreerTrameModalProps {
+  trigger?: React.ReactNode;
+  initialCategory?: string;
+  onCreated?: (id: string) => void;
+}
+
+export default function CreerTrameModal({
+  trigger,
+  initialCategory = '',
+  onCreated,
+}: CreerTrameModalProps = {}) {
   const [open, setOpen] = useState(false);
   const [nomTrame, setNomTrame] = useState('');
-  const [categorieSelectionnee, setCategorieSelectionnee] = useState('');
+  const [categorieSelectionnee, setCategorieSelectionnee] =
+    useState(initialCategory);
   const navigate = useNavigate();
   const createSection = useSectionStore((s) => s.create);
 
@@ -42,19 +53,25 @@ export default function CreerTrameModal() {
       title: nomTrame,
       kind: categorieSelectionnee,
     });
-    navigate(`/creation-trame/${section.id}`);
+    if (onCreated) {
+      onCreated(section.id);
+    } else {
+      navigate(`/creation-trame/${section.id}`);
+    }
     setOpen(false);
     setNomTrame('');
-    setCategorieSelectionnee('');
+    setCategorieSelectionnee(initialCategory);
   };
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button className="bg-blue-600 hover:bg-blue-700 text-white ">
-          <Plus className="h-4 w-4 mr-2" />
-          Créer sa trame
-        </Button>
+        {trigger || (
+          <Button className="bg-blue-600 hover:bg-blue-700 text-white ">
+            <Plus className="h-4 w-4 mr-2" />
+            Créer sa trame
+          </Button>
+        )}
       </DialogTrigger>
       <DialogContent className="sm:max-w-md bg-white">
         <DialogHeader>

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useSectionStore } from '../store/sections';
 import type { Question } from '../types/question';
 import { Button } from '@/components/ui/button';
@@ -49,6 +49,9 @@ const typesQuestions = [
 export default function CreationTrame() {
   const { sectionId } = useParams<{ sectionId: string }>();
   const navigate = useNavigate();
+  const { state } = useLocation() as {
+    state?: { returnTo?: string; wizardSection?: string; trameId?: string };
+  };
   const fetchOne = useSectionStore((s) => s.fetchOne);
   const updateSection = useSectionStore((s) => s.update);
   const [nomTrame, setNomTrame] = useState('');
@@ -127,7 +130,13 @@ export default function CreationTrame() {
       kind: categorie,
       schema: questions,
     });
-    navigate('/bibliotheque');
+    if (state?.returnTo) {
+      navigate(state.returnTo, {
+        state: { wizardSection: state.wizardSection, trameId: sectionId },
+      });
+    } else {
+      navigate('/bibliotheque');
+    }
   };
 
   return (

--- a/frontend/src/pages/EditeurBilan.tsx
+++ b/frontend/src/pages/EditeurBilan.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useEffect, useState, Suspense, lazy, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { Button } from '../components/ui/button';
@@ -28,6 +28,9 @@ import type { RichTextEditorHandle } from '../components/RichTextEditor';
 export default function Bilan() {
   const { bilanId } = useParams<{ bilanId: string }>();
   const navigate = useNavigate();
+  const { state } = useLocation() as {
+    state?: { wizardSection?: string; trameId?: string };
+  };
   const token = useAuth((s) => s.token);
   const [bilan, setBilan] = useState<BilanData | null>(null);
   const { descriptionHtml, setHtml, reset } = useBilanDraft();
@@ -98,6 +101,8 @@ export default function Bilan() {
                 <AiRightPanel
                   bilanId={bilanId}
                   onInsertText={(text) => editorRef.current?.insertHtml(text)}
+                  initialWizardSection={state?.wizardSection}
+                  initialTrameId={state?.trameId}
                 />
               )}
             </Suspense>


### PR DESCRIPTION
## Summary
- allow customizing CreerTrameModal trigger
- display a "Créer sa trame" card in WizardAIRightPanel
- keep wizard state after creating a trame

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6889c611d0cc8329904cedaa7cd346ec