### PR TITLE
[frontend] Refactor bilan page

### DIFF
--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -11,7 +11,6 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 
-import { Badge } from '@/components/ui/badge';
 import { Plus, Edit2 } from 'lucide-react';
 import type { Question, Answers } from '@/types/question';
 

--- a/frontend/src/components/bilans/BilansTable.tsx
+++ b/frontend/src/components/bilans/BilansTable.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface BilanItem {
+  id: string;
+  date: string;
+  patient?: { firstName: string; lastName: string };
+  bilanType?: { name: string };
+}
+
+interface BilansTableProps {
+  bilans: BilanItem[];
+  totalCount: number;
+  onRowClick: (id: string) => void;
+  onDelete: (bilan: BilanItem) => void;
+}
+
+export default function BilansTable({
+  bilans,
+  totalCount,
+  onRowClick,
+  onDelete,
+}: BilansTableProps) {
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('fr-FR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-xl font-semibold text-gray-900">
+          Historique des bilans
+        </h3>
+        <span className="text-sm text-gray-500">
+          {totalCount} bilan{totalCount > 1 ? 's' : ''}
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-32">Date</TableHead>
+              <TableHead>Nom Patient</TableHead>
+              <TableHead>Nom bilan</TableHead>
+              <TableHead className="w-10" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bilans.map((bilan) => (
+              <TableRow
+                key={bilan.id}
+                onClick={() => onRowClick(bilan.id)}
+                className="hover:bg-gray-200 cursor-pointer"
+              >
+                <TableCell className="font-medium">
+                  {formatDate(bilan.date)}
+                </TableCell>
+                <TableCell>
+                  {bilan.patient
+                    ? `${bilan.patient.firstName} ${bilan.patient.lastName}`
+                    : ''}
+                </TableCell>
+                <TableCell>{bilan.bilanType?.name ?? ''}</TableCell>
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="text-red-600"
+                    aria-label="Supprimer le bilan"
+                    onClick={() => onDelete(bilan)}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/bilans/DeleteDialog.tsx
+++ b/frontend/src/components/bilans/DeleteDialog.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteDialogProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void | Promise<void>;
+}
+
+export default function DeleteDialog({
+  open,
+  onCancel,
+  onConfirm,
+}: DeleteDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onCancel}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Supprimer ce bilan ?</AlertDialogTitle>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Annuler</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-red-600 hover:bg-red-700"
+            onClick={onConfirm}
+          >
+            Supprimer
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/bilans/EmptyState.tsx
+++ b/frontend/src/components/bilans/EmptyState.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { FileText, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface EmptyStateProps {
+  onNewPatient: () => void;
+  onExistingPatient: () => void;
+}
+
+export default function EmptyState({
+  onNewPatient,
+  onExistingPatient,
+}: EmptyStateProps) {
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-4xl mx-auto">
+        <Card className="border-2 border-dashed border-gray-200">
+          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+            <FileText className="w-16 h-16 text-gray-400 mb-6" />
+            <h2 className="text-2xl font-semibold text-gray-900 mb-2">
+              Aucun bilan disponible
+            </h2>
+            <p className="text-gray-600 mb-6 max-w-md">
+              Il semble que vous n&rsquo;ayez pas encore rédigé de bilan.
+              Commencez par en créer un nouveau.
+            </p>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button className="bg-blue-600 hover:bg-blue-700">
+                  <Plus className="w-4 h-4 mr-2" />
+                  Rédiger un nouveau bilan
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="center">
+                <DropdownMenuItem onClick={onNewPatient}>
+                  Nouveau patient
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onExistingPatient}>
+                  Patient existant
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/bilans/PaginationControls.tsx
+++ b/frontend/src/components/bilans/PaginationControls.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface PaginationControlsProps {
+  currentPage: number;
+  totalPages: number;
+  startIndex: number;
+  endIndex: number;
+  totalCount: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function PaginationControls({
+  currentPage,
+  totalPages,
+  startIndex,
+  endIndex,
+  totalCount,
+  onPageChange,
+}: PaginationControlsProps) {
+  if (totalPages <= 1) return null;
+
+  const go = (page: number) => {
+    onPageChange(Math.max(1, Math.min(page, totalPages)));
+  };
+
+  return (
+    <div className="flex items-center justify-between mt-6">
+      <div className="text-sm text-gray-500">
+        Affichage de {startIndex + 1} à {Math.min(endIndex, totalCount)} sur{' '}
+        {totalCount} bilans
+      </div>
+      <div className="flex items-center space-x-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => go(currentPage - 1)}
+          disabled={currentPage === 1}
+        >
+          <ChevronLeft className="w-4 h-4" />
+          Précédent
+        </Button>
+        <div className="flex items-center space-x-1">
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+            <Button
+              key={page}
+              variant={currentPage === page ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => go(page)}
+              className="w-8 h-8 p-0"
+            >
+              {page}
+            </Button>
+          ))}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => go(currentPage + 1)}
+          disabled={currentPage === totalPages}
+        >
+          Suivant
+          <ChevronRight className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -4,12 +4,11 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useSectionStore } from '../store/sections';
 import type { Question } from '../types/question';
-import { categories, type CategoryId } from '../types/trame';
+import { categories } from '../types/trame';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
   Select,
   SelectContent,
@@ -49,9 +48,6 @@ const typesQuestions = [
 ];
 
 export default function CreationTrame() {
-
-
-
   const { sectionId } = useParams<{ sectionId: string }>();
   const navigate = useNavigate();
   const { state } = useLocation() as {
@@ -63,7 +59,9 @@ export default function CreationTrame() {
   const [categorie, setCategorie] = useState('');
   const [questions, setQuestions] = useState<Question[]>([]);
   const [isPublic, setIsPublic] = useState(false);
-  const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(null);
+  const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(
+    null,
+  );
 
   const createDefaultNote = (): Question => ({
     id: Date.now().toString(),
@@ -71,14 +69,6 @@ export default function CreationTrame() {
     titre: 'Question sans titre',
     contenu: '',
   });
-
-  const createDefaultMultiple = (): Question => ({
-    id: Date.now().toString(),
-    type: 'choix-multiple',
-    titre: '',
-    options: ['Option 1'], // <-- default single option
-  });
-
 
   useEffect(() => {
     if (!sectionId) return;
@@ -99,28 +89,23 @@ export default function CreationTrame() {
 
   const ajouterQuestion = () => {
     const nouvelleQuestion = createDefaultNote();
-  
+
     setQuestions((qs) => {
       if (!selectedQuestionId) return [...qs, nouvelleQuestion];
-  
+
       const idx = qs.findIndex((q) => q.id === selectedQuestionId);
       if (idx === -1) return [...qs, nouvelleQuestion];
-  
-      return [
-        ...qs.slice(0, idx + 1),
-        nouvelleQuestion,
-        ...qs.slice(idx + 1),
-      ];
+
+      return [...qs.slice(0, idx + 1), nouvelleQuestion, ...qs.slice(idx + 1)];
     });
     setSelectedQuestionId(nouvelleQuestion.id);
   };
-  
-  
+
   const dupliquerQuestion = (id: string) => {
     // On trouve d'abord l'index de la question à dupliquer
-    const idx = questions.findIndex(q => q.id === id);
+    const idx = questions.findIndex((q) => q.id === id);
     if (idx === -1) return;
-  
+
     // On clone l'objet
     const original = questions[idx];
     const clone: Question = {
@@ -128,19 +113,14 @@ export default function CreationTrame() {
       id: Date.now().toString(),
       titre: 'Question sans titre',
     };
-  
+
     // On reconstruit le tableau en insérant la copie juste après l'original
     const before = questions.slice(0, idx + 1);
     const after = questions.slice(idx + 1);
-    const newList = [
-      ...before,
-      clone,
-      ...after,
-    ];
+    const newList = [...before, clone, ...after];
     setQuestions(newList);
     setSelectedQuestionId(clone.id);
   };
-  
 
   const supprimerQuestion = (id: string) => {
     setQuestions(questions.filter((q) => q.id !== id));
@@ -149,16 +129,6 @@ export default function CreationTrame() {
   const mettreAJourQuestion = (id: string, champ: string, valeur: unknown) => {
     setQuestions(
       questions.map((q) => (q.id === id ? { ...q, [champ]: valeur } : q)),
-    );
-  };
-
-  const ajouterOption = (questionId: string) => {
-    setQuestions(
-      questions.map((q) =>
-        q.id === questionId && q.options
-          ? { ...q, options: [...q.options, `Option ${q.options.length + 1}`] }
-          : q,
-      ),
     );
   };
 
@@ -207,7 +177,8 @@ export default function CreationTrame() {
             <Select
               value={categorie}
               onValueChange={(v) => setCategorie(v)}
-              className="w-48">
+              className="w-48"
+            >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Catégorie" />
               </SelectTrigger>
@@ -221,15 +192,15 @@ export default function CreationTrame() {
             </Select>
           </div>
           <Button
-              onClick={sauvegarderTrame}
-              className="ml-auto bg-blue-600 hover:bg-blue-700"
-            >
-              Sauvegarder la trame
+            onClick={sauvegarderTrame}
+            className="ml-auto bg-blue-600 hover:bg-blue-700"
+          >
+            Sauvegarder la trame
           </Button>
         </div>
 
         <div className="space-y-6">
-        <label className="flex items-center gap-2">
+          <label className="flex items-center gap-2">
             <input
               type="checkbox"
               checked={isPublic}
@@ -243,177 +214,192 @@ export default function CreationTrame() {
           {/* Liste des questions */}
           {questions.map((question, index) => (
             <div key={question.id} className="relative w-full">
-            <Card
-              onClick={() => setSelectedQuestionId(question.id)}
-              className={`w-[90%] mx-auto cursor-pointer transition-shadow ${
-                selectedQuestionId === question.id
-                  ? 'border-blue-500 ring-1 ring-blue-500 shadow-md'
-                  : ''
-              }`}
-            >
-              <CardHeader>
-                {/* Titre de la question + sélecteur de type */}
-                <div className="flex items-center gap-4">
-                  <Input
-                    className="flex-1"
-                    placeholder={`Question ${index + 1}`}
-                    value={question.titre}
-                    onChange={(e) =>
-                      mettreAJourQuestion(question.id, 'titre', e.target.value)
-                    }
-                  />
-                  {selectedQuestionId === question.id && (
-                    <Select
-                      value={question.type}
-                      onValueChange={(v) =>
-                        mettreAJourQuestion(question.id, 'type', v)
+              <Card
+                onClick={() => setSelectedQuestionId(question.id)}
+                className={`w-[90%] mx-auto cursor-pointer transition-shadow ${
+                  selectedQuestionId === question.id
+                    ? 'border-blue-500 ring-1 ring-blue-500 shadow-md'
+                    : ''
+                }`}
+              >
+                <CardHeader>
+                  {/* Titre de la question + sélecteur de type */}
+                  <div className="flex items-center gap-4">
+                    <Input
+                      className="flex-1"
+                      placeholder={`Question ${index + 1}`}
+                      value={question.titre}
+                      onChange={(e) =>
+                        mettreAJourQuestion(
+                          question.id,
+                          'titre',
+                          e.target.value,
+                        )
                       }
-                    >
-                      <SelectTrigger className="w-44">
-                        <SelectValue placeholder="Type de réponse" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {typesQuestions.map((t) => (
-                          <SelectItem key={t.id} value={t.id}>
-                            {t.title}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    />
+                    {selectedQuestionId === question.id && (
+                      <Select
+                        value={question.type}
+                        onValueChange={(v) =>
+                          mettreAJourQuestion(question.id, 'type', v)
+                        }
+                      >
+                        <SelectTrigger className="w-44">
+                          <SelectValue placeholder="Type de réponse" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {typesQuestions.map((t) => (
+                            <SelectItem key={t.id} value={t.id}>
+                              {t.title}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {question.type === 'notes' && (
+                    <div className="w-full rounded px-3 py-2 border-b border-dotted border-gray-200 text-gray-600">
+                      Réponse (prise de notes)
+                    </div>
                   )}
-                </div>
-                
-              </CardHeader>
-              <CardContent className="space-y-4">
 
-                {question.type === 'notes' && (
-                  <div className="w-full rounded px-3 py-2 border-b border-dotted border-gray-200 text-gray-600">
-                  Réponse (prise de notes)
-                  </div>
-                )}
-
-                {question.type === 'choix-multiple' && (
-                  <div>
-                    <Label>Options de réponse</Label>
-                    <div className="space-y-2">
-                      {/* Existing options as editable inputs */}
-                      {question.options?.map((option, optionIndex) => (
-                        <div key={optionIndex} className="flex items-center gap-2">
-                          <Input
-                            value={option}
-                            onChange={(e) => {
-                              const opts = [...(question.options || [])];
-                              opts[optionIndex] = e.target.value;
-                              mettreAJourQuestion(question.id, 'options', opts);
-                            }}
-                          />
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => supprimerOption(question.id, optionIndex)}
+                  {question.type === 'choix-multiple' && (
+                    <div>
+                      <Label>Options de réponse</Label>
+                      <div className="space-y-2">
+                        {/* Existing options as editable inputs */}
+                        {question.options?.map((option, optionIndex) => (
+                          <div
+                            key={optionIndex}
+                            className="flex items-center gap-2"
                           >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      ))}
+                            <Input
+                              value={option}
+                              onChange={(e) => {
+                                const opts = [...(question.options || [])];
+                                opts[optionIndex] = e.target.value;
+                                mettreAJourQuestion(
+                                  question.id,
+                                  'options',
+                                  opts,
+                                );
+                              }}
+                            />
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                supprimerOption(question.id, optionIndex)
+                              }
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        ))}
 
-                      {/* Modified: inline add field */}
-                      <Input
-                        placeholder="Ajouter une option"
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' && e.currentTarget.value.trim()) {
-                            const nouvelleOpt = e.currentTarget.value.trim();
-                            const opts = [...(question.options || []), nouvelleOpt];
-                            mettreAJourQuestion(question.id, 'options', opts);
-                            e.currentTarget.value = '';
+                        {/* Modified: inline add field */}
+                        <Input
+                          placeholder="Ajouter une option"
+                          onKeyDown={(e) => {
+                            if (
+                              e.key === 'Enter' &&
+                              e.currentTarget.value.trim()
+                            ) {
+                              const nouvelleOpt = e.currentTarget.value.trim();
+                              const opts = [
+                                ...(question.options || []),
+                                nouvelleOpt,
+                              ];
+                              mettreAJourQuestion(question.id, 'options', opts);
+                              e.currentTarget.value = '';
+                            }
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {question.type === 'echelle' && (
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label htmlFor={`min-${question.id}`}>
+                          Valeur minimum
+                        </Label>
+                        <Input
+                          id={`min-${question.id}`}
+                          type="number"
+                          value={question.echelle?.min || 1}
+                          onChange={(e) =>
+                            mettreAJourQuestion(question.id, 'echelle', {
+                              ...question.echelle,
+                              min: Number.parseInt(e.target.value),
+                            })
                           }
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor={`max-${question.id}`}>
+                          Valeur maximum
+                        </Label>
+                        <Input
+                          id={`max-${question.id}`}
+                          type="number"
+                          value={question.echelle?.max || 5}
+                          onChange={(e) =>
+                            mettreAJourQuestion(question.id, 'echelle', {
+                              ...question.echelle,
+                              max: Number.parseInt(e.target.value),
+                            })
+                          }
+                        />
+                      </div>
+                    </div>
+                  )}
+                  {/* Icônes Dupliquer / Supprimer en bas */}
+                  {selectedQuestionId === question.id && (
+                    <div className="flex justify-end gap-2 pt-4">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          dupliquerQuestion(question.id);
                         }}
-                      />
+                      >
+                        <Copy className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          supprimerQuestion(question.id);
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </div>
-                  </div>
-                )}
+                  )}
+                </CardContent>
+              </Card>
 
-                {question.type === 'echelle' && (
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor={`min-${question.id}`}>
-                        Valeur minimum
-                      </Label>
-                      <Input
-                        id={`min-${question.id}`}
-                        type="number"
-                        value={question.echelle?.min || 1}
-                        onChange={(e) =>
-                          mettreAJourQuestion(question.id, 'echelle', {
-                            ...question.echelle,
-                            min: Number.parseInt(e.target.value),
-                          })
-                        }
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor={`max-${question.id}`}>
-                        Valeur maximum
-                      </Label>
-                      <Input
-                        id={`max-${question.id}`}
-                        type="number"
-                        value={question.echelle?.max || 5}
-                        onChange={(e) =>
-                          mettreAJourQuestion(question.id, 'echelle', {
-                            ...question.echelle,
-                            max: Number.parseInt(e.target.value),
-                          })
-                        }
-                      />
-                    </div>
-                  </div>
-                )}
-              {/* Icônes Dupliquer / Supprimer en bas */}
               {selectedQuestionId === question.id && (
-                <div className="flex justify-end gap-2 pt-4">
+                <div className="absolute top-1/2 -translate-y-1/2 -right-4">
                   <Button
-                    variant="outline"
-                    size="sm"
+                    variant="primary"
+                    size="icon"
                     onClick={(e) => {
                       e.stopPropagation();
-                      dupliquerQuestion(question.id);
+                      ajouterQuestion();
                     }}
                   >
-                    <Copy className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      supprimerQuestion(question.id);
-                    }}
-                  >
-                    <Trash2 className="h-4 w-4" />
+                    <Plus className="h-6 w-6 text-white" />
                   </Button>
                 </div>
               )}
-            </CardContent>
-          </Card>
-
-
-            {selectedQuestionId === question.id && (
-              <div className="absolute top-1/2 -translate-y-1/2 -right-4">
-                <Button
-                  variant="primary"
-                  size="icon"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    ajouterQuestion();
-                  }}
-                >
-                  <Plus className="h-6 w-6 text-white" />
-                </Button>
-              </div>
-            )}
-          </div>
-          
+            </div>
           ))}
 
           {/* Actions */}
@@ -421,7 +407,7 @@ export default function CreationTrame() {
             <Button variant="outline" onClick={() => navigate(-1)}>
               Annuler
             </Button>
-            
+
             <Button
               onClick={sauvegarderTrame}
               className="bg-blue-600 hover:bg-blue-700"

--- a/frontend/src/pages/MesBilans.tsx
+++ b/frontend/src/pages/MesBilans.tsx
@@ -1,37 +1,18 @@
 'use client';
 
-import {
-  FileText,
-  Plus,
-  ChevronLeft,
-  ChevronRight,
-  Trash2,
-} from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import EmptyState from '@/components/bilans/EmptyState';
+import BilansTable from '@/components/bilans/BilansTable';
+import PaginationControls from '@/components/bilans/PaginationControls';
+import DeleteDialog from '@/components/bilans/DeleteDialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { NewPatientModal } from '@/components/ui/new-patient-modal';
 import { ExistingPatientModal } from '@/components/ui/existing-patient-modal';
 import { useAuth } from '../store/auth';
@@ -85,15 +66,6 @@ export default function Component() {
     setBilans((prev) => prev.filter((b) => b.id !== id));
   };
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('fr-FR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    });
-  };
-
   // Calculs pour la pagination
   const totalPages = Math.ceil(bilans.length / bilansPerPage);
   const startIndex = (currentPage - 1) * bilansPerPage;
@@ -107,42 +79,10 @@ export default function Component() {
   // État vide - aucun bilan
   if (bilans.length === 0) {
     return (
-      <div className="min-h-screen bg-gray-50 p-6">
-        <div className="max-w-4xl mx-auto">
-          <Card className="border-2 border-dashed border-gray-200">
-            <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-              <FileText className="w-16 h-16 text-gray-400 mb-6" />
-              <h2 className="text-2xl font-semibold text-gray-900 mb-2">
-                Aucun bilan disponible
-              </h2>
-              <p className="text-gray-600 mb-6 max-w-md">
-                Il semble que vous n&rsquo;ayez pas encore rédigé de bilan.
-                Commencez par en créer un nouveau.
-              </p>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button className="bg-blue-600 hover:bg-blue-700">
-                    <Plus className="w-4 h-4 mr-2" />
-                    Rédiger un nouveau bilan
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="center">
-                  <DropdownMenuItem
-                    onClick={() => setIsNewPatientModalOpen(true)}
-                  >
-                    Nouveau patient
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => setIsExistingPatientModalOpen(true)}
-                  >
-                    Patient existant
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
+      <EmptyState
+        onNewPatient={() => setIsNewPatientModalOpen(true)}
+        onExistingPatient={() => setIsExistingPatientModalOpen(true)}
+      />
     );
   }
 
@@ -193,107 +133,20 @@ export default function Component() {
           {/* Tableau des bilans */}
           <Card>
             <CardContent className="p-6">
-              <div className="flex items-center justify-between mb-6">
-                <h3 className="text-xl font-semibold text-gray-900">
-                  Historique des bilans
-                </h3>
-                <span className="text-sm text-gray-500">
-                  {bilans.length} bilan{bilans.length > 1 ? 's' : ''}
-                </span>
-              </div>
-
-              <div className="overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-32">Date</TableHead>
-                      <TableHead>Nom Patient</TableHead>
-                      <TableHead>Nom bilan</TableHead>
-                      <TableHead className="w-10" />
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {currentBilansPage.map((bilan) => (
-                      <TableRow
-                        key={bilan.id}
-                        onClick={() => navigate(`/bilan/${bilan.id}`)}
-                        className="hover:bg-gray-200 cursor-pointer"
-                      >
-                        <TableCell className="font-medium">
-                          {formatDate(bilan.date)}
-                        </TableCell>
-                        <TableCell>
-                          {bilan.patient
-                            ? `${bilan.patient.firstName} ${bilan.patient.lastName}`
-                            : ''}
-                        </TableCell>
-                        <TableCell>{bilan.bilanType?.name ?? ''}</TableCell>
-                        <TableCell onClick={(e) => e.stopPropagation()}>
-                          <Button
-                            size="icon"
-                            variant="ghost"
-                            className="text-red-600"
-                            aria-label="Supprimer le bilan"
-                            onClick={() => setToDelete(bilan)}
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-
-              {/* Pagination */}
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between mt-6">
-                  <div className="text-sm text-gray-500">
-                    Affichage de {startIndex + 1} à{' '}
-                    {Math.min(endIndex, bilans.length)} sur {bilans.length}{' '}
-                    bilans
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => goToPage(currentPage - 1)}
-                      disabled={currentPage === 1}
-                    >
-                      <ChevronLeft className="w-4 h-4" />
-                      Précédent
-                    </Button>
-
-                    <div className="flex items-center space-x-1">
-                      {Array.from({ length: totalPages }, (_, i) => i + 1).map(
-                        (page) => (
-                          <Button
-                            key={page}
-                            variant={
-                              currentPage === page ? 'default' : 'outline'
-                            }
-                            size="sm"
-                            onClick={() => goToPage(page)}
-                            className="w-8 h-8 p-0"
-                          >
-                            {page}
-                          </Button>
-                        ),
-                      )}
-                    </div>
-
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => goToPage(currentPage + 1)}
-                      disabled={currentPage === totalPages}
-                    >
-                      Suivant
-                      <ChevronRight className="w-4 h-4" />
-                    </Button>
-                  </div>
-                </div>
-              )}
+              <BilansTable
+                bilans={currentBilansPage}
+                totalCount={bilans.length}
+                onRowClick={(id) => navigate(`/bilan/${id}`)}
+                onDelete={(b) => setToDelete(b)}
+              />
+              <PaginationControls
+                currentPage={currentPage}
+                totalPages={totalPages}
+                startIndex={startIndex}
+                endIndex={endIndex}
+                totalCount={bilans.length}
+                onPageChange={goToPage}
+              />
             </CardContent>
           </Card>
         </div>
@@ -308,27 +161,16 @@ export default function Component() {
         onClose={() => setIsExistingPatientModalOpen(false)}
         onPatientSelected={createBilan}
       />
-      <AlertDialog open={!!toDelete} onOpenChange={() => setToDelete(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Supprimer ce bilan ?</AlertDialogTitle>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Annuler</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-red-600 hover:bg-red-700"
-              onClick={async () => {
-                if (toDelete) {
-                  await removeBilan(toDelete.id);
-                  setToDelete(null);
-                }
-              }}
-            >
-              Supprimer
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteDialog
+        open={!!toDelete}
+        onCancel={() => setToDelete(null)}
+        onConfirm={async () => {
+          if (toDelete) {
+            await removeBilan(toDelete.id);
+            setToDelete(null);
+          }
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- extract EmptyState, BilansTable, PaginationControls and DeleteDialog components
- refactor MesBilans page to use those components
- clean unused code in DataEntry and CreationTrame

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_688b896433cc8329a3ddb3297814c6e3