### PR TITLE
[frontend] Add table import mode to ImportMagique

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -21,7 +21,7 @@ const kindMap: Record<string, string> = {
   'profil-sensoriel': 'profil_sensoriel',
   'observations-cliniques': 'observations',
   'tests-mabc': 'tests_standards',
-  'conclusions': 'conclusions',
+  conclusions: 'conclusions',
 };
 
 const sections: SectionInfo[] = [
@@ -125,7 +125,7 @@ export default function AiRightPanel({
   );
   const [regenSection, setRegenSection] = useState<string | null>(null);
   const [regenPrompt, setRegenPrompt] = useState('');
-  const { selection } = useEditorUi();
+  useEditorUi((s) => s.selection);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -173,25 +173,36 @@ export default function AiRightPanel({
     remove(id).catch(() => {});
   };
 
-  function markdownifyTable(q: Question, ansTable: any): string {
+  type TableAnswers = Record<string, unknown> & { commentaire?: string };
+
+  function markdownifyTable(q: Question, ansTable: TableAnswers): string {
     if (!q.tableau?.colonnes) {
       return '';
     }
 
-    const header = `**${q.titre}**\n\n` +
+    const header =
+      `**${q.titre}**\n\n` +
       `| ${['Ligne', ...q.tableau?.colonnes].join(' | ')} |\n` +
       `| ${['---', ...q.tableau?.colonnes.map(() => '---')].join(' | ')} |\n`;
 
-    const body = q.tableau?.lignes
-      ?.map(ligne => {
-        const cells = q.tableau?.colonnes?.map(col => ansTable[ligne]?.[col] || '') || [];
-        return `| ${[ligne, ...cells].join(' | ')} |`;
-      })
-      .join('\n') || '';
+    const body =
+      q.tableau?.lignes
+        ?.map((ligne) => {
+          const row = ansTable[ligne] as Record<string, unknown> | undefined;
+          const cells =
+            q.tableau?.colonnes?.map((col) => {
+              const v = (row?.[col] as string) || '';
+              return v;
+            }) || [];
+          return `| ${[ligne, ...cells].join(' | ')} |`;
+        })
+        .join('\n') || '';
 
-    const comment = ansTable.commentaire
-      ? `\n\n> **Commentaire** : ${ansTable.commentaire}`
-      : '';
+    const commentVal = ansTable.commentaire;
+    const comment =
+      typeof commentVal === 'string'
+        ? `\n\n> **Commentaire** : ${commentVal}`
+        : '';
 
     return header + body + comment;
   }
@@ -199,13 +210,13 @@ export default function AiRightPanel({
   function markdownifyField(q: Question, value: string): string {
     switch (q.type) {
       case 'notes':
-        return `${q.titre}\n\n${value}`;  
+        return `${q.titre}\n\n${value}`;
       case 'choix-multiple':
-        return `${q.titre}\n\n${value}`;  
+        return `${q.titre}\n\n${value}`;
       case 'echelle':
-        return `${q.titre}\n\n${value}`; 
+        return `${q.titre}\n\n${value}`;
       case 'titre':
-        return `## ${q.titre}\n\n${value}`;  
+        return `## ${q.titre}\n\n${value}`;
       default:
         return `${q.titre} : ${value}`;
     }
@@ -216,29 +227,28 @@ export default function AiRightPanel({
     setSelectedSection(section.id);
 
     try {
-      const trameId = selectedTrames[section.id]
-      const trame = trames[section.id].find(t => t.value === trameId)
-      const questions: Question[] = (trame?.schema as Question[]) || []
-      const ans = newAnswers || answers[section.id] || {}
-  
+      const trameId = selectedTrames[section.id];
+      const trame = trames[section.id].find((t) => t.value === trameId);
+      const questions: Question[] = (trame?.schema as Question[]) || [];
+      const ans = newAnswers || answers[section.id] || {};
+
       const mdBlocks: string[] = [];
 
       // Titre principal
       // mdBlocks.push(`# ${section.title}\n`);
-  
+
       for (const q of questions) {
         if (q.type === 'tableau') {
-          const ansTable = (ans[q.id] as Record<string, any>) || {};
+          const ansTable = (ans[q.id] as TableAnswers) || {};
           mdBlocks.push(markdownifyTable(q, ansTable));
-        }
-        else {
+        } else {
           const raw = String(ans[q.id] ?? '').trim();
           if (raw) {
             mdBlocks.push(markdownifyField(q, raw));
           }
         }
       }
-  
+
       // 5) Concatène tout avec deux retours à la ligne
       const promptMarkdown = mdBlocks.join('\n\n');
 
@@ -246,11 +256,11 @@ export default function AiRightPanel({
         section: kindMap[section.id],
         answers: promptMarkdown,
         examples: examples
-          .filter(e => e.sectionId === trameId)
-          .map(e => e.content)
-      }
+          .filter((e) => e.sectionId === trameId)
+          .map((e) => e.content),
+      };
 
-      console.log("body", body)
+      console.log('body', body);
 
       const res = await apiFetch<{ text: string }>(
         `/api/v1/bilans/${bilanId}/generate`,
@@ -263,7 +273,7 @@ export default function AiRightPanel({
 
       const header = `## ${section.title}\n\n`;
       const textWithHeader = header + res.text;
-      
+
       onInsertText(textWithHeader);
       setGenerated((g) => ({ ...g, [section.id]: true }));
       setRegenSection(section.id);
@@ -278,7 +288,7 @@ export default function AiRightPanel({
   return (
     <div className="w-full max-w-md bg-white rounded-lg shadow-lg">
       <div className="flex flex-col h-full">
-{/*         {selection?.text && (
+        {/*         {selection?.text && (
           <div className="bg-blue-50 text-blue-800 text-sm p-2 border-b border-blue-100">
             <div className="font-medium mb-1">Texte sélectionné :</div>
             <div className="italic truncate">&quot;{selection.text}&quot;</div>
@@ -301,8 +311,8 @@ export default function AiRightPanel({
           {regenSection ? (
             <div className="space-y-4">
               <h3 className="text-sm font-medium text-left">
-                Si vous voulez ajuster le contenu généré, vous pouvez préciser ici
-                les éléments que vous souhaitez re-générer
+                Si vous voulez ajuster le contenu généré, vous pouvez préciser
+                ici les éléments que vous souhaitez re-générer
               </h3>
               <div className="w-full">
                 <Textarea
@@ -326,7 +336,9 @@ export default function AiRightPanel({
                 <Button
                   size="sm"
                   onClick={() => {
-                    const section = sections.find((s) => s.id === regenSection)!;
+                    const section = sections.find(
+                      (s) => s.id === regenSection,
+                    )!;
                     handleGenerate(section);
                   }}
                   disabled={isGenerating}
@@ -436,7 +448,10 @@ export default function AiRightPanel({
                       trameOptions={trameOpts}
                       selectedTrame={selected}
                       onTrameChange={(v) =>
-                        setSelectedTrames({ ...selectedTrames, [section.id]: v })
+                        setSelectedTrames({
+                          ...selectedTrames,
+                          [section.id]: v,
+                        })
                       }
                       examples={getExamples(
                         section.id,
@@ -446,7 +461,11 @@ export default function AiRightPanel({
                         addExample(section.id, selectedTrames[section.id], ex)
                       }
                       onRemoveExample={(id) =>
-                        removeExample(section.id, selectedTrames[section.id], id)
+                        removeExample(
+                          section.id,
+                          selectedTrames[section.id],
+                          id,
+                        )
                       }
                       questions={(selected?.schema as Question[]) || []}
                       answers={answers[section.id] || {}}

--- a/frontend/src/components/ImportMagique.test.tsx
+++ b/frontend/src/components/ImportMagique.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ImportMagique from './ImportMagique';
+import { useAuth } from '@/store/auth';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+
+// Ensure token exists for hook
+useAuth.setState({ token: 'tok' });
+
+describe('ImportMagique', () => {
+  it('converts pasted table into tableau question', async () => {
+    const onDone = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <Dialog open>
+        <DialogContent>
+          <ImportMagique onDone={onDone} onCancel={onCancel} />
+        </DialogContent>
+      </Dialog>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tableau' }));
+    fireEvent.change(screen.getByPlaceholderText(/Collez votre tableau/), {
+      target: { value: '\tC1\tC2\nL1\tA\tB\nL2\tC\tD' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Transformer' }));
+
+    await waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(onDone).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: expect.any(String),
+        type: 'tableau',
+        titre: 'Question sans titre',
+        tableau: { lignes: ['L1', 'L2'], colonnes: ['C1', 'C2'] },
+      }),
+    ]);
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ImportMagique.tsx
+++ b/frontend/src/components/ImportMagique.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { apiFetch } from '@/utils/api';
 import { useAuth } from '@/store/auth';
+import { cn } from '@/lib/utils';
 import type { Question } from '@/types/question';
 
 interface ImportMagiqueProps {
@@ -15,22 +16,53 @@ export default function ImportMagique({
   onDone,
   onCancel,
 }: ImportMagiqueProps) {
+  const [mode, setMode] = useState<'liste' | 'tableau'>('liste');
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
   const token = useAuth((s) => s.token);
 
+  const transformTable = () => {
+    const rows = text
+      .trimEnd()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((r) => r.split('\t'));
+    if (rows.length === 0) return [];
+    const header = rows[0];
+    const colonnes = header
+      .slice(1)
+      .map((c) => c.trim())
+      .filter(Boolean);
+    const lignes = rows
+      .slice(1)
+      .map((r) => r[0].trim())
+      .filter(Boolean);
+    return [
+      {
+        id: Date.now().toString(),
+        type: 'tableau' as const,
+        titre: 'Question sans titre',
+        tableau: { lignes, colonnes },
+      },
+    ];
+  };
+
   const handle = async () => {
     setLoading(true);
     try {
-      const res = await apiFetch<{ result: Question[] }>(
-        '/api/v1/import/transform',
-        {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${token}` },
-          body: JSON.stringify({ content: text }),
-        },
-      );
-      onDone(res.result);
+      if (mode === 'liste') {
+        const res = await apiFetch<{ result: Question[] }>(
+          '/api/v1/import/transform',
+          {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ content: text }),
+          },
+        );
+        onDone(res.result);
+      } else {
+        onDone(transformTable());
+      }
     } finally {
       setLoading(false);
       onCancel();
@@ -43,13 +75,41 @@ export default function ImportMagique({
         <DialogHeader className="mb-4">
           <DialogTitle>Importe ta trame magiquement</DialogTitle>
         </DialogHeader>
+        <div className="mb-4 flex border-b">
+          <button
+            className={cn(
+              'px-4 py-2 text-sm font-medium',
+              mode === 'liste'
+                ? 'border-b-2 border-primary text-primary'
+                : 'text-muted-foreground',
+            )}
+            onClick={() => setMode('liste')}
+          >
+            Liste de questions
+          </button>
+          <button
+            className={cn(
+              'px-4 py-2 text-sm font-medium',
+              mode === 'tableau'
+                ? 'border-b-2 border-primary text-primary'
+                : 'text-muted-foreground',
+            )}
+            onClick={() => setMode('tableau')}
+          >
+            Tableau
+          </button>
+        </div>
         <div className="space-y-4">
           <div className="relative">
             <Textarea
               value={text}
               onChange={(e) => setText(e.target.value)}
               className="min-h-[200px] max-h-[50vh] w-full resize-y"
-              placeholder="Collez votre texte ici..."
+              placeholder={
+                mode === 'liste'
+                  ? 'Collez votre texte ici...'
+                  : 'Collez votre tableau ici...'
+              }
             />
           </div>
         </div>

--- a/frontend/src/pages/CreationTrame.test.tsx
+++ b/frontend/src/pages/CreationTrame.test.tsx
@@ -55,7 +55,9 @@ it('shows table specific options', async () => {
     </MemoryRouter>,
   );
   expect(
-    await screen.findByRole('button', { name: /\+ Ajout case commentaire/i }),
+    await screen.findByRole('button', {
+      name: /\+ Ajouter une zone de commentaire/i,
+    }),
   ).toBeInTheDocument();
   expect(screen.getByText(/Type de valeur/)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add tabbed interface to ImportMagique for list and table imports
- convert pasted spreadsheets into tableau questions without API calls
- tighten AiRightPanel table answer typing

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_688dc62b5ec88329be84116b3e325bc2