### PR TITLE
[backend] Remove valueType from table prompts

### DIFF
--- a/backend/src/services/ai/prompts/transformImageToTable.ts
+++ b/backend/src/services/ai/prompts/transformImageToTable.ts
@@ -18,14 +18,10 @@ const DEFAULT_SCHEMA = {
         type: 'object',
         additionalProperties: false,
         properties: {
-          id:        { type: 'string' },
-          label:     { type: 'string' },
-          valueType: {
-            type: 'string',
-            enum: ['bool', 'number', 'text', 'choice', 'image'],
-          },
+          id:    { type: 'string' },
+          label: { type: 'string' },
         },
-        required: ['id', 'label', 'valueType'],
+        required: ['id', 'label'],
       },
     },
     rowsGroups: {

--- a/backend/src/services/ai/prompts/transformTextToTable.ts
+++ b/backend/src/services/ai/prompts/transformTextToTable.ts
@@ -17,14 +17,10 @@ const DEFAULT_SCHEMA = {
         type: 'object',
         additionalProperties: false,
         properties: {
-          id:        { type: 'string' },
-          label:     { type: 'string' },
-          valueType: {
-            type: 'string',
-            enum: ['bool', 'number', 'text', 'choice', 'image'],
-          },
+          id:    { type: 'string' },
+          label: { type: 'string' },
         },
-        required: ['id', 'label', 'valueType'],
+        required: ['id', 'label'],
       },
     },
     rowsGroups: {

--- a/backend/tests/import.routes.test.ts
+++ b/backend/tests/import.routes.test.ts
@@ -28,8 +28,10 @@ describe('POST /api/v1/import/transform', () => {
 describe('POST /api/v1/import/transform-image', () => {
   it('calls ai service with image data', async () => {
     mockedTransformImage.mockResolvedValueOnce({
-      colonnes: ['C1'],
-      lignes: ['L1'],
+      columns: [{ id: 'c1', label: 'C1' }],
+      rowsGroups: [
+        { id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] },
+      ],
     })
 
     const res = await request(app)
@@ -42,7 +44,7 @@ describe('POST /api/v1/import/transform-image', () => {
       titre: 'Question sans titre',
       tableau: {
         columns: [expect.objectContaining({ label: 'C1' })],
-        sections: [
+        rowsGroups: [
           expect.objectContaining({
             rows: [expect.objectContaining({ label: 'L1' })],
           }),
@@ -56,8 +58,10 @@ describe('POST /api/v1/import/transform-image', () => {
 describe('POST /api/v1/import/transform-text-table', () => {
   it('calls ai service with text data', async () => {
     mockedTransformTextToTable.mockResolvedValueOnce({
-      colonnes: ['C1'],
-      lignes: ['L1'],
+      columns: [{ id: 'c1', label: 'C1' }],
+      rowsGroups: [
+        { id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] },
+      ],
     })
 
     const res = await request(app)
@@ -70,7 +74,7 @@ describe('POST /api/v1/import/transform-text-table', () => {
       titre: 'Question sans titre',
       tableau: {
         columns: [expect.objectContaining({ label: 'C1' })],
-        sections: [
+        rowsGroups: [
           expect.objectContaining({
             rows: [expect.objectContaining({ label: 'L1' })],
           }),

--- a/frontend/src/components/ImportMagique.test.tsx
+++ b/frontend/src/components/ImportMagique.test.tsx
@@ -80,7 +80,7 @@ describe('ImportMagique', () => {
           type: 'tableau',
           titre: 'Question sans titre',
           tableau: {
-            columns: [{ id: 'c1', label: 'C1', valueType: 'text' }],
+            columns: [{ id: 'c1', label: 'C1' }],
             sections: [
               { id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] },
             ],
@@ -115,7 +115,9 @@ describe('ImportMagique', () => {
       expect.objectContaining({
         type: 'tableau',
         tableau: expect.objectContaining({
-          columns: [expect.objectContaining({ label: 'C1' })],
+          columns: [
+            expect.objectContaining({ label: 'C1', valueType: 'text' }),
+          ],
           sections: [
             expect.objectContaining({
               rows: [expect.objectContaining({ label: 'L1' })],
@@ -138,7 +140,7 @@ describe('ImportMagique', () => {
           type: 'tableau',
           titre: 'Question sans titre',
           tableau: {
-            columns: [{ id: 'c1', label: 'C1', valueType: 'text' }],
+            columns: [{ id: 'c1', label: 'C1' }],
             sections: [
               { id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] },
             ],
@@ -173,7 +175,9 @@ describe('ImportMagique', () => {
       expect.objectContaining({
         type: 'tableau',
         tableau: expect.objectContaining({
-          columns: [expect.objectContaining({ label: 'C1' })],
+          columns: [
+            expect.objectContaining({ label: 'C1', valueType: 'text' }),
+          ],
           sections: [
             expect.objectContaining({
               rows: [expect.objectContaining({ label: 'L1' })],
@@ -196,7 +200,7 @@ describe('ImportMagique', () => {
           type: 'tableau',
           titre: 'Question sans titre',
           tableau: {
-            columns: [{ id: 'c1', label: 'C1', valueType: 'text' }],
+            columns: [{ id: 'c1', label: 'C1' }],
             sections: [
               { id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] },
             ],
@@ -234,6 +238,16 @@ describe('ImportMagique', () => {
       '/api/v1/import/transform-image',
       expect.any(Object),
     );
+    expect(onDone).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: 'tableau',
+        tableau: expect.objectContaining({
+          columns: [
+            expect.objectContaining({ label: 'C1', valueType: 'text' }),
+          ],
+        }),
+      }),
+    ]);
     expect(onCancel).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- drop valueType from table extraction prompts
- default imported table columns to text valueType on frontend
- update import tests

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test tests/import.routes.test.ts`
- `pnpm --filter frontend exec eslint src/components/ImportMagique.tsx`
- `pnpm --filter frontend run test src/components/ImportMagique.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68939569bbc4832984371c29bff31ee1