### PR TITLE
[frontend] add virtual selection overlay

### DIFF
--- a/frontend/src/hooks/useVirtualSelection.ts
+++ b/frontend/src/hooks/useVirtualSelection.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+import { useEditorUi } from '../store/editorUi';
+
+export function useVirtualSelection(editorRef: React.RefObject<HTMLElement>) {
+  const setSelection = useEditorUi((s) => s.setSelection);
+
+  useEffect(() => {
+    const onChange = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const r = sel.getRangeAt(0);
+      if (!editorRef.current?.contains(r.commonAncestorContainer)) return;
+      if (sel.isCollapsed) return;
+
+      const clone = r.cloneRange();
+      const rects = typeof clone.getClientRects === 'function'
+        ? Array.from(clone.getClientRects())
+        : [];
+      const text = sel.toString();
+
+      const htmlFragment = (() => {
+        const frag = clone.cloneContents();
+        const div = document.createElement('div');
+        div.appendChild(frag);
+        return div.innerHTML;
+      })();
+
+      const restore = () => {
+        try {
+          const s = window.getSelection();
+          s?.removeAllRanges();
+          s?.addRange(clone);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
+      const clear = () => setSelection(null);
+
+      setSelection({ rects, text, htmlFragment, restore, clear });
+    };
+
+    document.addEventListener('selectionchange', onChange);
+    return () => document.removeEventListener('selectionchange', onChange);
+  }, [editorRef, setSelection]);
+}

--- a/frontend/src/store/editorUi.test.ts
+++ b/frontend/src/store/editorUi.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useEditorUi, type SelectionSnapshot } from './editorUi';
+
+describe('useEditorUi', () => {
+  it('updates mode and selection', () => {
+    const restore = vi.fn();
+    const snap: SelectionSnapshot = {
+      rects: [],
+      text: 't',
+      htmlFragment: '<p>t</p>',
+      restore,
+      clear: vi.fn(),
+    };
+
+    useEditorUi.setState({ mode: 'idle', selection: null, aiBlockId: null });
+    useEditorUi.getState().setMode('suggest');
+    expect(useEditorUi.getState().mode).toBe('suggest');
+
+    useEditorUi.getState().setSelection(snap);
+    expect(useEditorUi.getState().selection).toBe(snap);
+  });
+});

--- a/frontend/src/store/editorUi.ts
+++ b/frontend/src/store/editorUi.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+export type Mode = 'idle' | 'suggest' | 'refine';
+
+export interface SelectionSnapshot {
+  rects: DOMRect[];
+  text: string;
+  htmlFragment: string;
+  restore: () => boolean;
+  clear: () => void;
+}
+
+interface EditorUiState {
+  mode: Mode;
+  selection: SelectionSnapshot | null;
+  aiBlockId: string | null;
+  setMode: (m: Mode) => void;
+  setSelection: (s: SelectionSnapshot | null) => void;
+  setAiBlockId: (id: string | null) => void;
+}
+
+export const useEditorUi = create<EditorUiState>((set) => ({
+  mode: 'idle',
+  selection: null,
+  aiBlockId: null,
+  setMode: (m) => set({ mode: m }),
+  setSelection: (s) => set({ selection: s }),
+  setAiBlockId: (id) => set({ aiBlockId: id }),
+}));


### PR DESCRIPTION
## Summary
- add Zustand store for editor UI state
- create `useVirtualSelection` hook to capture native selections
- overlay highlights selections in `RichTextEditor`
- basic unit test for the new store

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_688bc085aa088329bd6547e97718ae48