### PR TITLE
[frontend] Refactor CreationTrame into modular editors

### DIFF
--- a/frontend/src/components/Editors.tsx
+++ b/frontend/src/components/Editors.tsx
@@ -1,0 +1,308 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { Question } from '@/types/Typequestion';
+import { Trash2 } from 'lucide-react';
+
+export type EditorProps = {
+  q: Question;
+  onPatch: (p: Partial<Question>) => void;
+};
+
+export function NotesEditor({ q, onPatch }: EditorProps) {
+  return (
+    <div className="space-y-4">
+      <Input
+        value={q.titre}
+        placeholder="Question"
+        onChange={(e) => onPatch({ titre: e.target.value })}
+      />
+      <div className="w-full rounded px-3 py-2 border-b border-dotted border-gray-200 text-gray-600">
+        Réponse (prise de notes)
+      </div>
+    </div>
+  );
+}
+
+export function MultiChoiceEditor({ q, onPatch }: EditorProps) {
+  const options = ('options' in q && q.options) || [];
+  const updateOption = (idx: number, value: string) => {
+    const opts = [...options];
+    opts[idx] = value;
+    onPatch({ options: opts } as Partial<Question>);
+  };
+  const removeOption = (idx: number) => {
+    const opts = options.filter((_, i) => i !== idx);
+    onPatch({ options: opts } as Partial<Question>);
+  };
+  const addOption = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onPatch({ options: [...options, trimmed] } as Partial<Question>);
+  };
+  return (
+    <div className="space-y-4">
+      <Input
+        value={q.titre}
+        placeholder="Question"
+        onChange={(e) => onPatch({ titre: e.target.value })}
+      />
+      <div>
+        <Label>Options de réponse</Label>
+        <div className="space-y-2">
+          {options.map((option, optionIndex) => (
+            <div key={optionIndex} className="flex items-center gap-2">
+              <Input
+                value={option}
+                onChange={(e) => updateOption(optionIndex, e.target.value)}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => removeOption(optionIndex)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          <Input
+            placeholder="Ajouter une option"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                addOption(e.currentTarget.value);
+                e.currentTarget.value = '';
+              }
+            }}
+            onBlur={(e) => {
+              addOption(e.currentTarget.value);
+              e.currentTarget.value = '';
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ScaleEditor({ q, onPatch }: EditorProps) {
+  return (
+    <div className="space-y-4">
+      <Input
+        value={q.titre}
+        placeholder="Question"
+        onChange={(e) => onPatch({ titre: e.target.value })}
+      />
+      {/* Placeholder for scale configuration */}
+    </div>
+  );
+}
+
+export function TableEditor({ q, onPatch }: EditorProps) {
+  const tableau = 'tableau' in q ? q.tableau || { lignes: [] } : { lignes: [] };
+  const addLine = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onPatch({
+      tableau: { ...tableau, lignes: [...(tableau.lignes || []), trimmed] },
+    } as Partial<Question>);
+  };
+  const addColumn = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onPatch({
+      tableau: { ...tableau, colonnes: [...(tableau.colonnes || []), trimmed] },
+    } as Partial<Question>);
+  };
+  const toggleComment = () => {
+    onPatch({
+      tableau: { ...tableau, commentaire: !tableau.commentaire },
+    } as Partial<Question>);
+  };
+  const setValeurType = (v: string) => {
+    onPatch({
+      tableau: {
+        ...tableau,
+        valeurType: v as 'texte' | 'score' | 'choix-multiple' | 'case-a-cocher',
+        options: v === 'choix-multiple' ? tableau.options || [] : undefined,
+      },
+    } as Partial<Question>);
+  };
+  const addOption = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onPatch({
+      tableau: { ...tableau, options: [...(tableau.options || []), trimmed] },
+    } as Partial<Question>);
+  };
+  const removeOption = (idx: number) => {
+    const opts = (tableau.options || []).filter((_, i) => i !== idx);
+    onPatch({ tableau: { ...tableau, options: opts } } as Partial<Question>);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Input
+        value={q.titre}
+        placeholder="Question"
+        onChange={(e) => onPatch({ titre: e.target.value })}
+      />
+      <div className="overflow-auto">
+        <table className="w-full border">
+          <thead>
+            <tr>
+              <th className="p-1">
+                <Input
+                  placeholder="Ajouter une colonne"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      addColumn(e.currentTarget.value);
+                      e.currentTarget.value = '';
+                    }
+                  }}
+                  onBlur={(e) => {
+                    addColumn(e.currentTarget.value);
+                    e.currentTarget.value = '';
+                  }}
+                />
+              </th>
+              {tableau.colonnes?.map((_, idx) => (
+                <th key={idx} className="p-1" />
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {tableau.lignes?.map((ligne, ligneIdx) => (
+              <tr key={ligneIdx}>
+                <th className="p-1">
+                  <Input
+                    value={ligne}
+                    readOnly
+                    className="pointer-events-none"
+                  />
+                </th>
+                {tableau.colonnes?.map((_, colIdx) => (
+                  <td key={colIdx} className="p-1">
+                    <Input disabled className="pointer-events-none" />
+                  </td>
+                ))}
+              </tr>
+            ))}
+            <tr>
+              <th className="p-1">
+                <Input
+                  placeholder="Ajouter une ligne"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      addLine(e.currentTarget.value);
+                      e.currentTarget.value = '';
+                    }
+                  }}
+                  onBlur={(e) => {
+                    addLine(e.currentTarget.value);
+                    e.currentTarget.value = '';
+                  }}
+                />
+              </th>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div className="space-y-2">
+        {tableau.commentaire ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={toggleComment}
+            className="text-red-500 hover:text-red-700"
+          >
+            Retirer le commentaire
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" onClick={toggleComment}>
+            + Ajouter une zone de commentaire
+          </Button>
+        )}
+        <div className="flex items-center gap-2">
+          <Label>Type de valeur</Label>
+          <Select
+            value={tableau.valeurType || 'texte'}
+            onValueChange={setValeurType}
+          >
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Texte" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="texte">Texte</SelectItem>
+              <SelectItem value="score">Score</SelectItem>
+              <SelectItem value="choix-multiple">Choix multiples</SelectItem>
+              <SelectItem value="case-a-cocher">Case à cocher</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {tableau.valeurType === 'choix-multiple' && (
+          <div className="space-y-2">
+            {tableau.options?.map((opt, idx) => (
+              <div key={idx} className="flex items-center gap-2">
+                <Input
+                  value={opt}
+                  onChange={(e) => {
+                    const opts = [...(tableau.options || [])];
+                    opts[idx] = e.target.value;
+                    onPatch({
+                      tableau: { ...tableau, options: opts },
+                    } as Partial<Question>);
+                  }}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => removeOption(idx)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <Input
+              placeholder="Ajouter une valeur"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  addOption(e.currentTarget.value);
+                  e.currentTarget.value = '';
+                }
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TitleEditor({ q, onPatch }: EditorProps) {
+  return (
+    <Input
+      value={q.titre}
+      placeholder="Titre de section"
+      className="text-3xl font-bold border-none shadow-none focus-visible:ring-0 p-0"
+      onChange={(e) => onPatch({ titre: e.target.value })}
+    />
+  );
+}
+
+export const EDITORS: Record<
+  Question['type'],
+  (props: EditorProps) => JSX.Element
+> = {
+  notes: NotesEditor,
+  'choix-multiple': MultiChoiceEditor,
+  echelle: ScaleEditor,
+  tableau: TableEditor,
+  titre: TitleEditor,
+};

--- a/frontend/src/components/QuestionList.tsx
+++ b/frontend/src/components/QuestionList.tsx
@@ -1,0 +1,172 @@
+import { useRef } from 'react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { GripVertical, Copy, Trash2, Plus } from 'lucide-react';
+import type { Question } from '@/types/Typequestion';
+import { EDITORS } from './Editors';
+
+const typesQuestions = [
+  { id: 'notes', title: 'Réponse (prise de notes)' },
+  { id: 'choix-multiple', title: 'Choix multiples' },
+  { id: 'echelle', title: 'Échelle chiffrée' },
+  { id: 'tableau', title: 'Tableaux de résultats' },
+  { id: 'titre', title: 'Titre de section' },
+];
+
+interface Props {
+  questions: Question[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onPatch: (id: string, partial: Partial<Question>) => void;
+  onReorder: (from: number, to: number) => void;
+  onDuplicate: (id: string) => void;
+  onDelete: (id: string) => void;
+  onAddAfter: () => void;
+}
+
+export default function QuestionList({
+  questions,
+  selectedId,
+  onSelect,
+  onPatch,
+  onReorder,
+  onDuplicate,
+  onDelete,
+  onAddAfter,
+}: Props) {
+  const dragIndex = useRef<number | null>(null);
+  const handleDragStart = (index: number) => {
+    dragIndex.current = index;
+  };
+  const handleDragEnd = () => {
+    dragIndex.current = null;
+  };
+  const handleDrop = (index: number) => {
+    if (dragIndex.current === null || dragIndex.current === index) {
+      dragIndex.current = null;
+      return;
+    }
+    onReorder(dragIndex.current, index);
+    dragIndex.current = null;
+  };
+
+  return (
+    <div className="space-y-6">
+      {questions.map((question, index) => {
+        const Editor = EDITORS[question.type];
+        return (
+          <div
+            key={question.id}
+            className="relative w-full"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => handleDrop(index)}
+          >
+            <button
+              aria-label="Déplacer la question"
+              draggable
+              onDragStart={() => handleDragStart(index)}
+              onDragEnd={handleDragEnd}
+              className={`absolute top left-1/2 cursor-move p-1 rounded transition-opacity opacity-0 ${
+                selectedId === question.id
+                  ? 'opacity-100'
+                  : 'group-hover:opacity-100'
+              }`}
+            >
+              <GripVertical className="h-4 w-4 text-gray-400 rotate-90" />
+            </button>
+            <Card
+              onClick={() => onSelect(question.id)}
+              className={`group w-[90%] mx-auto cursor-pointer transition-shadow ${
+                selectedId === question.id
+                  ? 'border-primary-500 ring-1 ring-primary-500 shadow-md'
+                  : ''
+              }`}
+            >
+              <CardHeader>
+                <div className="flex items-center gap-4">
+                  <Input
+                    className={
+                      question.type === 'titre'
+                        ? 'text-3xl font-bold border-none shadow-none focus-visible:ring-0 p-0 flex-1'
+                        : 'flex-1'
+                    }
+                    placeholder={
+                      question.type === 'titre'
+                        ? 'Titre de section'
+                        : `Question ${index + 1}`
+                    }
+                    value={question.titre}
+                    onChange={(e) =>
+                      onPatch(question.id, { titre: e.target.value })
+                    }
+                  />
+                  {selectedId === question.id && (
+                    <Select
+                      value={question.type}
+                      onValueChange={(v) =>
+                        onPatch(question.id, { type: v as Question['type'] })
+                      }
+                    >
+                      <SelectTrigger className="w-44">
+                        <SelectValue placeholder="Type de réponse" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {typesQuestions.map((t) => (
+                          <SelectItem key={t.id} value={t.id}>
+                            {t.title}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Editor q={question} onPatch={(p) => onPatch(question.id, p)} />
+                {selectedId === question.id && (
+                  <div className="flex justify-end gap-2 pt-4">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDuplicate(question.id);
+                      }}
+                    >
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDelete(question.id);
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            {selectedId === question.id && (
+              <div className="absolute top-1/2 -translate-y-1/2 -right-4">
+                <Button variant="primary" size="icon" onClick={onAddAfter}>
+                  <Plus className="h-6 w-6 text-white" />
+                </Button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/TrameHeader.tsx
+++ b/frontend/src/components/TrameHeader.tsx
@@ -1,0 +1,82 @@
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import type { Category } from '@/types/trame';
+
+interface Props {
+  title: string;
+  category: string;
+  isPublic: boolean;
+  categories: Category[];
+  onTitleChange: (v: string) => void;
+  onCategoryChange: (v: string) => void;
+  onPublicChange: (v: boolean) => void;
+  onSave: () => void;
+  onImport: () => void;
+  onBack: () => void;
+}
+
+export default function TrameHeader({
+  title,
+  category,
+  isPublic,
+  categories,
+  onTitleChange,
+  onCategoryChange,
+  onPublicChange,
+  onSave,
+  onImport,
+  onBack,
+}: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 mb-6">
+      <Button variant="outline" onClick={onBack}>
+        <ArrowLeft className="h-4 w-4 mr-2" />
+        Retour
+      </Button>
+      <Input
+        value={title}
+        onChange={(e) => onTitleChange(e.target.value)}
+        placeholder="Titre de la trame"
+        className="text-2xl font-bold text-gray-900 flex-1"
+      />
+      <div className="w-48 flex-shrink-0">
+        <Select value={category} onValueChange={onCategoryChange}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Catégorie" />
+          </SelectTrigger>
+          <SelectContent>
+            {categories.map((cat) => (
+              <SelectItem key={cat.id} value={cat.id}>
+                {cat.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={isPublic}
+          onChange={(e) => onPublicChange(e.target.checked)}
+          aria-label="Partager la trame"
+        />
+        <Label className="text-md text-gray-700">Partager</Label>
+      </div>
+      <Button onClick={onSave} variant="primary" className="ml-auto">
+        Sauvegarder la trame
+      </Button>
+      <Button variant="outline" onClick={onImport}>
+        Import Magique
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/types/Typequestion.ts
+++ b/frontend/src/types/Typequestion.ts
@@ -1,0 +1,51 @@
+export type NotesQuestion = {
+  id: string;
+  type: 'notes';
+  titre: string;
+  contenu: string;
+};
+
+export type MultiChoiceQuestion = {
+  id: string;
+  type: 'choix-multiple';
+  titre: string;
+  options: string[];
+};
+
+export type ScaleQuestion = {
+  id: string;
+  type: 'echelle';
+  titre: string;
+  echelle: { min: number; max: number; labels?: { min: string; max: string } };
+};
+
+export type TableQuestion = {
+  id: string;
+  type: 'tableau';
+  titre: string;
+  tableau: {
+    lignes: string[];
+    colonnes?: string[];
+    valeurType?: 'texte' | 'score' | 'choix-multiple' | 'case-a-cocher';
+    options?: string[];
+    commentaire?: boolean;
+  };
+};
+
+export type TitleQuestion = {
+  id: string;
+  type: 'titre';
+  titre: string;
+};
+
+export type Question =
+  | NotesQuestion
+  | MultiChoiceQuestion
+  | ScaleQuestion
+  | TableQuestion
+  | TitleQuestion;
+
+export type Answers = Record<
+  string,
+  string | string[] | number | boolean | Record<string, unknown>
+>;


### PR DESCRIPTION
## Summary
- split CreationTrame into container and presentational components
- add registry-driven editors for each question type
- introduce discriminated union Question types

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68905e63d7bc8329b7c7700e44e1a37f