### PR TITLE
[frontend] support clipboard table import

### DIFF
--- a/backend/src/controllers/import.controller.ts
+++ b/backend/src/controllers/import.controller.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction } from 'express';
 import {
   transformText,
   transformImageToTable,
+  transformTextToTable,
 } from '../services/ai/generate.service';
 import { promptConfigs } from '../services/ai/prompts/promptconfig';
 
@@ -27,7 +28,54 @@ export const ImportController = {
         id: Date.now().toString(),
         type: 'tableau' as const,
         titre: 'Question sans titre',
-        tableau: table,
+        tableau: {
+          columns: table.colonnes.map((c: string, idx: number) => ({
+            id: `c${idx}`,
+            label: String(c).trim(),
+            valueType: 'text',
+          })),
+          sections: [
+            {
+              id: 's1',
+              title: '',
+              rows: table.lignes.map((l: string, idx: number) => ({
+                id: `r${idx}`,
+                label: String(l).trim(),
+              })),
+            },
+          ],
+        },
+      };
+      res.json({ result: [question] });
+    } catch (e) {
+      next(e);
+    }
+  },
+  async transformTextToTable(req: Request, res: Response, next: NextFunction) {
+    try {
+      const content = String(req.body.content || '');
+      const table = await transformTextToTable({ content });
+      const question = {
+        id: Date.now().toString(),
+        type: 'tableau' as const,
+        titre: 'Question sans titre',
+        tableau: {
+          columns: table.colonnes.map((c: string, idx: number) => ({
+            id: `c${idx}`,
+            label: String(c).trim(),
+            valueType: 'text',
+          })),
+          sections: [
+            {
+              id: 's1',
+              title: '',
+              rows: table.lignes.map((l: string, idx: number) => ({
+                id: `r${idx}`,
+                label: String(l).trim(),
+              })),
+            },
+          ],
+        },
       };
       res.json({ result: [question] });
     } catch (e) {

--- a/backend/src/routes/import.routes.ts
+++ b/backend/src/routes/import.routes.ts
@@ -5,3 +5,4 @@ export const importRouter = Router();
 
 importRouter.post('/transform', ImportController.transform);
 importRouter.post('/transform-image', ImportController.transformImage);
+importRouter.post('/transform-text-table', ImportController.transformTextToTable);

--- a/backend/src/services/ai/generate.service.ts
+++ b/backend/src/services/ai/generate.service.ts
@@ -35,6 +35,10 @@ import {
   generateTableFromImage,
   type TransformImageToTableParams,
 } from "./prompts/transformImageToTable";
+import {
+  generateTableFromText,
+  type TransformTextToTableParams,
+} from "./prompts/transformTextToTable";
 
 export async function transformText(params: TransformPromptParams) {
   // 1. RGPD pre-processing similar to generateText
@@ -51,10 +55,20 @@ export async function transformText(params: TransformPromptParams) {
 
 export async function transformImageToTable(
   params: TransformImageToTableParams,
-) {
+): Promise<{ colonnes: string[]; lignes: string[] }> {
   const sanitized = guardrails.pre(JSON.stringify(params));
   const structured = await generateTableFromImage(
     JSON.parse(sanitized) as TransformImageToTableParams,
   );
-  return guardrails.post(structured);
+  return guardrails.post(structured) as { colonnes: string[]; lignes: string[] };
+}
+
+export async function transformTextToTable(
+  params: TransformTextToTableParams,
+): Promise<{ colonnes: string[]; lignes: string[] }> {
+  const sanitized = guardrails.pre(JSON.stringify(params));
+  const structured = await generateTableFromText(
+    JSON.parse(sanitized) as TransformTextToTableParams,
+  );
+  return guardrails.post(structured) as { colonnes: string[]; lignes: string[] };
 }

--- a/backend/src/services/ai/guardrails.ts
+++ b/backend/src/services/ai/guardrails.ts
@@ -5,10 +5,10 @@ export function pre(text: string) {
   return text.replace(PHI_REGEX, "[REDACTED]");
 }
 
-export function post(text: string) {
+export function post<T>(text: T): T {
   // interdit contenu NSFW basique
-  if (/(\bsex\b|\bviolence\b)/i.test(text)) {
-    throw new Error("Content policy violation");
+  if (typeof text === 'string' && /(\bsex\b|\bviolence\b)/i.test(text)) {
+    throw new Error('Content policy violation');
   }
   return text;
 }

--- a/backend/src/services/ai/prompts/transformTextToTable.ts
+++ b/backend/src/services/ai/prompts/transformTextToTable.ts
@@ -1,0 +1,76 @@
+import OpenAI from 'openai'
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
+
+export interface TransformTextToTableParams {
+  content: string
+  systemPrompt?: string
+  instructions?: string
+}
+
+const DEFAULT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    colonnes: { type: 'array', items: { type: 'string' } },
+    lignes: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['colonnes', 'lignes'],
+} as const
+
+export function buildTransformTextToTablePrompt(
+  params: TransformTextToTableParams,
+) {
+  const msgs: ChatCompletionMessageParam[] = []
+
+  msgs.push({
+    role: 'system',
+    content:
+      (params.systemPrompt ??
+        "Tu extrais un tableau présent dans un texte (plain ou HTML) et tu renvoies un JSON structuré.").trim(),
+  })
+
+  const instructionText = `### Instructions\n${(
+    params.instructions ??
+    "Identifie les intitulés des colonnes et des lignes du tableau fourni. Retourne uniquement un JSON conforme au schéma fourni."
+  ).trim()}`
+
+  msgs.push({ role: 'user', content: params.content })
+
+  const schemaStr = JSON.stringify(DEFAULT_SCHEMA)
+  msgs.push({
+    role: 'user',
+    content: `### Schéma de sortie structuré (JSON)\n\`\`\`json\n${schemaStr}\n\`\`\``,
+  })
+
+  msgs.push({ role: 'user', content: instructionText })
+
+  return msgs
+}
+
+export async function generateTableFromText(
+  params: TransformTextToTableParams,
+) {
+  const openai = new OpenAI()
+  const messages = buildTransformTextToTablePrompt(params)
+
+  const response = await openai.chat.completions.create({
+    model: 'gpt-4o-2024-08-06',
+    messages,
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'transformTextToTable',
+        strict: true,
+        schema: DEFAULT_SCHEMA,
+      },
+    },
+  })
+
+  const content = response.choices[0].message.content
+  if (!content) {
+    throw new Error('No content in response from OpenAI API')
+  }
+
+  return JSON.parse(content)
+}
+

--- a/backend/tests/import.routes.test.ts
+++ b/backend/tests/import.routes.test.ts
@@ -3,12 +3,14 @@ import app from '../src/app'
 import {
   transformText,
   transformImageToTable,
+  transformTextToTable,
 } from '../src/services/ai/generate.service'
 
 jest.mock('../src/services/ai/generate.service')
 
 const mockedTransformText = transformText as unknown as jest.Mock
 const mockedTransformImage = transformImageToTable as unknown as jest.Mock
+const mockedTransformTextToTable = transformTextToTable as unknown as jest.Mock
 
 describe('POST /api/v1/import/transform', () => {
   it('calls ai service with content', async () => {
@@ -38,8 +40,43 @@ describe('POST /api/v1/import/transform-image', () => {
     expect(res.body.result[0]).toMatchObject({
       type: 'tableau',
       titre: 'Question sans titre',
-      tableau: { colonnes: ['C1'], lignes: ['L1'] },
+      tableau: {
+        columns: [expect.objectContaining({ label: 'C1' })],
+        sections: [
+          expect.objectContaining({
+            rows: [expect.objectContaining({ label: 'L1' })],
+          }),
+        ],
+      },
     })
     expect(mockedTransformImage).toHaveBeenCalledWith({ imageBase64: 'abc' })
+  })
+})
+
+describe('POST /api/v1/import/transform-text-table', () => {
+  it('calls ai service with text data', async () => {
+    mockedTransformTextToTable.mockResolvedValueOnce({
+      colonnes: ['C1'],
+      lignes: ['L1'],
+    })
+
+    const res = await request(app)
+      .post('/api/v1/import/transform-text-table')
+      .send({ content: 'txt' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.result[0]).toMatchObject({
+      type: 'tableau',
+      titre: 'Question sans titre',
+      tableau: {
+        columns: [expect.objectContaining({ label: 'C1' })],
+        sections: [
+          expect.objectContaining({
+            rows: [expect.objectContaining({ label: 'L1' })],
+          }),
+        ],
+      },
+    })
+    expect(mockedTransformTextToTable).toHaveBeenCalledWith({ content: 'txt' })
   })
 })


### PR DESCRIPTION
## Summary
- allow pasting plain text, html, or images into ImportMagique
- add backend prompt and endpoint to turn text into table questions
- handle failed transformations with an alert

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test -- -t "ImportMagique"` *(fails: shows table specific options, renders table rows, uses number input for score type, renders select for choix multiple type, renders checkbox for case a cocher type)*

------
https://chatgpt.com/codex/tasks/task_e_6890dc8dd8708329960d00c87e62b555