### PR TITLE
[frontend] add example input with preview

### DIFF
--- a/frontend/src/components/ImportMagique.tsx
+++ b/frontend/src/components/ImportMagique.tsx
@@ -1,11 +1,7 @@
 import { useState } from 'react';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
-import {
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from '@/components/ui/dialog';
+import { DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { apiFetch } from '@/utils/api';
 import { useAuth } from '@/store/auth';
 import type { Question } from '@/types/question';
@@ -60,12 +56,17 @@ export default function ImportMagique({
       </div>
       <div className="px-6 py-4 border-t bg-muted/20">
         <div className="flex justify-end gap-3">
-          <Button variant="outline" onClick={onCancel} type="button" className="min-w-[100px]">
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            type="button"
+            className="min-w-[100px]"
+          >
             Annuler
           </Button>
-          <Button 
-            onClick={handle} 
-            disabled={loading || !text.trim()} 
+          <Button
+            onClick={handle}
+            disabled={loading || !text.trim()}
             type="button"
             className="min-w-[120px]"
           >

--- a/frontend/src/components/SaisieExempleTrame.test.tsx
+++ b/frontend/src/components/SaisieExempleTrame.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import SaisieExempleTrame from './SaisieExempleTrame';
+
+it('adds example on button click', () => {
+  const handle = vi.fn();
+  render(<SaisieExempleTrame examples={[]} onAdd={handle} />);
+  fireEvent.change(screen.getByRole('textbox'), {
+    target: { value: 'exemple' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /ajouter un exemple/i }));
+  expect(handle).toHaveBeenCalledWith('exemple');
+});

--- a/frontend/src/components/SaisieExempleTrame.tsx
+++ b/frontend/src/components/SaisieExempleTrame.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface SaisieExempleTrameProps {
+  examples: string[];
+  onAdd: (content: string) => void;
+}
+
+export default function SaisieExempleTrame({
+  examples,
+  onAdd,
+}: SaisieExempleTrameProps) {
+  const [text, setText] = useState('');
+
+  const add = () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setText('');
+  };
+
+  return (
+    <div className="space-y-4">
+      {examples.length > 0 && (
+        <div className="space-y-2">
+          {examples.map((e, idx) => (
+            <div
+              key={idx}
+              className="p-2 border rounded bg-gray-50 whitespace-pre-wrap"
+            >
+              {e}
+            </div>
+          ))}
+        </div>
+      )}
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Coller votre exemple ici"
+        className="min-h-32"
+      />
+      <Button
+        onClick={add}
+        disabled={!text.trim()}
+        className="bg-blue-600 hover:bg-blue-700"
+      >
+        Ajouter un exemple
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/confirm-dialog.tsx
+++ b/frontend/src/components/ui/confirm-dialog.tsx
@@ -13,7 +13,13 @@ interface ConfirmDialogProps {
   title: string;
   confirmText?: string;
   cancelText?: string;
-  confirmVariant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+  confirmVariant?:
+    | 'default'
+    | 'destructive'
+    | 'outline'
+    | 'secondary'
+    | 'ghost'
+    | 'link';
   onConfirm: () => void;
   onOpenChange: (open: boolean) => void;
 }
@@ -21,7 +27,7 @@ interface ConfirmDialogProps {
 export function ConfirmDialog({
   open,
   title,
-  confirmText = 'Confirmer',
+  confirmText = 'Supprimer',
   cancelText = 'Annuler',
   confirmVariant = 'destructive',
   onConfirm,
@@ -41,7 +47,11 @@ export function ConfirmDialog({
         <AlertDialogFooter>
           <AlertDialogCancel>{cancelText}</AlertDialogCancel>
           <AlertDialogAction
-            className={confirmVariant === 'destructive' ? 'bg-red-600 hover:bg-red-700 text-white' : ''}
+            className={
+              confirmVariant === 'destructive'
+                ? 'bg-red-600 hover:bg-red-700 text-white'
+                : ''
+            }
             onClick={handleConfirm}
           >
             {confirmText}

--- a/frontend/src/pages/CreationTrame.test.tsx
+++ b/frontend/src/pages/CreationTrame.test.tsx
@@ -4,7 +4,7 @@ import CreationTrame from './CreationTrame';
 import { useSectionStore } from '../store/sections';
 import { vi } from 'vitest';
 
-it('shows import magique button', () => {
+it('shows navigation tabs', () => {
   useSectionStore.setState({
     fetchOne: vi.fn().mockResolvedValue({ title: '', kind: '', schema: [] }),
     update: vi.fn(),
@@ -19,4 +19,11 @@ it('shows import magique button', () => {
   expect(
     screen.getByRole('button', { name: /import magique/i }),
   ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /Questions/i }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /Pré-visualisation/i }),
+  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Exemples/i })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add an example input component
- connect `CreationTrame` to section examples
- show preview tab with `DataEntry`
- expose tab navigation in creation page
- adjust confirm dialog default text

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_688c701f86e08329987a196343c81252