### PR TITLE
[backend] Add CRUD for bilan section instances

### DIFF
--- a/backend/eslint.config.cjs
+++ b/backend/eslint.config.cjs
@@ -11,8 +11,10 @@ module.exports = [
       'coverage/',
       'prettier.config.ts',
       'jest.config.ts',
-      'prisma/seeds/**'
-      ,'__mocks__/**'
+      'prisma/seeds/**',
+      'prisma/*.js',
+      '__mocks__/**',
+      'tests/**/*.js',
     ]
   },
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import { bilanRouter } from './routes/bilan.routes';
 import { sectionRouter } from './routes/section.routes';
 import { sectionExampleRouter } from './routes/sectionExample.routes';
 import { importRouter } from './routes/import.routes';
+import { bilanSectionInstanceRouter } from './routes/bilanSectionInstance.routes';
 import { errorHandler } from './middlewares/error.middleware';
 import { requireAuth } from './middlewares/requireAuth';
 
@@ -88,6 +89,7 @@ app.use('/api/v1/bilans', bilanRouter);
 app.use('/api/v1/profile', profileRouter);
 app.use('/api/v1/sections', sectionRouter);
 app.use('/api/v1/section-examples', sectionExampleRouter);
+app.use('/api/v1/bilan-section-instances', bilanSectionInstanceRouter);
 app.use('/api/v1/import', importRouter);
 
 app.use(errorHandler);

--- a/backend/src/controllers/bilanSectionInstance.controller.ts
+++ b/backend/src/controllers/bilanSectionInstance.controller.ts
@@ -1,0 +1,65 @@
+import type { Request, Response, NextFunction } from 'express';
+import { BilanSectionInstanceService } from '../services/bilanSectionInstance.service';
+
+export const BilanSectionInstanceController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const instance = await BilanSectionInstanceService.create(req.user.id, req.body);
+      res.status(201).json(instance);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { bilanId } = req.query as { bilanId: string };
+      const instances = await BilanSectionInstanceService.list(req.user.id, bilanId);
+      res.json(instances);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const instance = await BilanSectionInstanceService.get(
+        req.user.id,
+        req.params.bilanSectionInstanceId,
+      );
+      if (!instance) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(instance);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const instance = await BilanSectionInstanceService.update(
+        req.user.id,
+        req.params.bilanSectionInstanceId,
+        req.body,
+      );
+      res.json(instance);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await BilanSectionInstanceService.remove(
+        req.user.id,
+        req.params.bilanSectionInstanceId,
+      );
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};
+

--- a/backend/src/routes/bilanSectionInstance.routes.ts
+++ b/backend/src/routes/bilanSectionInstance.routes.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { BilanSectionInstanceController } from '../controllers/bilanSectionInstance.controller';
+import { validateBody, validateParams, validateQuery } from '../middlewares/validate.middleware';
+import {
+  createBilanSectionInstanceSchema,
+  updateBilanSectionInstanceSchema,
+  bilanSectionInstanceIdParam,
+  bilanSectionInstanceListQuery,
+} from '../schemas/bilanSectionInstance.schema';
+
+export const bilanSectionInstanceRouter = Router();
+
+bilanSectionInstanceRouter
+  .route('/')
+  .post(
+    validateBody(createBilanSectionInstanceSchema),
+    BilanSectionInstanceController.create,
+  )
+  .get(
+    validateQuery(bilanSectionInstanceListQuery),
+    BilanSectionInstanceController.list,
+  );
+
+bilanSectionInstanceRouter
+  .route('/:bilanSectionInstanceId')
+  .get(
+    validateParams(bilanSectionInstanceIdParam),
+    BilanSectionInstanceController.get,
+  )
+  .put(
+    validateParams(bilanSectionInstanceIdParam),
+    validateBody(updateBilanSectionInstanceSchema),
+    BilanSectionInstanceController.update,
+  )
+  .delete(
+    validateParams(bilanSectionInstanceIdParam),
+    BilanSectionInstanceController.remove,
+  );
+

--- a/backend/src/schemas/bilanSectionInstance.schema.ts
+++ b/backend/src/schemas/bilanSectionInstance.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+const statusEnum = z.enum(['DRAFT', 'GENERATED', 'REFINED', 'PUBLISHED']);
+
+export const createBilanSectionInstanceSchema = z.object({
+  bilanId: z.string().uuid(),
+  sectionId: z.string().uuid(),
+  order: z.number().int(),
+  contentNotes: z.any(),
+  generatedContent: z.any().optional(),
+  status: statusEnum.optional(),
+});
+
+export const updateBilanSectionInstanceSchema = createBilanSectionInstanceSchema.partial();
+
+export const bilanSectionInstanceIdParam = z.object({
+  bilanSectionInstanceId: z.string().uuid(),
+});
+
+export const bilanSectionInstanceListQuery = z.object({
+  bilanId: z.string().uuid(),
+});
+

--- a/backend/src/services/ai/prompts/transformImageToTable.ts
+++ b/backend/src/services/ai/prompts/transformImageToTable.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai'
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
 
 export interface TransformImageToTableParams {
   imageBase64: string
@@ -19,7 +20,7 @@ const DEFAULT_SCHEMA = {
 export function buildTransformImageToTablePrompt(
   params: TransformImageToTableParams,
 ) {
-  const msgs: any[] = []
+  const msgs: ChatCompletionMessageParam[] = []
 
   msgs.push({
     role: 'system',

--- a/backend/src/services/bilanSectionInstance.service.ts
+++ b/backend/src/services/bilanSectionInstance.service.ts
@@ -1,0 +1,67 @@
+import { prisma } from '../prisma';
+import { NotFoundError } from './profile.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any;
+
+export type BilanSectionInstanceData = {
+  bilanId: string;
+  sectionId: string;
+  order: number;
+  contentNotes: unknown;
+  generatedContent?: unknown;
+  status?: 'DRAFT' | 'GENERATED' | 'REFINED' | 'PUBLISHED';
+};
+
+export const BilanSectionInstanceService = {
+  async create(userId: string, data: BilanSectionInstanceData) {
+    const bilan = await db.bilan.findFirst({
+      where: { id: data.bilanId, patient: { profile: { userId } } },
+    });
+    if (!bilan) throw new NotFoundError('Bilan not found for user');
+
+    const section = await db.section.findFirst({
+      where: {
+        id: data.sectionId,
+        OR: [
+          { isPublic: true },
+          { author: { userId } },
+        ],
+      },
+    });
+    if (!section) throw new NotFoundError('Section not found for user');
+
+    return db.bilanSectionInstance.create({ data });
+  },
+
+  list(userId: string, bilanId: string) {
+    return db.bilanSectionInstance.findMany({
+      where: { bilanId, bilan: { patient: { profile: { userId } } } },
+      orderBy: { order: 'asc' },
+      include: { section: { select: { title: true } } },
+    });
+  },
+
+  get(userId: string, id: string) {
+    return db.bilanSectionInstance.findFirst({
+      where: { id, bilan: { patient: { profile: { userId } } } },
+    });
+  },
+
+  async update(userId: string, id: string, data: Partial<BilanSectionInstanceData>) {
+    const { count } = await db.bilanSectionInstance.updateMany({
+      where: { id, bilan: { patient: { profile: { userId } } } },
+      data,
+    });
+    if (count === 0) throw new NotFoundError();
+    return db.bilanSectionInstance.findUnique({ where: { id } });
+  },
+
+  async remove(userId: string, id: string) {
+    const { count } = await db.bilanSectionInstance.deleteMany({
+      where: { id, bilan: { patient: { profile: { userId } } } },
+    });
+    if (count === 0) throw new NotFoundError();
+  },
+};
+

--- a/backend/tests/bilanSectionInstance.routes.test.ts
+++ b/backend/tests/bilanSectionInstance.routes.test.ts
@@ -1,0 +1,31 @@
+import request from 'supertest';
+import app from '../src/app';
+import { BilanSectionInstanceService } from '../src/services/bilanSectionInstance.service';
+
+jest.mock('../src/services/bilanSectionInstance.service');
+
+interface InstanceStub {
+  id: string;
+  contentNotes: unknown;
+}
+
+const mockedService = BilanSectionInstanceService as jest.Mocked<typeof BilanSectionInstanceService>;
+
+describe('GET /api/v1/bilan-section-instances', () => {
+  it('returns instances from service', async () => {
+    mockedService.list.mockResolvedValueOnce([
+      { id: '1', contentNotes: {} } as InstanceStub,
+    ]);
+
+    const res = await request(app)
+      .get('/api/v1/bilan-section-instances')
+      .query({ bilanId: '00000000-0000-0000-0000-000000000001' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith(
+      'demo-user',
+      '00000000-0000-0000-0000-000000000001',
+    );
+  });
+});
+

--- a/backend/tests/import.routes.test.ts
+++ b/backend/tests/import.routes.test.ts
@@ -12,7 +12,7 @@ const mockedTransformImage = transformImageToTable as unknown as jest.Mock
 
 describe('POST /api/v1/import/transform', () => {
   it('calls ai service with content', async () => {
-    mockedTransformText.mockResolvedValueOnce(['q1'] as any)
+    mockedTransformText.mockResolvedValueOnce(['q1'] as unknown as string[])
     const res = await request(app)
       .post('/api/v1/import/transform')
       .send({ content: 'txt' })


### PR DESCRIPTION
## Summary
- implement service and controller for managing Bilan section instances
- expose CRUD API routes with validation and integrate router in app
- cover listing of section instances with a dedicated test

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6890775d856483298bc37d98582b37c0