### PR TITLE
[frontend] add title question type

### DIFF
--- a/backend/src/services/ai/prompts/transformPrompt.ts
+++ b/backend/src/services/ai/prompts/transformPrompt.ts
@@ -19,7 +19,7 @@ const ITEM_SCHEMA = {
         id: { type: 'string' },
         type: {
           type: 'string',
-          enum: ['notes', 'choix-multiple', 'echelle'],
+          enum: ['notes', 'choix-multiple', 'echelle', 'titre'],
         },
         titre: { type: 'string' },
         contenu: { type: 'string' },
@@ -60,13 +60,14 @@ export function buildTransformPrompt(params: TransformPromptParams): SingleMessa
     })
   }
 
-  const defaultInstr = `
+   const defaultInstr = `
 Pour chaque question en entrée :
 1. Génère un **id** unique basé sur un timestamp en millisecondes (format string).
 2. Détecte le **type** :
    - "notes" si question ouverte.
    - "choix-multiple" si tu trouves des options entre parenthèses ou séparées par des virgules.
    - "echelle" si tu repères une mention d'échelle (1-5, 1-10, etc.).
+   - "titre" si c'est uniquement un titre sans contenu associé.
   `.trim()
   msgs.push({
     role: 'user',

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -27,6 +27,12 @@ const tableQuestion: Question = {
   tableau: { lignes: ['L1', 'L2'], colonnes: ['C1'] },
 };
 
+const titleQuestion: Question = {
+  id: '4',
+  type: 'titre',
+  titre: 'Titre Section',
+};
+
 describe('DataEntry', () => {
   it('renders multiple choice options as buttons', () => {
     render(<DataEntry questions={[mcQuestion]} answers={{}} onChange={noop} />);
@@ -86,5 +92,19 @@ describe('DataEntry', () => {
       />,
     );
     expect(screen.getAllByRole('textbox').length).toBe(2);
+  });
+
+  it('renders heading for title question', () => {
+    render(
+      <DataEntry
+        questions={[titleQuestion]}
+        answers={{}}
+        onChange={noop}
+        inline
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Titre Section' }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -120,44 +120,56 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
         case 'tableau':
           // Safely handle the type conversion for table data
           let data: Record<string, Record<string, string>> = {};
-          if (local[q.id] && typeof local[q.id] === 'object' && !Array.isArray(local[q.id])) {
+          if (
+            local[q.id] &&
+            typeof local[q.id] === 'object' &&
+            !Array.isArray(local[q.id])
+          ) {
             data = local[q.id] as Record<string, Record<string, string>>;
           }
-            return (
-              <table className="w-full table-fixed border-collapse">
-                <thead>
-                  <tr>
-                    <th className="px-2 py-1"></th>
+          return (
+            <table className="w-full table-fixed border-collapse">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1"></th>
+                  {q.tableau?.colonnes?.map((col) => (
+                    <th
+                      key={col}
+                      className="px-2 py-1 text-xs font-medium text-left"
+                    >
+                      {col}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {q.tableau?.lignes?.map((ligne) => (
+                  <tr key={ligne}>
+                    <td className="px-2 py-1 text-xs font-medium">{ligne}</td>
                     {q.tableau?.colonnes?.map((col) => (
-                      <th key={col} className="px-2 py-1 text-xs font-medium text-left">
-                        {col}
-                      </th>
+                      <td key={col} className="px-2 py-1">
+                        <Input
+                          size="sm"
+                          value={data[ligne]?.[col] ?? ''}
+                          onChange={(e) => {
+                            const row = data[ligne] || {};
+                            const updatedRow = {
+                              ...row,
+                              [col]: e.target.value,
+                            };
+                            const updated = { ...data, [ligne]: updatedRow };
+                            setLocal({ ...local, [q.id]: updated });
+                          }}
+                        />
+                      </td>
                     ))}
                   </tr>
-                </thead>
-                <tbody>
-                  {q.tableau?.lignes?.map((ligne) => (
-                    <tr key={ligne}>
-                      <td className="px-2 py-1 text-xs font-medium">{ligne}</td>
-                      {q.tableau?.colonnes?.map((col) => (
-                        <td key={col} className="px-2 py-1">
-                          <Input
-                            size="sm"
-                            value={data[ligne]?.[col] ?? ''}
-                            onChange={(e) => {
-                              const row = data[ligne] || {};
-                              const updatedRow = { ...row, [col]: e.target.value };
-                              const updated = { ...data, [ligne]: updatedRow };
-                              setLocal({ ...local, [q.id]: updated });
-                            }}
-                          />
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            );
+                ))}
+              </tbody>
+            </table>
+          );
+        case 'titre':
+          return null;
         default:
           return null;
       }
@@ -172,8 +184,14 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
               q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
             }`}
           >
-            <Label className="text-sm font-medium">{q.titre}</Label>
-            {renderQuestion(q)}
+            {q.type === 'titre' ? (
+              <h3 className="text-lg font-semibold">{q.titre}</h3>
+            ) : (
+              <>
+                <Label className="text-sm font-medium">{q.titre}</Label>
+                {renderQuestion(q)}
+              </>
+            )}
           </div>
         ))}
       </div>
@@ -213,8 +231,14 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                       q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
                     }`}
                   >
-                    <Label className="text-sm font-medium">{q.titre}</Label>
-                    {renderQuestion(q)}
+                    {q.type === 'titre' ? (
+                      <h3 className="text-lg font-semibold">{q.titre}</h3>
+                    ) : (
+                      <>
+                        <Label className="text-sm font-medium">{q.titre}</Label>
+                        {renderQuestion(q)}
+                      </>
+                    )}
                   </div>
                 ))}
                 <Button onClick={save} className="w-full mt-4">
@@ -260,8 +284,16 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                         q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
                       }`}
                     >
-                      <Label className="text-sm font-medium">{q.titre}</Label>
-                      {renderQuestion(q)}
+                      {q.type === 'titre' ? (
+                        <h3 className="text-lg font-semibold">{q.titre}</h3>
+                      ) : (
+                        <>
+                          <Label className="text-sm font-medium">
+                            {q.titre}
+                          </Label>
+                          {renderQuestion(q)}
+                        </>
+                      )}
                     </div>
                   ))}
                   <Button onClick={save} className="w-full mt-4">

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -35,6 +35,7 @@ import {
   CheckSquare,
   BarChart3,
   Table,
+  Heading3,
 } from 'lucide-react';
 
 const typesQuestions = [
@@ -61,6 +62,12 @@ const typesQuestions = [
     title: 'Tableaux de résultats',
     icon: Table,
     description: 'Liste de lignes avec notation',
+  },
+  {
+    id: 'titre',
+    title: 'Titre de section',
+    icon: Heading3,
+    description: 'Titre sans réponse',
   },
 ];
 

--- a/frontend/src/types/question.ts
+++ b/frontend/src/types/question.ts
@@ -1,6 +1,6 @@
 export interface Question {
   id: string;
-  type: 'notes' | 'choix-multiple' | 'echelle' | 'tableau';
+  type: 'notes' | 'choix-multiple' | 'echelle' | 'tableau' | 'titre';
   titre: string;
   contenu?: string;
   options?: string[];


### PR DESCRIPTION
## Summary
- support `titre` question type for schema
- render title-only questions in DataEntry
- expose new option in CreationTrame
- update transformPrompt with `titre` type
- test heading render

## Testing
- `pnpm --filter frontend run lint` *(fails: 2 errors)*
- `pnpm --filter frontend run test`
- `pnpm --filter backend run lint` *(fails: Parsing error)*
- `pnpm --filter backend run test` *(fails: 1 failed, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688cb5f5aa2c83298eefd76f1533e9cb