### PR TITLE
[frontend] add exit confirmation modal for editors

### DIFF
--- a/frontend/src/components/ExitConfirmation.tsx
+++ b/frontend/src/components/ExitConfirmation.tsx
@@ -1,0 +1,39 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface ExitConfirmationProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export default function ExitConfirmation({
+  open,
+  onOpenChange,
+  onConfirm,
+  onCancel,
+}: ExitConfirmationProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Souhaitez-vous conserver les modifications apportées ?
+          </AlertDialogTitle>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>Non</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Oui</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -26,6 +26,7 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import ImportMagique from '@/components/ImportMagique';
 import SaisieExempleTrame from '@/components/SaisieExempleTrame';
 import { DataEntry } from '@/components/bilan/DataEntry';
+import ExitConfirmation from '@/components/ExitConfirmation';
 import {
   ArrowLeft,
   Copy,
@@ -96,6 +97,7 @@ export default function CreationTrame() {
     null,
   );
   const [showImport, setShowImport] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const createDefaultNote = (): Question => ({
     id: Date.now().toString(),
@@ -293,7 +295,7 @@ export default function CreationTrame() {
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center gap-4 mb-6">
-          <Button variant="outline" onClick={() => navigate(-1)}>
+          <Button variant="outline" onClick={() => setShowConfirm(true)}>
             <ArrowLeft className="h-4 w-4 mr-2" />
             Retour
           </Button>
@@ -337,7 +339,9 @@ export default function CreationTrame() {
           <nav className="flex gap-4">
             <button
               className={`pb-2 px-1 border-b-2 ${
-                tab === 'questions' ? 'border-primary-600' : 'border-transparent'
+                tab === 'questions'
+                  ? 'border-primary-600'
+                  : 'border-transparent'
               }`}
               onClick={() => setTab('questions')}
             >
@@ -718,8 +722,8 @@ export default function CreationTrame() {
                                 </Button>
                                 <div className="p-2 border rounded">
                                   <p className="text-sm text-gray-500 mb-1">
-                                    La zone de commentaire sera disponible lors de
-                                    la saisie des données
+                                    La zone de commentaire sera disponible lors
+                                    de la saisie des données
                                   </p>
                                 </div>
                               </div>
@@ -876,10 +880,7 @@ export default function CreationTrame() {
                   Annuler
                 </Button>
 
-                <Button
-                  onClick={sauvegarderTrame}
-                  variant="primary"
-                  >
+                <Button onClick={sauvegarderTrame} variant="primary">
                   Sauvegarder la trame
                 </Button>
               </div>
@@ -931,6 +932,12 @@ export default function CreationTrame() {
           />
         </DialogContent>
       </Dialog>
+      <ExitConfirmation
+        open={showConfirm}
+        onOpenChange={setShowConfirm}
+        onConfirm={sauvegarderTrame}
+        onCancel={() => navigate(-1)}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/EditeurBilan.test.tsx
+++ b/frontend/src/pages/EditeurBilan.test.tsx
@@ -1,11 +1,32 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  act,
+} from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import Bilan from './EditeurBilan';
 import { useAuth, type AuthState } from '../store/auth';
+import { useBilanDraft } from '../store/bilanDraft';
 import { vi } from 'vitest';
 
 vi.mock('../components/AiRightPanel', () => ({
   default: () => <div>Assistant IA</div>,
+}));
+vi.mock('../components/RichTextEditor', () => ({
+  default: ({
+    onChange,
+    onSave,
+  }: {
+    onChange: (v: string) => void;
+    onSave: () => void;
+  }) => (
+    <div>
+      <button onClick={onSave}>Save</button>
+      <textarea onChange={(e) => onChange(e.target.value)} />
+    </div>
+  ),
 }));
 
 vi.stubGlobal('fetch', vi.fn());
@@ -60,6 +81,52 @@ describe('Bilan page', () => {
     await screen.findByText(/mon bilan/i);
     const saveBtn = await screen.findByRole('button', { name: 'Save' });
     saveBtn.click();
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        '/api/v1/bilans/1',
+        expect.objectContaining({ method: 'PUT' }),
+      ),
+    );
+  });
+
+  it('prompts to save when leaving with changes', async () => {
+    useAuth.setState({ token: 't' } as Partial<AuthState>);
+    const fetchMock = fetch as unknown as vi.Mock;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: '1', descriptionHtml: '<b>txt</b>' }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: '1', descriptionHtml: '<b>txt</b>' }),
+      });
+
+    render(
+      <MemoryRouter initialEntries={['/bilan/1']}>
+        <Routes>
+          <Route path="/bilan/:bilanId" element={<Bilan />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText(/mon bilan/i);
+    act(() => {
+      useBilanDraft.setState({ descriptionHtml: 'changed' });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Retour/i }));
+
+    expect(
+      await screen.findByText(
+        /Souhaitez-vous conserver les modifications apportées/i,
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Oui' }));
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenLastCalledWith(

--- a/frontend/src/pages/EditeurBilan.tsx
+++ b/frontend/src/pages/EditeurBilan.tsx
@@ -2,15 +2,7 @@ import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useEffect, useState, Suspense, lazy, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { Button } from '../components/ui/button';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '../components/ui/alert-dialog';
+import ExitConfirmation from '../components/ExitConfirmation';
 import { apiFetch } from '../utils/api';
 import { useAuth } from '../store/auth';
 import { useBilanDraft } from '../store/bilanDraft';
@@ -109,28 +101,15 @@ export default function Bilan() {
           </div>
         </div>
       </div>
-      <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              Souhaitez-vous conserver les modifications apportées ?
-            </AlertDialogTitle>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => navigate('/')}>
-              Non
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={async () => {
-                await save();
-                navigate('/');
-              }}
-            >
-              Oui
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ExitConfirmation
+        open={showConfirm}
+        onOpenChange={setShowConfirm}
+        onConfirm={async () => {
+          await save();
+          navigate('/');
+        }}
+        onCancel={() => navigate('/')}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `ExitConfirmation` dialog component
- prompt for saving when leaving trame or bilan editors
- cover new exit behavior with tests

## Testing
- `pnpm --filter frontend exec eslint src/components/ExitConfirmation.tsx src/pages/CreationTrame.tsx src/pages/CreationTrame.test.tsx src/pages/EditeurBilan.tsx src/pages/EditeurBilan.test.tsx`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6890431cbb108329a99ff73498b8f08c