### PR TITLE
[frontend] render wizard panel in parent

### DIFF
--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -11,7 +11,6 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 
-import { Badge } from '@/components/ui/badge';
 import { Plus, Edit2 } from 'lucide-react';
 import type { Question, Answers } from '@/types/question';
 

--- a/frontend/src/pages/EditeurBilan.tsx
+++ b/frontend/src/pages/EditeurBilan.tsx
@@ -36,6 +36,9 @@ export default function Bilan() {
   const { descriptionHtml, setHtml, reset } = useBilanDraft();
   const editorRef = useRef<RichTextEditorHandle>(null);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [wizardElement, setWizardElement] = useState<React.ReactNode | null>(
+    null,
+  );
 
   const hasChanges = bilan?.descriptionHtml !== descriptionHtml;
 
@@ -103,12 +106,14 @@ export default function Bilan() {
                   onInsertText={(text) => editorRef.current?.insertHtml(text)}
                   initialWizardSection={state?.wizardSection}
                   initialTrameId={state?.trameId}
+                  onWizardChange={setWizardElement}
                 />
               )}
             </Suspense>
           </div>
         </div>
       </div>
+      {wizardElement}
       <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
         <AlertDialogContent>
           <AlertDialogHeader>


### PR DESCRIPTION
## Summary
- move WizardAIRightPanel rendering to EditeurBilan
- expose wizard output via `onWizardChange` prop in AiRightPanel
- add overlay logic for wizard
- fix lint issue in DataEntry

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_688af374071c832997174b57e1bedf76