### PR TITLE
[frontend][backend] Fix lint errors

### DIFF
--- a/frontend/src/components/Editors.tsx
+++ b/frontend/src/components/Editors.tsx
@@ -115,8 +115,6 @@ export function TableEditor({ q, onPatch }: EditorProps) {
         columns: [],
         rowsGroups: [{ id: genId(), title: '', rows: [] }],
       };
-  const lastIndex = tableau.rowsGroups.length - 1;
-
   const setTable = (tb: SurveyTable & { commentaire?: boolean }) => {
     onPatch({ tableau: tb } as Partial<Question>);
   };

--- a/frontend/src/components/ImportMagique.tsx
+++ b/frontend/src/components/ImportMagique.tsx
@@ -189,7 +189,10 @@ export default function ImportMagique({
 
         <div className="space-y-4">
           <p className="text-sm text-muted-foreground">
-            ✨ Collez simplement un document Word à partir de votre trame
+            <span role="img" aria-label="sparkles">
+              ✨
+            </span>{' '}
+            Collez simplement un document Word à partir de votre trame
             habituelle : il sera automatiquement importé et prêt à être utilisé
             dans l’application.
           </p>

--- a/frontend/src/lib/auth.keycloak.ts
+++ b/frontend/src/lib/auth.keycloak.ts
@@ -3,7 +3,10 @@ import type { Session } from '@supabase/supabase-js';
 import kc, { initKeycloak } from './keycloak';
 import { setAuthTokenGetter } from '../utils/authToken';
 
-type KcSession = { user: any | null; access_token: string | null };
+type KcSession = {
+  user: Record<string, unknown> | null;
+  access_token: string | null;
+};
 
 setAuthTokenGetter(() => kc.token || undefined);
 
@@ -42,7 +45,7 @@ export function createAuthProvider() {
         }
       }
 
-      // @ts-expect-error cast vers Session
+      // @ts-expect-error - cast vers Session
       return { data: { session: currentSession() as unknown as Session } };
     },
 
@@ -55,11 +58,11 @@ export function createAuthProvider() {
           const refreshed = await kc.updateToken(60);
           if (refreshed) {
             setAuthTokenGetter(() => kc.token || undefined);
-            // @ts-expect-error
+            // @ts-expect-error - token refresh emits loosely typed session
             callback('TOKEN_REFRESHED', currentSession() as unknown as Session);
           }
         } catch {
-          // @ts-expect-error
+          // @ts-expect-error - callback expects session type
           callback('SIGNED_OUT', null);
         }
       }, 20_000);

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,7 +2,7 @@
 const provider = (import.meta.env.VITE_AUTH_PROVIDER || 'fake').toLowerCase();
 console.log('AUTH PROVIDER =', provider);
 
-let authImpl: any;
+let authImpl: unknown;
 if (provider === 'keycloak') {
   const m = await import('./auth.keycloak');
   authImpl = m.createAuthProvider();


### PR DESCRIPTION
## Summary
- define token payload types and remove unused JWT import in backend auth middleware
- cleanup unused variables and improve accessibility in frontend components
- add type-safe handling and comments for Keycloak auth utilities

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter frontend run lint`
- `pnpm --filter backend run test` *(fails: Jest failed to parse jose ESM module)*
- `pnpm --filter frontend run test` *(fails: multiple Vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898d218bbc483299b9dd8ac1366a28e