### PR TITLE
[frontend] add results table question type

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -209,7 +209,7 @@ export default function AiRightPanel({
         {selection?.text && (
           <div className="bg-blue-50 text-blue-800 text-sm p-2 border-b border-blue-100">
             <div className="font-medium mb-1">Texte sélectionné :</div>
-            <div className="italic truncate">"{selection.text}"</div>
+            <div className="italic truncate">&quot;{selection.text}&quot;</div>
           </div>
         )}
         <div className="sticky top-0 z-10 flex items-center justify-between bg-white border-b border-gray-200 px-4 py-2 h-14">

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -20,6 +20,13 @@ const scaleQuestion: Question = {
   echelle: { min: 1, max: 5 },
 };
 
+const tableQuestion: Question = {
+  id: '3',
+  type: 'tableau',
+  titre: 'Table',
+  tableau: { lignes: ['L1', 'L2'] },
+};
+
 describe('DataEntry', () => {
   it('renders multiple choice options as buttons', () => {
     render(<DataEntry questions={[mcQuestion]} answers={{}} onChange={noop} />);
@@ -67,5 +74,17 @@ describe('DataEntry', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Opt1' }));
     ref.current?.save();
     expect(handle).toHaveBeenCalledWith({ [mcQuestion.id]: 'Opt1' });
+  });
+
+  it('renders table rows', () => {
+    render(
+      <DataEntry
+        questions={[tableQuestion]}
+        answers={{}}
+        onChange={noop}
+        inline
+      />,
+    );
+    expect(screen.getAllByRole('textbox').length).toBe(2);
   });
 });

--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -117,6 +117,31 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
               )}
             </div>
           );
+        case 'tableau':
+          return (
+            <div className="space-y-2">
+              {q.tableau?.lignes?.map((ligne) => (
+                <div key={ligne} className="flex items-center gap-2">
+                  <Label className="flex-1 text-xs">{ligne}</Label>
+                  <Input
+                    value={
+                      (value as Record<string, string | number> | undefined)?.[
+                        ligne
+                      ] ?? ''
+                    }
+                    onChange={(e) => {
+                      const current =
+                        (local[q.id] as
+                          | Record<string, string | number>
+                          | undefined) || {};
+                      const updated = { ...current, [ligne]: e.target.value };
+                      setLocal({ ...local, [q.id]: updated });
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          );
         default:
           return null;
       }

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -24,6 +24,7 @@ import {
   FileText,
   CheckSquare,
   BarChart3,
+  Table,
 } from 'lucide-react';
 
 const typesQuestions = [
@@ -44,6 +45,12 @@ const typesQuestions = [
     title: 'Échelle chiffrée',
     icon: BarChart3,
     description: 'Évaluation sur une échelle numérique',
+  },
+  {
+    id: 'tableau',
+    title: 'Tableaux de résultats',
+    icon: Table,
+    description: 'Liste de lignes avec notation',
   },
 ];
 
@@ -137,6 +144,21 @@ export default function CreationTrame() {
       questions.map((q) =>
         q.id === questionId && q.options
           ? { ...q, options: q.options.filter((_, i) => i !== index) }
+          : q,
+      ),
+    );
+  };
+
+  const supprimerLigne = (questionId: string, index: number) => {
+    setQuestions(
+      questions.map((q) =>
+        q.id === questionId && q.tableau?.lignes
+          ? {
+              ...q,
+              tableau: {
+                lignes: q.tableau.lignes.filter((_, i) => i !== index),
+              },
+            }
           : q,
       ),
     );
@@ -353,6 +375,61 @@ export default function CreationTrame() {
                               max: Number.parseInt(e.target.value),
                             })
                           }
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {question.type === 'tableau' && (
+                    <div>
+                      <Label>Lignes du tableau</Label>
+                      <div className="space-y-2">
+                        {question.tableau?.lignes?.map((ligne, ligneIdx) => (
+                          <div
+                            key={ligneIdx}
+                            className="flex items-center gap-2"
+                          >
+                            <Input
+                              value={ligne}
+                              onChange={(e) => {
+                                const lignes = [
+                                  ...(question.tableau?.lignes || []),
+                                ];
+                                lignes[ligneIdx] = e.target.value;
+                                mettreAJourQuestion(question.id, 'tableau', {
+                                  lignes,
+                                });
+                              }}
+                            />
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                supprimerLigne(question.id, ligneIdx)
+                              }
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        ))}
+                        <Input
+                          placeholder="Ajouter une ligne"
+                          onKeyDown={(e) => {
+                            if (
+                              e.key === 'Enter' &&
+                              e.currentTarget.value.trim()
+                            ) {
+                              const nouvelle = e.currentTarget.value.trim();
+                              const lignes = [
+                                ...(question.tableau?.lignes || []),
+                                nouvelle,
+                              ];
+                              mettreAJourQuestion(question.id, 'tableau', {
+                                lignes,
+                              });
+                              e.currentTarget.value = '';
+                            }
+                          }}
                         />
                       </div>
                     </div>

--- a/frontend/src/types/question.ts
+++ b/frontend/src/types/question.ts
@@ -1,10 +1,14 @@
 export interface Question {
   id: string;
-  type: 'notes' | 'choix-multiple' | 'echelle';
+  type: 'notes' | 'choix-multiple' | 'echelle' | 'tableau';
   titre: string;
   contenu?: string;
   options?: string[];
   echelle?: { min: number; max: number; labels?: { min: string; max: string } };
+  tableau?: { lignes: string[] };
 }
 
-export type Answers = Record<string, string | string[] | number>;
+export type Answers = Record<
+  string,
+  string | string[] | number | Record<string, string | number>
+>;


### PR DESCRIPTION
## Summary
- add new `tableau` question type for results tables
- allow editing table lines with removable rows
- handle table answers in `DataEntry`
- update DataEntry tests for the new type
- fix quoting bug in `AiRightPanel`

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`

------
https://chatgpt.com/codex/tasks/task_e_688c4c21bee483299b32a0974b3c4cb4