### PR TITLE
[frontend] Add tab filtering to AI wizard trames

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -80,6 +80,9 @@ const useTrames = () => {
           label: s.title,
           description: s.description,
           schema: (s.schema || []) as Question[],
+          isPublic: s.isPublic,
+          authorId: s.authorId,
+          author: s.author,
         }));
     });
     return res;

--- a/frontend/src/components/WizardAIRightPanel.tsx
+++ b/frontend/src/components/WizardAIRightPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import {
@@ -12,6 +12,8 @@ import ExitConfirmation from './ExitConfirmation';
 import { Loader2, Plus, Wand2, X } from 'lucide-react';
 import { apiFetch } from '@/utils/api';
 import { useAuth } from '@/store/auth';
+import { Tabs } from '@/components/ui/tabs';
+import { useUserProfileStore } from '@/store/userProfile';
 
 const kindMap: Record<string, string> = {
   anamnese: 'anamnese',
@@ -62,6 +64,44 @@ export default function WizardAIRightPanel({
   const token = useAuth((s) => s.token);
   const [instanceId, setInstanceId] = useState<string | null>(null);
   const [showConfirm, setShowConfirm] = useState(false);
+  const { profile, fetchProfile } = useUserProfileStore();
+  const profileId = useMemo(
+    () => profile?.id ?? (profile as any)?.id ?? null,
+    [profile],
+  );
+  const OFFICIAL_AUTHOR_ID = import.meta.env.VITE_OFFICIAL_AUTHOR_ID;
+
+  useEffect(() => {
+    fetchProfile().catch(() => {});
+  }, [fetchProfile]);
+
+  const myTrames = trameOptions.filter(
+    (s) => !!profileId && s.authorId === profileId,
+  );
+  const officialTrames = trameOptions.filter(
+    (s) =>
+      !!OFFICIAL_AUTHOR_ID &&
+      s.isPublic &&
+      s.authorId === OFFICIAL_AUTHOR_ID,
+  );
+  const communityTrames = trameOptions.filter(
+    (s) =>
+      s.isPublic &&
+      (!OFFICIAL_AUTHOR_ID || s.authorId !== OFFICIAL_AUTHOR_ID),
+  );
+  const [activeTab, setActiveTab] = useState<'mine' | 'official' | 'community'>(
+    'community',
+  );
+  const matchesActiveFilter = (s: TrameOption) => {
+    if (activeTab === 'mine') return !!profileId && s.authorId === profileId;
+    if (activeTab === 'official')
+      return (
+        !!OFFICIAL_AUTHOR_ID &&
+        s.isPublic &&
+        s.authorId === OFFICIAL_AUTHOR_ID
+      );
+    return s.isPublic && (!OFFICIAL_AUTHOR_ID || s.authorId !== OFFICIAL_AUTHOR_ID);
+  };
 
   // Preload latest notes when section/trame changes
   useEffect(() => {
@@ -105,19 +145,48 @@ export default function WizardAIRightPanel({
   let content: JSX.Element | null = null;
 
   if (step === 1) {
+    const displayedTrames = trameOptions.filter(matchesActiveFilter);
     content = (
       <div className="space-y-4">
         <p className="text-md">
           Choisissez une trame parmi notre bibliothèque:
         </p>
+        <Tabs
+          active={activeTab}
+          onChange={(k) =>
+            setActiveTab(k as 'mine' | 'official' | 'community')
+          }
+          tabs={[
+            {
+              key: 'mine',
+              label: 'Mes trames',
+              count: myTrames.length,
+              hidden: myTrames.length === 0,
+            },
+            {
+              key: 'official',
+              label: 'Trames Bilan Plume',
+              count: officialTrames.length,
+            },
+            {
+              key: 'community',
+              label: 'Trames de la communauté',
+              count: communityTrames.length,
+            },
+          ]}
+        />
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 overflow-auto-y">
-          {trameOptions.map((trame) => (
+          {displayedTrames.map((trame) => (
             <TrameCard
               key={trame.value}
               trame={{
                 id: trame.value,
                 title: trame.label,
                 description: trame.description,
+                sharedBy:
+                  trame.isPublic && trame.author?.prenom
+                    ? trame.author.prenom
+                    : undefined,
               }}
               selected={selectedTrame?.value === trame.value}
               onSelect={() => onTrameChange(trame.value)}

--- a/frontend/src/components/bilan/TrameSelector.tsx
+++ b/frontend/src/components/bilan/TrameSelector.tsx
@@ -25,6 +25,9 @@ export interface TrameOption {
   label: string;
   description?: string | null;
   schema?: unknown;
+  isPublic?: boolean;
+  authorId?: string | null;
+  author?: { prenom?: string | null } | null;
 }
 
 export interface TrameExample {


### PR DESCRIPTION
## Summary
- allow TrameOption to include author info and visibility flags
- surface section author data in AI panel
- add tabs filtering (mine/official/community) for trame selection in wizard

## Testing
- `pnpm run lint`
- `pnpm run test` *(fails: Test Files 3 failed | 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899be8ba7e48329ac87452944031cd3