### PR TITLE
[backend] add section duplicate route

### DIFF
--- a/backend/src/controllers/section.controller.ts
+++ b/backend/src/controllers/section.controller.ts
@@ -32,6 +32,18 @@ export const SectionController = {
     }
   },
 
+  async duplicate(req: Request, res: Response, next: NextFunction) {
+    try {
+      const section = await SectionService.duplicate(
+        req.user.id,
+        req.params.sectionId,
+      );
+      res.status(201).json(section);
+    } catch (e) {
+      next(e);
+    }
+  },
+
   async update(req: Request, res: Response, next: NextFunction) {
     try {
       const section = await SectionService.update(

--- a/backend/src/routes/section.routes.ts
+++ b/backend/src/routes/section.routes.ts
@@ -14,6 +14,12 @@ sectionRouter
   .post(validateBody(createSectionSchema), SectionController.create)
   .get(SectionController.list);
 
+sectionRouter.post(
+  '/:sectionId/duplicate',
+  validateParams(sectionIdParam),
+  SectionController.duplicate,
+);
+
 sectionRouter
   .route('/:sectionId')
   .get(validateParams(sectionIdParam), SectionController.get)

--- a/backend/src/services/section.service.ts
+++ b/backend/src/services/section.service.ts
@@ -46,6 +46,32 @@ export const SectionService = {
     });
   },
 
+  async duplicate(userId: string, id: string) {
+    const profile = await db.profile.findUnique({ where: { userId } });
+    if (!profile) throw new Error('Profile not found for user');
+    const section = await db.section.findFirst({
+      where: {
+        id,
+        OR: [
+          { isPublic: true },
+          { author: { userId } },
+        ],
+      },
+    });
+    if (!section) throw new NotFoundError();
+    return db.section.create({
+      data: {
+        title: section.title,
+        kind: section.kind,
+        description: section.description,
+        schema: section.schema,
+        defaultContent: section.defaultContent,
+        isPublic: false,
+        authorId: profile.id,
+      },
+    });
+  },
+
   async update(userId: string, id: string, data: Partial<SectionData>) {
     const { count } = await db.section.updateMany({
       where: { id, author: { userId } },

--- a/backend/tests/section.routes.test.ts
+++ b/backend/tests/section.routes.test.ts
@@ -23,3 +23,17 @@ describe('GET /api/v1/sections', () => {
     expect(mockedService.list).toHaveBeenCalledWith('demo-user');
   });
 });
+
+describe('POST /api/v1/sections/:id/duplicate', () => {
+  it('duplicates a section using the service', async () => {
+    mockedService.duplicate.mockResolvedValueOnce({
+      id: '2',
+      title: 'Sec copy',
+    } as SectionStub);
+
+    const res = await request(app).post('/api/v1/sections/1/duplicate');
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe('2');
+    expect(mockedService.duplicate).toHaveBeenCalledWith('demo-user', '1');
+  });
+});


### PR DESCRIPTION
## Summary
- add route to duplicate sections
- implement service method to clone section for user
- test section duplication route

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Property 'columns' does not exist on type '{ colonnes: string[]; lignes: string[]; }')*


------
https://chatgpt.com/codex/tasks/task_e_6891aa4e2660832993ebc455fd887ae3