### PR TITLE
[frontend] refactor table typing

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -181,26 +181,32 @@ export default function AiRightPanel({
   type TableAnswers = Record<string, unknown> & { commentaire?: string };
 
   function markdownifyTable(q: Question, ansTable: TableAnswers): string {
-    if (!q.tableau?.colonnes) {
+    if (!q.tableau?.columns) {
       return '';
     }
 
     const header =
       `**${q.titre}**\n\n` +
-      `| ${['Ligne', ...q.tableau?.colonnes].join(' | ')} |\n` +
-      `| ${['---', ...q.tableau?.colonnes.map(() => '---')].join(' | ')} |\n`;
+      `| ${['Ligne', ...q.tableau.columns.map((c) => c.label)].join(' | ')} |\n` +
+      `| ${['---', ...q.tableau.columns.map(() => '---')].join(' | ')} |\n`;
 
     const body =
-      q.tableau?.lignes
-        ?.map((ligne) => {
-          const row = ansTable[ligne] as Record<string, unknown> | undefined;
-          const cells =
-            q.tableau?.colonnes?.map((col) => {
-              const v = (row?.[col] as string) || '';
-              return v;
-            }) || [];
-          return `| ${[ligne, ...cells].join(' | ')} |`;
-        })
+      q.tableau.sections
+        ?.flatMap((section) =>
+          section.rows.map((row) => {
+            const rowData = ansTable[row.id] as
+              | Record<string, unknown>
+              | undefined;
+            const cells =
+              q.tableau?.columns?.map((col) => {
+                const v = rowData?.[col.id];
+                return typeof v === 'string' || typeof v === 'number'
+                  ? String(v)
+                  : '';
+              }) || [];
+            return `| ${[row.label, ...cells].join(' | ')} |`;
+          }),
+        )
         .join('\n') || '';
 
     const commentVal = ansTable.commentaire;

--- a/frontend/src/components/ChoixTypeDeValeurTableau.tsx
+++ b/frontend/src/components/ChoixTypeDeValeurTableau.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { X } from 'lucide-react';
+import type { ColumnDef, ValueType } from '@/types/question';
+
+interface Props {
+  column: ColumnDef | null;
+  onClose: () => void;
+  onChange: (col: ColumnDef) => void;
+}
+
+export default function ChoixTypeDeValeurTableau({
+  column,
+  onClose,
+  onChange,
+}: Props) {
+  const [local, setLocal] = useState<ColumnDef | null>(column);
+
+  useEffect(() => {
+    setLocal(column);
+  }, [column]);
+
+  if (!column || !local) return null;
+
+  const updateOption = (idx: number, value: string) => {
+    const opts = [...(local.options || [])];
+    opts[idx] = value;
+    setLocal({ ...local, options: opts });
+  };
+
+  const removeOption = (idx: number) => {
+    const opts = (local.options || []).filter((_, i) => i !== idx);
+    setLocal({ ...local, options: opts });
+  };
+
+  const addOption = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setLocal({ ...local, options: [...(local.options || []), trimmed] });
+  };
+
+  return (
+    <Dialog open={!!column} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Type de valeur</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Type</Label>
+            <Select
+              value={local.valueType}
+              onValueChange={(v) =>
+                setLocal({
+                  ...local,
+                  valueType: v as ValueType,
+                  options: v === 'choice' ? local.options || [] : undefined,
+                })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="text">Texte</SelectItem>
+                <SelectItem value="number">Nombre</SelectItem>
+                <SelectItem value="bool">Booléen</SelectItem>
+                <SelectItem value="choice">Choix</SelectItem>
+                <SelectItem value="image">Image</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {local.valueType === 'choice' && (
+            <div className="space-y-2">
+              {local.options?.map((opt, idx) => (
+                <div key={idx} className="flex items-center gap-2">
+                  <Input
+                    value={opt}
+                    onChange={(e) => updateOption(idx, e.target.value)}
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => removeOption(idx)}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <Input
+                placeholder="Ajouter une option"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    addOption(e.currentTarget.value);
+                    e.currentTarget.value = '';
+                  }
+                }}
+                onBlur={(e) => {
+                  addOption(e.currentTarget.value);
+                  e.currentTarget.value = '';
+                }}
+              />
+            </div>
+          )}
+          <div className="flex justify-end">
+            <Button
+              onClick={() => {
+                onChange(local);
+                onClose();
+              }}
+            >
+              Valider
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ImportMagique.test.tsx
+++ b/frontend/src/components/ImportMagique.test.tsx
@@ -49,7 +49,20 @@ describe('ImportMagique', () => {
         id: expect.any(String),
         type: 'tableau',
         titre: 'Question sans titre',
-        tableau: { lignes: ['L1', 'L2'], colonnes: ['C1', 'C2'] },
+        tableau: expect.objectContaining({
+          columns: [
+            expect.objectContaining({ label: 'C1', valueType: 'text' }),
+            expect.objectContaining({ label: 'C2', valueType: 'text' }),
+          ],
+          sections: [
+            expect.objectContaining({
+              rows: [
+                expect.objectContaining({ label: 'L1' }),
+                expect.objectContaining({ label: 'L2' }),
+              ],
+            }),
+          ],
+        }),
       }),
     ]);
     expect(onCancel).toHaveBeenCalled();
@@ -65,7 +78,12 @@ describe('ImportMagique', () => {
           id: '1',
           type: 'tableau',
           titre: 'Question sans titre',
-          tableau: { lignes: ['L1'], colonnes: ['C1'] },
+          tableau: {
+            columns: [{ id: 'c1', label: 'C1', valueType: 'text' }],
+            sections: [
+              { id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] },
+            ],
+          },
         },
       ],
     });
@@ -94,7 +112,14 @@ describe('ImportMagique', () => {
     expect(onDone).toHaveBeenCalledWith([
       expect.objectContaining({
         type: 'tableau',
-        tableau: { lignes: ['L1'], colonnes: ['C1'] },
+        tableau: expect.objectContaining({
+          columns: [expect.objectContaining({ label: 'C1' })],
+          sections: [
+            expect.objectContaining({
+              rows: [expect.objectContaining({ label: 'L1' })],
+            }),
+          ],
+        }),
       }),
     ]);
     expect(onCancel).toHaveBeenCalled();

--- a/frontend/src/components/ImportMagique.tsx
+++ b/frontend/src/components/ImportMagique.tsx
@@ -6,7 +6,7 @@ import { DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { apiFetch } from '@/utils/api';
 import { useAuth } from '@/store/auth';
 import { cn } from '@/lib/utils';
-import type { Question } from '@/types/question';
+import type { Question, ColumnDef, Row } from '@/types/question';
 
 interface ImportMagiqueProps {
   onDone: (questions: Question[]) => void;
@@ -29,20 +29,24 @@ export default function ImportMagique({
   const transformTable = (rows: (string | number)[][]) => {
     if (rows.length === 0) return [];
     const header = rows[0];
-    const colonnes = header
+    const columns: ColumnDef[] = header
       .slice(1)
-      .map((c) => String(c).trim())
-      .filter(Boolean);
-    const lignes = rows
+      .map((c, idx) => ({
+        id: `c${idx}`,
+        label: String(c).trim(),
+        valueType: 'text',
+      }))
+      .filter((c) => c.label);
+    const lignes: Row[] = rows
       .slice(1)
-      .map((r) => String(r[0]).trim())
-      .filter(Boolean);
+      .map((r, idx) => ({ id: `r${idx}`, label: String(r[0]).trim() }))
+      .filter((r) => r.label);
     return [
       {
         id: Date.now().toString(),
         type: 'tableau' as const,
         titre: 'Question sans titre',
-        tableau: { lignes, colonnes },
+        tableau: { columns, sections: [{ id: 's1', title: '', rows: lignes }] },
       },
     ];
   };

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -24,21 +24,40 @@ const tableQuestion: Question = {
   id: '3',
   type: 'tableau',
   titre: 'Table',
-  tableau: { lignes: ['L1', 'L2'], colonnes: ['C1'] },
+  tableau: {
+    columns: [{ id: 'c1', label: 'C1', valueType: 'text' }],
+    sections: [
+      {
+        id: 's1',
+        title: '',
+        rows: [
+          { id: 'r1', label: 'L1' },
+          { id: 'r2', label: 'L2' },
+        ],
+      },
+    ],
+  },
 };
 
 const tableCommentQuestion: Question = {
   id: '5',
   type: 'tableau',
   titre: 'Table',
-  tableau: { lignes: ['L1'], colonnes: ['C1'], commentaire: true },
+  tableau: {
+    columns: [{ id: 'c1', label: 'C1', valueType: 'text' }],
+    sections: [{ id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] }],
+    commentaire: true,
+  },
 };
 
 const tableScoreQuestion: Question = {
   id: '6',
   type: 'tableau',
   titre: 'Table',
-  tableau: { lignes: ['L1'], colonnes: ['C1'], valeurType: 'score' },
+  tableau: {
+    columns: [{ id: 'c1', label: 'C1', valueType: 'number' }],
+    sections: [{ id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] }],
+  },
 };
 
 const tableSelectQuestion: Question = {
@@ -46,10 +65,15 @@ const tableSelectQuestion: Question = {
   type: 'tableau',
   titre: 'Table',
   tableau: {
-    lignes: ['L1'],
-    colonnes: ['C1'],
-    valeurType: 'choix-multiple',
-    options: ['A', 'B'],
+    columns: [
+      {
+        id: 'c1',
+        label: 'C1',
+        valueType: 'choice',
+        options: ['A', 'B'],
+      },
+    ],
+    sections: [{ id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] }],
   },
 };
 
@@ -57,7 +81,10 @@ const tableCheckQuestion: Question = {
   id: '8',
   type: 'tableau',
   titre: 'Table',
-  tableau: { lignes: ['L1'], colonnes: ['C1'], valeurType: 'case-a-cocher' },
+  tableau: {
+    columns: [{ id: 'c1', label: 'C1', valueType: 'bool' }],
+    sections: [{ id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] }],
+  },
 };
 
 const titleQuestion: Question = {

--- a/frontend/src/pages/CreationTrame.test.tsx
+++ b/frontend/src/pages/CreationTrame.test.tsx
@@ -42,7 +42,10 @@ it('shows table specific options', async () => {
           id: 't1',
           type: 'tableau',
           titre: 'Table',
-          tableau: { lignes: [], colonnes: [] },
+          tableau: {
+            columns: [],
+            sections: [{ id: 's1', title: '', rows: [] }],
+          },
         },
       ],
     }),
@@ -60,7 +63,9 @@ it('shows table specific options', async () => {
       name: /\+ Ajouter une zone de commentaire/i,
     }),
   ).toBeInTheDocument();
-  expect(screen.getByText(/Type de valeur/)).toBeInTheDocument();
+  expect(
+    screen.getByPlaceholderText(/Ajouter une colonne/),
+  ).toBeInTheDocument();
 });
 
 it('prompts to save when leaving and saves on confirm', async () => {

--- a/frontend/src/types/Typequestion.ts
+++ b/frontend/src/types/Typequestion.ts
@@ -19,17 +19,51 @@ export type ScaleQuestion = {
   echelle: { min: number; max: number; labels?: { min: string; max: string } };
 };
 
+export type ValueType = 'bool' | 'number' | 'text' | 'choice' | 'image';
+
+export type ColumnDef = {
+  id: string;
+  label: string;
+  valueType: ValueType;
+  /** Facultatif: enum pour 'choice' */
+  options?: string[];
+};
+
+export type Row = {
+  id: string;
+  /** Libellé principal (Markdown ou texte simple) */
+  label: string;
+  /** S’il y a une image plutôt qu’un texte */
+  media?: { src: string; alt?: string };
+  /** Pour les étiquettes coupées : ["La balle", "la plus grosse"] */
+  labelParts?: string[];
+};
+
+export type Footer = {
+  /** ex. "countTrue" ou "sum" */
+  formula: string;
+  columnId?: string; // si formule liée à une colonne (Oui / Non)
+  label?: string; // "/5"
+};
+
+export type Section = {
+  id: string;
+  title: string; // 1. PROFIL HYPOREACTIF
+  rows: Row[];
+  footer?: Footer;
+  showIndex?: boolean; // numérotation automatique
+};
+
+export type SurveyTable = {
+  columns: ColumnDef[];
+  sections: Section[];
+};
+
 export type TableQuestion = {
   id: string;
   type: 'tableau';
   titre: string;
-  tableau: {
-    lignes: string[];
-    colonnes?: string[];
-    valeurType?: 'texte' | 'score' | 'choix-multiple' | 'case-a-cocher';
-    options?: string[];
-    commentaire?: boolean;
-  };
+  tableau: SurveyTable & { commentaire?: boolean };
 };
 
 export type TitleQuestion = {

--- a/frontend/src/types/question.ts
+++ b/frontend/src/types/question.ts
@@ -1,3 +1,39 @@
+export type ValueType = 'bool' | 'number' | 'text' | 'choice' | 'image';
+
+export interface ColumnDef {
+  id: string;
+  label: string;
+  valueType: ValueType;
+  options?: string[];
+}
+
+export interface Row {
+  id: string;
+  label: string;
+  media?: { src: string; alt?: string };
+  labelParts?: string[];
+}
+
+export interface Footer {
+  formula: string;
+  columnId?: string;
+  label?: string;
+}
+
+export interface Section {
+  id: string;
+  title: string;
+  rows: Row[];
+  footer?: Footer;
+  showIndex?: boolean;
+}
+
+export interface SurveyTable {
+  columns: ColumnDef[];
+  sections: Section[];
+  commentaire?: boolean;
+}
+
 export interface Question {
   id: string;
   type: 'notes' | 'choix-multiple' | 'echelle' | 'tableau' | 'titre';
@@ -5,13 +41,7 @@ export interface Question {
   contenu?: string;
   options?: string[];
   echelle?: { min: number; max: number; labels?: { min: string; max: string } };
-  tableau?: {
-    lignes: string[];
-    colonnes?: string[];
-    valeurType?: 'texte' | 'score' | 'choix-multiple' | 'case-a-cocher';
-    options?: string[];
-    commentaire?: boolean;
-  };
+  tableau?: SurveyTable;
 }
 
 export type Answers = Record<


### PR DESCRIPTION
## Summary
- refactor table question types to support per-column value types and sections
- add ChoixTypeDeValeurTableau modal and update editors & data entry
- adapt import and AI export utilities to new table format

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_6890c1c25a648329a096ec1558580d3a