### PR TITLE
[frontend] Save and display bilan titles

### DIFF
--- a/frontend/src/components/bilans/GenericTable.tsx
+++ b/frontend/src/components/bilans/GenericTable.tsx
@@ -16,7 +16,6 @@ export interface BilanItem {
   title: string;
   date: string;
   patient?: { firstName: string; lastName: string };
-  bilanType?: { name: string };
 }
 
 export type GenericItem = BilanItem | Patient;
@@ -86,9 +85,7 @@ export function GenericTable({
                         ? `${(item as BilanItem).patient!.firstName} ${(item as BilanItem).patient!.lastName}`
                         : ''}
                     </TableCell>
-                    <TableCell>
-                      {(item as BilanItem).bilanType?.name ?? ''}
-                    </TableCell>
+                    <TableCell>{(item as BilanItem).title}</TableCell>
                     <TableCell onClick={(e) => e.stopPropagation()}>
                       <Button
                         size="icon"

--- a/frontend/src/components/ui/creation-bilan-modal.test.tsx
+++ b/frontend/src/components/ui/creation-bilan-modal.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { CreationBilan } from './creation-bilan-modal';
 
 describe('CreationBilan', () => {
-  it('calls callbacks when selecting patient type', () => {
+  it('passes the title to callbacks', () => {
     const onNew = vi.fn();
     const onExisting = vi.fn();
     render(
@@ -14,9 +14,11 @@ describe('CreationBilan', () => {
         onExistingPatient={onExisting}
       />,
     );
+    const input = screen.getByLabelText(/titre du bilan/i);
+    fireEvent.change(input, { target: { value: 'Mon bilan' } });
     fireEvent.click(screen.getByText(/nouveau patient/i));
-    expect(onNew).toHaveBeenCalled();
+    expect(onNew).toHaveBeenCalledWith('Mon bilan');
     fireEvent.click(screen.getByText(/patient existant/i));
-    expect(onExisting).toHaveBeenCalled();
+    expect(onExisting).toHaveBeenCalledWith('Mon bilan');
   });
 });

--- a/frontend/src/components/ui/creation-bilan-modal.tsx
+++ b/frontend/src/components/ui/creation-bilan-modal.tsx
@@ -15,8 +15,8 @@ import { Label } from '@/components/ui/label';
 interface CreationBilanProps {
   isOpen: boolean;
   onClose: () => void;
-  onNewPatient: () => void;
-  onExistingPatient: () => void;
+  onNewPatient: (title: string) => void;
+  onExistingPatient: (title: string) => void;
 }
 
 export function CreationBilan({
@@ -51,7 +51,7 @@ export function CreationBilan({
             type="button"
             variant="outline"
             onClick={() => {
-              onNewPatient();
+              onNewPatient(title);
               handleClose();
             }}
           >
@@ -60,7 +60,7 @@ export function CreationBilan({
           <Button
             type="button"
             onClick={() => {
-              onExistingPatient();
+              onExistingPatient(title);
               handleClose();
             }}
           >

--- a/frontend/src/pages/MesBilans.test.tsx
+++ b/frontend/src/pages/MesBilans.test.tsx
@@ -17,7 +17,7 @@ describe('BilanV2 page', () => {
             id: '1',
             date: '2024-01-01',
             patient: { firstName: 'John', lastName: 'Doe' },
-            bilanType: { name: 'Initial' },
+            title: 'Bilan initial',
           },
         ]),
     });
@@ -32,6 +32,7 @@ describe('BilanV2 page', () => {
 
     await waitFor(() => expect(fetch).toHaveBeenCalled());
     expect(await screen.findByText(/John Doe/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bilan initial/)).toBeInTheDocument();
   });
 
   it('deletes bilan after confirmation', async () => {
@@ -46,7 +47,7 @@ describe('BilanV2 page', () => {
               id: '1',
               date: '2024-01-01',
               patient: { firstName: 'John', lastName: 'Doe' },
-              bilanType: { name: 'Initial' },
+              title: 'Bilan initial',
             },
           ]),
       })
@@ -79,6 +80,9 @@ describe('BilanV2 page', () => {
     );
     await waitFor(() =>
       expect(screen.queryByText(/John Doe/)).not.toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText(/Bilan initial/)).not.toBeInTheDocument(),
     );
   });
 });

--- a/frontend/src/pages/MesBilans.tsx
+++ b/frontend/src/pages/MesBilans.tsx
@@ -27,6 +27,7 @@ export default function Component() {
   const token = useAuth((s) => s.token);
   const navigate = useNavigate();
   const [isCreationModalOpen, setIsCreationModalOpen] = useState(false);
+  const [bilanTitle, setBilanTitle] = useState('');
 
   useEffect(() => {
     if (!token) return;
@@ -159,18 +160,24 @@ export default function Component() {
       <CreationBilan
         isOpen={isCreationModalOpen}
         onClose={() => setIsCreationModalOpen(false)}
-        onNewPatient={() => setIsNewPatientModalOpen(true)}
-        onExistingPatient={() => setIsExistingPatientModalOpen(true)}
+        onNewPatient={(title) => {
+          setBilanTitle(title);
+          setIsNewPatientModalOpen(true);
+        }}
+        onExistingPatient={(title) => {
+          setBilanTitle(title);
+          setIsExistingPatientModalOpen(true);
+        }}
       />
       <NewPatientModal
         isOpen={isNewPatientModalOpen}
         onClose={() => setIsNewPatientModalOpen(false)}
-        onPatientCreated={createBilan}
+        onPatientCreated={(id) => createBilan(id, bilanTitle)}
       />
       <ExistingPatientModal
         isOpen={isExistingPatientModalOpen}
         onClose={() => setIsExistingPatientModalOpen(false)}
-        onPatientSelected={createBilan}
+        onPatientSelected={(id) => createBilan(id, bilanTitle)}
       />
       <ConfirmDialog
         open={!!toDelete}


### PR DESCRIPTION
## Summary
- Forward new bilan titles from CreationBilan modal
- Persist and show bilan titles in MesBilans table
- Add tests for title propagation and rendering

## Testing
- `pnpm --filter frontend run lint` *(fails: Unexpected any, no-unused-vars)*
- `pnpm --filter frontend run test` *(fails: 4 failed, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899ac749e88832999d25fa1f8d5d398