### PR TITLE
[frontend] Simplify refine mode selection logic

### DIFF
--- a/frontend/src/components/SelectionOverlay.test.tsx
+++ b/frontend/src/components/SelectionOverlay.test.tsx
@@ -22,4 +22,17 @@ describe('SelectionOverlay', () => {
     fireEvent.click(btn);
     expect(useEditorUi.getState().mode).toBe('refine');
   });
+
+  it('hides button when already in refine mode', () => {
+    const snap: SelectionSnapshot = {
+      rects: [new DOMRect(10, 20, 30, 40)],
+      text: 'demo',
+      htmlFragment: '<p>demo</p>',
+      restore: vi.fn(),
+      clear: vi.fn(),
+    };
+    useEditorUi.setState({ mode: 'refine', selection: snap, aiBlockId: null });
+    render(<SelectionOverlay />);
+    expect(screen.queryByText('Refine')).toBeNull();
+  });
 });

--- a/frontend/src/components/SelectionOverlay.tsx
+++ b/frontend/src/components/SelectionOverlay.tsx
@@ -4,9 +4,11 @@ import { useEditorUi } from '@/store/editorUi';
 
 export default function SelectionOverlay() {
   const selection = useEditorUi((s) => s.selection);
+  const mode = useEditorUi((s) => s.mode);
   const setMode = useEditorUi((s) => s.setMode);
 
-  if (!selection || selection.rects.length === 0) return null;
+  if (!selection || selection.rects.length === 0 || mode === 'refine')
+    return null;
   const rect = selection.rects[0];
   const style: React.CSSProperties = {
     position: 'absolute',
@@ -16,7 +18,12 @@ export default function SelectionOverlay() {
   };
 
   return createPortal(
-    <Button size="sm" style={style} onClick={() => setMode('refine')}>
+    <Button
+      size="sm"
+      style={style}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => setMode('refine')}
+    >
       Refine
     </Button>,
     document.body,

--- a/frontend/src/hooks/useVirtualSelection.test.tsx
+++ b/frontend/src/hooks/useVirtualSelection.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useRef } from 'react';
+import { useVirtualSelection } from './useVirtualSelection';
+import { useEditorUi } from '@/store/editorUi';
+
+function Wrapper() {
+  const ref = useRef<HTMLDivElement>(null);
+  useVirtualSelection(ref);
+  return (
+    <div>
+      <div ref={ref} data-testid="editor">
+        <span>hello</span>
+        <span>world</span>
+      </div>
+    </div>
+  );
+}
+
+function selectText(node: Node) {
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  const sel = window.getSelection();
+  sel?.removeAllRanges();
+  sel?.addRange(range);
+  document.dispatchEvent(new Event('selectionchange'));
+}
+
+describe('useVirtualSelection', () => {
+  beforeEach(() => {
+    useEditorUi.setState({ mode: 'idle', selection: null, aiBlockId: null });
+  });
+
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+  });
+
+  it('clears selection when clicking away in idle mode', () => {
+    const { getByTestId } = render(<Wrapper />);
+    const spans = getByTestId('editor').querySelectorAll('span');
+    selectText(spans[1]);
+    expect(useEditorUi.getState().selection?.text).toBe('world');
+    window.getSelection()?.removeAllRanges();
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(useEditorUi.getState().selection).toBeNull();
+  });
+
+  it('keeps and updates selection in refine mode', () => {
+    useEditorUi.setState({ mode: 'refine', selection: null, aiBlockId: null });
+    const { getByTestId } = render(<Wrapper />);
+    const spans = getByTestId('editor').querySelectorAll('span');
+    selectText(spans[1]);
+    expect(useEditorUi.getState().selection?.text).toBe('world');
+    window.getSelection()?.removeAllRanges();
+    document.dispatchEvent(new Event('selectionchange'));
+    expect(useEditorUi.getState().selection?.text).toBe('world');
+    selectText(spans[0]);
+    expect(useEditorUi.getState().selection?.text).toBe('hello');
+  });
+});

--- a/frontend/src/hooks/useVirtualSelection.ts
+++ b/frontend/src/hooks/useVirtualSelection.ts
@@ -7,10 +7,11 @@ export function useVirtualSelection(editorRef: React.RefObject<HTMLElement>) {
   useEffect(() => {
     const onChange = () => {
       const sel = window.getSelection();
+      const mode = useEditorUi.getState().mode;
 
       // Gérer le cas où il n'y a pas de sélection ou qu'elle est vide
       if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
-        setSelection(null);
+        if (mode !== 'refine') setSelection(null);
         return;
       }
 
@@ -18,7 +19,7 @@ export function useVirtualSelection(editorRef: React.RefObject<HTMLElement>) {
 
       // Gérer le clic en dehors de l'éditeur
       if (!editorRef.current?.contains(r.commonAncestorContainer)) {
-        setSelection(null);
+        if (mode !== 'refine') setSelection(null);
         return;
       }
 

--- a/frontend/src/pages/EditeurBilan.tsx
+++ b/frontend/src/pages/EditeurBilan.tsx
@@ -7,6 +7,7 @@ import { apiFetch } from '../utils/api';
 import { useAuth } from '../store/auth';
 import { useBilanDraft } from '../store/bilanDraft';
 import SelectionOverlay from '../components/SelectionOverlay';
+import { useEditorUi } from '../store/editorUi';
 
 const RichTextEditor = lazy(() => import('../components/RichTextEditor'));
 const AiRightPanel = lazy(() => import('../components/AiRightPanel'));
@@ -29,6 +30,8 @@ export default function Bilan() {
   const { descriptionHtml, setHtml, reset } = useBilanDraft();
   const editorRef = useRef<RichTextEditorHandle>(null);
   const [showConfirm, setShowConfirm] = useState(false);
+  const setMode = useEditorUi((s) => s.setMode);
+  const setSelection = useEditorUi((s) => s.setSelection);
 
   const hasChanges = bilan?.descriptionHtml !== descriptionHtml;
 
@@ -49,6 +52,13 @@ export default function Bilan() {
       setHtml(data.descriptionHtml ?? '');
     });
   }, [bilanId, token, setHtml]);
+
+  useEffect(() => {
+    return () => {
+      setMode('idle');
+      setSelection(null);
+    };
+  }, [setMode, setSelection]);
 
   const save = async () => {
     if (!bilanId) return;


### PR DESCRIPTION
## Summary
- Preserve text selection when refine mode is active and ignore outside clicks
- Hide refine overlay while refining and keep selection when clicking the button
- Reset refine state on bilan editor unmount and add unit tests for new selection behavior

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test src/components/SelectionOverlay.test.tsx src/hooks/useVirtualSelection.test.tsx`
- `pnpm --filter frontend run test src/pages/EditeurBilan.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68920ae00eb08329901642e1d1b4174a