### PR TITLE
[frontend] add Import Magique feature

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import { patientRouter } from './routes/patient.routes';
 import { bilanRouter } from './routes/bilan.routes';
 import { sectionRouter } from './routes/section.routes';
 import { sectionExampleRouter } from './routes/sectionExample.routes';
+import { importRouter } from './routes/import.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -83,6 +84,7 @@ app.use('/api/v1/bilans', bilanRouter);
 app.use('/api/v1/profile', profileRouter);
 app.use('/api/v1/sections', sectionRouter);
 app.use('/api/v1/section-examples', sectionExampleRouter);
+app.use('/api/v1/import', importRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/controllers/import.controller.ts
+++ b/backend/src/controllers/import.controller.ts
@@ -1,0 +1,23 @@
+import type { Request, Response, NextFunction } from 'express';
+import { generateText } from '../services/ai/generate.service';
+
+export const ImportController = {
+  async transform(req: Request, res: Response, next: NextFunction) {
+    try {
+      const content = String(req.body.content || '');
+      const text = (await generateText({
+        instructions: 'transforme en liste de questions',
+        userContent: content,
+      })) as string;
+      let result: unknown;
+      try {
+        result = JSON.parse(text);
+      } catch {
+        result = text;
+      }
+      res.json({ result });
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/import.routes.ts
+++ b/backend/src/routes/import.routes.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { ImportController } from '../controllers/import.controller';
+
+export const importRouter = Router();
+
+importRouter.post('/transform', ImportController.transform);

--- a/backend/src/services/ai/prompts/promptconfig.ts
+++ b/backend/src/services/ai/prompts/promptconfig.ts
@@ -48,5 +48,9 @@ export const promptConfigs = {
   2. Utilise un ton descriptif, nuancé et factuel.
       `.trim(),
     },
+    transformationImport: {
+      title: "Transformation Import",
+      instructions: `transforme en liste de questions`.trim(),
+    },
   } as const;
   

--- a/backend/tests/import.routes.test.ts
+++ b/backend/tests/import.routes.test.ts
@@ -1,0 +1,23 @@
+import request from 'supertest';
+import app from '../src/app';
+import { generateText } from '../src/services/ai/generate.service';
+
+jest.mock('../src/services/ai/generate.service');
+
+const mockedGenerate = generateText as jest.MockedFunction<typeof generateText>;
+
+describe('POST /api/v1/import/transform', () => {
+  it('calls ai service with content', async () => {
+    mockedGenerate.mockResolvedValueOnce('["q1"]');
+    const res = await request(app)
+      .post('/api/v1/import/transform')
+      .send({ content: 'txt' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ result: ['q1'] });
+    expect(mockedGenerate).toHaveBeenCalledWith({
+      instructions: 'transforme en liste de questions',
+      userContent: 'txt',
+    });
+  });
+});

--- a/frontend/src/components/ImportMagique.tsx
+++ b/frontend/src/components/ImportMagique.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import {
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { apiFetch } from '@/utils/api';
+import { useAuth } from '@/store/auth';
+import type { Question } from '@/types/question';
+
+interface ImportMagiqueProps {
+  onDone: (questions: Question[]) => void;
+  onCancel: () => void;
+}
+
+export default function ImportMagique({
+  onDone,
+  onCancel,
+}: ImportMagiqueProps) {
+  const [text, setText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const token = useAuth((s) => s.token);
+
+  const handle = async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch<{ result: Question[] }>(
+        '/api/v1/import/transform',
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ content: text }),
+        },
+      );
+      onDone(res.result);
+    } finally {
+      setLoading(false);
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <DialogHeader>
+        <DialogTitle>Importe ta trame magiquement</DialogTitle>
+      </DialogHeader>
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        className="min-h-60"
+      />
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel} type="button">
+          Annuler
+        </Button>
+        <Button onClick={handle} disabled={loading || !text} type="button">
+          Transformer
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -24,7 +24,7 @@ const tableQuestion: Question = {
   id: '3',
   type: 'tableau',
   titre: 'Table',
-  tableau: { lignes: ['L1', 'L2'] },
+  tableau: { lignes: ['L1', 'L2'], colonnes: ['C1'] },
 };
 
 describe('DataEntry', () => {

--- a/frontend/src/pages/CreationTrame.test.tsx
+++ b/frontend/src/pages/CreationTrame.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import CreationTrame from './CreationTrame';
+import { useSectionStore } from '../store/sections';
+import { vi } from 'vitest';
+
+it('shows import magique button', () => {
+  useSectionStore.setState({
+    fetchOne: vi.fn().mockResolvedValue({ title: '', kind: '', schema: [] }),
+    update: vi.fn(),
+  });
+  render(
+    <MemoryRouter initialEntries={['/creation-trame/1']}>
+      <Routes>
+        <Route path="/creation-trame/:sectionId" element={<CreationTrame />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  expect(
+    screen.getByRole('button', { name: /import magique/i }),
+  ).toBeInTheDocument();
+});

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -16,6 +16,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import ImportMagique from '@/components/ImportMagique';
 import {
   ArrowLeft,
   Copy,
@@ -69,6 +71,7 @@ export default function CreationTrame() {
   const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(
     null,
   );
+  const [showImport, setShowImport] = useState(false);
 
   const createDefaultNote = (): Question => ({
     id: Date.now().toString(),
@@ -249,6 +252,9 @@ export default function CreationTrame() {
             className="ml-auto bg-blue-600 hover:bg-blue-700"
           >
             Sauvegarder la trame
+          </Button>
+          <Button variant="outline" onClick={() => setShowImport(true)}>
+            Import Magique
           </Button>
         </div>
 
@@ -593,6 +599,14 @@ export default function CreationTrame() {
           </div>
         </div>
       </div>
+      <Dialog open={showImport} onOpenChange={setShowImport}>
+        <DialogContent>
+          <ImportMagique
+            onDone={(qs) => setQuestions(qs)}
+            onCancel={() => setShowImport(false)}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add new ImportMagique component to transform pasted text
- wire Import Magique dialog into CreationTrame page
- expose import transformation endpoint on backend
- add prompt configuration and controller for TransformationImport
- test new API and update DataEntry test

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter backend run test`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_688c56a513888329a60ecb8aa410dfc4