### PR TITLE
[frontend] Enable editing of tableau columns and rows

### DIFF
--- a/frontend/src/components/Editors.tsx
+++ b/frontend/src/components/Editors.tsx
@@ -120,6 +120,24 @@ export function TableEditor({ q, onPatch }: EditorProps) {
       tableau: { ...tableau, colonnes: [...(tableau.colonnes || []), trimmed] },
     } as Partial<Question>);
   };
+  const updateColumn = (idx: number, value: string) => {
+    const colonnes = [...(tableau.colonnes || [])];
+    colonnes[idx] = value;
+    onPatch({ tableau: { ...tableau, colonnes } } as Partial<Question>);
+  };
+  const removeColumn = (idx: number) => {
+    const colonnes = (tableau.colonnes || []).filter((_, i) => i !== idx);
+    onPatch({ tableau: { ...tableau, colonnes } } as Partial<Question>);
+  };
+  const updateLine = (idx: number, value: string) => {
+    const lignes = [...(tableau.lignes || [])];
+    lignes[idx] = value;
+    onPatch({ tableau: { ...tableau, lignes } } as Partial<Question>);
+  };
+  const removeLine = (idx: number) => {
+    const lignes = (tableau.lignes || []).filter((_, i) => i !== idx);
+    onPatch({ tableau: { ...tableau, lignes } } as Partial<Question>);
+  };
   const toggleComment = () => {
     onPatch({
       tableau: { ...tableau, commentaire: !tableau.commentaire },
@@ -153,45 +171,74 @@ export function TableEditor({ q, onPatch }: EditorProps) {
         placeholder="Question"
         onChange={(e) => onPatch({ titre: e.target.value })}
       />
-      <div className="overflow-auto">
-        <table className="w-full border">
+      <div className="flex-shrink-0 w-full overflow-x-auto">
+        <table className="table-auto w-full border-collapse">
           <thead>
             <tr>
+              <th className="p-1"></th>
+              {tableau.colonnes?.map((col, colIdx) => (
+                <th key={colIdx} className="p-1">
+                  <div className="flex items-center gap-2">
+                    <Input
+                      className="flex-1"
+                      value={col}
+                      onChange={(e) => updateColumn(colIdx, e.target.value)}
+                    />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => removeColumn(colIdx)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </th>
+              ))}
               <th className="p-1">
                 <Input
                   placeholder="Ajouter une colonne"
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
+                    if (e.key === 'Enter' && e.currentTarget.value.trim()) {
                       addColumn(e.currentTarget.value);
                       e.currentTarget.value = '';
                     }
                   }}
                   onBlur={(e) => {
-                    addColumn(e.currentTarget.value);
-                    e.currentTarget.value = '';
+                    if (e.currentTarget.value.trim()) {
+                      addColumn(e.currentTarget.value);
+                      e.currentTarget.value = '';
+                    }
                   }}
                 />
               </th>
-              {tableau.colonnes?.map((_, idx) => (
-                <th key={idx} className="p-1" />
-              ))}
             </tr>
           </thead>
           <tbody>
             {tableau.lignes?.map((ligne, ligneIdx) => (
               <tr key={ligneIdx}>
                 <th className="p-1">
-                  <Input
-                    value={ligne}
-                    readOnly
-                    className="pointer-events-none"
-                  />
+                  <div className="group relative flex items-center gap-2">
+                    <Input
+                      className="w-50"
+                      value={ligne}
+                      onChange={(e) => updateLine(ligneIdx, e.target.value)}
+                    />
+                    <Button
+                      className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => removeLine(ligneIdx)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </th>
                 {tableau.colonnes?.map((_, colIdx) => (
                   <td key={colIdx} className="p-1">
                     <Input disabled className="pointer-events-none" />
                   </td>
                 ))}
+                <td className="p-1"></td>
               </tr>
             ))}
             <tr>
@@ -199,14 +246,16 @@ export function TableEditor({ q, onPatch }: EditorProps) {
                 <Input
                   placeholder="Ajouter une ligne"
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
+                    if (e.key === 'Enter' && e.currentTarget.value.trim()) {
                       addLine(e.currentTarget.value);
                       e.currentTarget.value = '';
                     }
                   }}
                   onBlur={(e) => {
-                    addLine(e.currentTarget.value);
-                    e.currentTarget.value = '';
+                    if (e.currentTarget.value.trim()) {
+                      addLine(e.currentTarget.value);
+                      e.currentTarget.value = '';
+                    }
                   }}
                 />
               </th>
@@ -216,14 +265,22 @@ export function TableEditor({ q, onPatch }: EditorProps) {
       </div>
       <div className="space-y-2">
         {tableau.commentaire ? (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={toggleComment}
-            className="text-red-500 hover:text-red-700"
-          >
-            Retirer le commentaire
-          </Button>
+          <div className="space-y-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={toggleComment}
+              className="text-red-500 hover:text-red-700"
+            >
+              Retirer le commentaire
+            </Button>
+            <div className="p-2 border rounded">
+              <p className="text-sm text-gray-500 mb-1">
+                La zone de commentaire sera disponible lors de la saisie des
+                données
+              </p>
+            </div>
+          </div>
         ) : (
           <Button variant="outline" size="sm" onClick={toggleComment}>
             + Ajouter une zone de commentaire
@@ -272,7 +329,7 @@ export function TableEditor({ q, onPatch }: EditorProps) {
             <Input
               placeholder="Ajouter une valeur"
               onKeyDown={(e) => {
-                if (e.key === 'Enter') {
+                if (e.key === 'Enter' && e.currentTarget.value.trim()) {
                   addOption(e.currentTarget.value);
                   e.currentTarget.value = '';
                 }


### PR DESCRIPTION
## Summary
- allow renaming and removal of tableau columns and rows
- show comment info and keep option controls

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_689068dd8e908329af9844b6e17da335