### PR TITLE
[frontend] refactor DataEntry into subcomponents

### DIFF
--- a/frontend/src/components/bilan/Chip.tsx
+++ b/frontend/src/components/bilan/Chip.tsx
@@ -1,0 +1,29 @@
+import { Check } from 'lucide-react';
+import React from 'react';
+
+interface ChipProps {
+  selected: boolean;
+  children: React.ReactNode;
+  onClick: () => void;
+}
+
+export function Chip({ selected, children, onClick }: ChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={[
+        'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40',
+        selected
+          ? 'bg-primary-50 text-primary-700 border-primary-400'
+          : 'bg-white text-gray-800 border-gray-300 hover:bg-gray-50',
+        'shadow-sm',
+      ].join(' ')}
+    >
+      {selected ? <Check className="h-3.5 w-3.5" /> : null}
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, forwardRef, useImperativeHandle, useRef } from 'react';
+import {
+  useState,
+  useEffect,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -8,18 +14,10 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-
 import { Plus, Edit2 } from 'lucide-react';
-import type { Question, Answers, ColumnDef } from '@/types/question';
+import type { Question, Answers } from '@/types/question';
+import { QuestionRenderer } from './QuestionRenderer';
+import { GroupedQuestionsNav } from './GroupedQuestionsNav';
 
 interface DataEntryProps {
   questions: Question[];
@@ -28,52 +26,19 @@ interface DataEntryProps {
   inline?: boolean;
 }
 
-const FIELD_BASE =
-  "rounded-lg border border-gray-300 bg-white shadow-sm focus-visible:ring-2 focus-visible:ring-primary-500/40 focus-visible:outline-none";
-
-const FIELD_DENSE = "h-9 px-3"; // pour <Input> compacts
-
-
-import { Check } from "lucide-react";
-
-function Chip({
-  selected,
-  children,
-  onClick,
-}: {
-  selected: boolean;
-  children: React.ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={selected}
-      className={[
-        // base
-        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40",
-        // states
-        selected
-          ? "bg-primary-50 text-primary-700 border-primary-400"
-          : "bg-white text-gray-800 border-gray-300 hover:bg-gray-50",
-        // shadow
-        "shadow-sm",
-      ].join(" ")}
-    >
-      {selected ? <Check className="h-3.5 w-3.5" /> : null}
-      {children}
-    </button>
-  );
-}
-
 export interface DataEntryHandle {
   save: () => Answers | void;
   getAnswers: () => Answers;
   load: (values: Answers) => void;
   clear: () => void;
 }
+
+type QuestionGroup = {
+  id: string;
+  title: string;
+  index: number;
+  items: Question[];
+};
 
 export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
   function DataEntry(
@@ -84,18 +49,21 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
     const [local, setLocal] = useState<Answers>({});
     const [errors, setErrors] = useState<Record<string, string>>({});
 
-    type questionGroup = { id: string; title: string; index: number; items: Question[] };
-
-    const groups: questionGroup[] = (() => {
-      const res: questionGroup[] = [];
-      let current: questionGroup | null = null;
-      questions.forEach((q, i) => {
-        if (q.type === "titre") {
-          current = { id: `sec-${res.length}`, title: q.titre ?? "Groupe de question", index: res.length, items: [] };
+    const groups: QuestionGroup[] = (() => {
+      const res: QuestionGroup[] = [];
+      let current: QuestionGroup | null = null;
+      questions.forEach((q) => {
+        if (q.type === 'titre') {
+          current = {
+            id: `sec-${res.length}`,
+            title: q.titre ?? 'Groupe de question',
+            index: res.length,
+            items: [],
+          };
           res.push(current);
         } else {
           if (!current) {
-            current = { id: `sec-0`, title: "Général", index: 0, items: [] };
+            current = { id: `sec-0`, title: 'Général', index: 0, items: [] };
             res.push(current);
           }
           current.items.push(q);
@@ -105,10 +73,7 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
     })();
 
     const [activeSec, setActiveSec] = useState(0);
-    const secRefs = groups.map(() => useState<HTMLDivElement | null>(null)[0]); // placeholder
-    const containerRef = useState<HTMLDivElement | null>(null)[0]; // pour le scroll area
-
-    // Crée un tableau de refs persistants
+    const containerRef = useRef<HTMLDivElement | null>(null);
     const groupEls = useRef<(HTMLDivElement | null)[]>([]);
     if (groupEls.current.length !== groups.length) {
       groupEls.current = Array(groups.length).fill(null);
@@ -119,13 +84,19 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
         (entries) => {
           const visible = entries
             .filter((e) => e.isIntersecting)
-            .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+            .sort(
+              (a, b) => a.boundingClientRect.top - b.boundingClientRect.top,
+            );
           if (visible[0]) {
-            const idx = Number(visible[0].target.getAttribute("data-idx"));
+            const idx = Number(visible[0].target.getAttribute('data-idx'));
             if (!Number.isNaN(idx)) setActiveSec(idx);
           }
         },
-        { root: document.querySelector("#dataentry-scroll-root"), rootMargin: "-20% 0px -70% 0px", threshold: 0.01 }
+        {
+          root: containerRef.current,
+          rootMargin: '-20% 0px -70% 0px',
+          threshold: 0.01,
+        },
       );
       groupEls.current.forEach((el) => el && obs.observe(el));
       return () => obs.disconnect();
@@ -133,34 +104,17 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
 
     const goTo = (i: number) => {
       const el = groupEls.current[i];
-      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     };
-    
+
     const goNext = () => goTo(Math.min(activeSec + 1, groups.length - 1));
     const goPrev = () => goTo(Math.max(activeSec - 1, 0));
-    
+
     useEffect(() => {
       setLocal(answers);
     }, [answers]);
 
     const answeredCount = Object.keys(answers).length;
-
-    const validateEchelle = (q: Question, v: string) => {
-      if (q.type !== 'echelle' || !q.echelle) return;
-      const num = Number(v);
-      if (v === '') {
-        setErrors((p) => ({ ...p, [q.id]: '' }));
-        return;
-      }
-      if (isNaN(num) || num < q.echelle.min || num > q.echelle.max) {
-        setErrors((p) => ({
-          ...p,
-          [q.id]: `Valeur entre ${q.echelle.min} et ${q.echelle.max}`,
-        }));
-      } else {
-        setErrors((p) => ({ ...p, [q.id]: '' }));
-      }
-    };
 
     const save = () => {
       if (Object.values(errors).some((e) => e)) {
@@ -178,226 +132,50 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
       clear: () => setLocal({}),
     }));
 
-    const renderQuestion = (q: Question) => {
-      const value = local[q.id] ?? '';
-      switch (q.type) {
-        case 'notes':
-          return (
-            <Textarea
-              value={String(value)}
-              onChange={(e) => setLocal({ ...local, [q.id]: e.target.value })}
-              placeholder={q.contenu}
-              className={`min-h-20 ${FIELD_BASE}`}
-            />
-          );
-        case "choix-multiple":
-          return (
-            <div className="flex flex-wrap gap-2">
-              {q.options?.map((opt) => (
-                <Chip
-                  key={opt}
-                  selected={value === opt}
-                  onClick={() => setLocal({ ...local, [q.id]: opt })}
-                >
-                  {opt}
-                </Chip>
-              ))}
-            </div>
-          );
-        case 'echelle':
-          return (
-            <div className="space-y-1">
-              <Input
-                type="number"
-                value={String(value)}
-                min={q.echelle?.min}
-                max={q.echelle?.max}
-                onChange={(e) => {
-                  setLocal({ ...local, [q.id]: e.target.value });
-                  validateEchelle(q, e.target.value);
-                }}
-                className={`${FIELD_BASE} ${FIELD_DENSE}`}
-              />
-              {errors[q.id] && (
-                <p className="text-xs text-red-600">{errors[q.id]}</p>
-              )}
-            </div>
-          );
-        case 'tableau':
-          let data: Record<string, Record<string, unknown>> & {
-            commentaire?: string;
-          } = {};
-          if (
-            local[q.id] &&
-            typeof local[q.id] === 'object' &&
-            !Array.isArray(local[q.id])
-          ) {
-            data = local[q.id] as Record<string, Record<string, unknown>> & {
-              commentaire?: string;
-            };
-          }
-          const renderCell = (rowId: string, col: ColumnDef) => {
-            const cellValue = data[rowId]?.[col.id];
-            const update = (v: unknown) => {
-              const row = data[rowId] || {};
-              const updatedRow = { ...row, [col.id]: v };
-              const updated = { ...data, [rowId]: updatedRow };
-              setLocal({ ...local, [q.id]: updated });
-            };
-            switch (col.valueType) {
-              case 'number':
-                return (
-                  <Input
-                    type="number"
-                    size="sm"
-                    value={(cellValue as number | string | undefined) ?? ''}
-                    onChange={(e) =>
-                      update(
-                        e.target.value === '' ? '' : Number(e.target.value),
-                      )
-                    }
-                    className={`${FIELD_BASE} ${FIELD_DENSE}`}
-                  />
-                );
-              case 'choice':
-                return (
-                  <Select
-                    value={(cellValue as string) ?? ''}
-                    onValueChange={(v) => update(v)}
-                  >
-                    <SelectTrigger className="h-8 w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {col.options?.map((opt) => (
-                        <SelectItem key={opt} value={opt}>
-                          {opt}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                );
-              case 'bool':
-                return (
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500/40"
-                    checked={Boolean(cellValue)}
-                    onChange={(e) => update(e.target.checked)}
-                  />
-                );
-              case 'image':
-                return (
-                  <Input
-                    size="sm"
-                    value={(cellValue as string) ?? ''}
-                    onChange={(e) => update(e.target.value)}
-                    placeholder="URL"
-                    className={`${FIELD_BASE} ${FIELD_DENSE}`}
-                  />
-                );
-              default:
-                return (
-                  <Input
-                    size="sm"
-                    value={(cellValue as string) ?? ''}
-                    onChange={(e) => update(e.target.value)}
-                  />
-                );
-            }
-          };
-          return (
-            <div className="space-y-2">
-              {q.tableau?.rowsGroups?.map((rowsGroup) => (
-                <div key={rowsGroup.id} className="mb-4">
-                  {rowsGroup.title && (
-                    <div className="px-2 py-1 font-bold text-sm">
-                      {rowsGroup.title}
-                    </div>
-                  )}
-                  <table className="w-full table-fixed border-collapse">
-                    <thead>
-                      <tr>
-                        <th className="px-2 py-1"></th>
-                        {q.tableau?.columns?.map((col) => (
-                          <th
-                            key={col.id}
-                            className="px-2 py-1 text-xs font-medium text-left"
-                          >
-                            {col.label}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {rowsGroup.rows.map((row) => (
-                        <tr key={row.id}>
-                          <td className="px-2 py-1 text-xs font-medium">
-                            {row.label}
-                          </td>
-                          {q.tableau?.columns?.map((col) => (
-                            <td key={col.id} className="px-2 py-1">
-                              {renderCell(row.id, col)}
-                            </td>
-                          ))}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              ))}
-              {q.tableau?.commentaire && (
-                <div>
-                  <Label className="text-sm font-medium">Commentaire</Label>
-                  <Textarea
-                    value={data.commentaire || ''}
-                    onChange={(e) =>
-                      setLocal({
-                        ...local,
-                        [q.id]: { ...data, commentaire: e.target.value },
-                      })
-                    }
-                  />
-                </div>
-              )}
-            </div>
-          );
-        case 'titre':
-          return null;
-        default:
-          return null;
-      }
-    };
-
-    const form = (
-      <div className="space-y-4">
-        {questions.map((q) => (
+    const inlineForm = (
+      <div id="dataentry-scroll-root" ref={containerRef} className="space-y-8">
+        {groups.map((group, i) => (
           <div
-            key={q.id}
-            className={`space-y-2 p-2 rounded-md ${
-              q.type === 'notes' ? 'focus-within:bg-wood-200/50' : ''
-            }`}
+            key={group.id}
+            data-idx={i}
+            ref={(el) => (groupEls.current[i] = el)}
+            className="space-y-4"
           >
-            {q.type === 'titre' ? (
-              <div className="mt-8 border-t border-gray-200 pt-4 flex items-center gap-2">
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary-100 text-primary-700 text-sm font-bold">
-                  {q.icon ?? '•'}
-                </span>
-                <h3 className="text-xl font-bold">{q.titre}</h3>
+            <h3 className="text-xl font-bold mt-8 border-t border-gray-200 pt-4">
+              {group.title}
+            </h3>
+            {group.items.map((q) => (
+              <div key={q.id} className="space-y-2 p-2 rounded-md">
+                <Label className="block text-sm font-medium text-gray-800 mb-1">
+                  {q.titre}
+                </Label>
+                <QuestionRenderer
+                  question={q}
+                  value={local[q.id]}
+                  onChange={(v) => setLocal({ ...local, [q.id]: v })}
+                  error={errors[q.id]}
+                  setError={(msg) => setErrors((p) => ({ ...p, [q.id]: msg }))}
+                />
               </div>
-            ) : (
-              <>
-                <Label className="block text-sm font-medium text-gray-800 mb-1">{q.titre}</Label>
-                {renderQuestion(q)}
-              </>
-            )}
+            ))}
           </div>
         ))}
       </div>
     );
 
     if (inline) {
-      return <div className="mb-4">{form}</div>;
+      return (
+        <div className="mb-4">
+          <GroupedQuestionsNav
+            groups={groups}
+            active={activeSec}
+            onNavigate={goTo}
+            onPrev={goPrev}
+            onNext={goNext}
+          />
+          {inlineForm}
+        </div>
+      );
     }
 
     return (
@@ -435,7 +213,15 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                     ) : (
                       <>
                         <Label className="text-sm font-medium">{q.titre}</Label>
-                        {renderQuestion(q)}
+                        <QuestionRenderer
+                          question={q}
+                          value={local[q.id]}
+                          onChange={(v) => setLocal({ ...local, [q.id]: v })}
+                          error={errors[q.id]}
+                          setError={(msg) =>
+                            setErrors((p) => ({ ...p, [q.id]: msg }))
+                          }
+                        />
                       </>
                     )}
                   </div>
@@ -480,7 +266,7 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                     <div
                       key={q.id}
                       className={`space-y-2 p-2 rounded-md border border-gray-200${
-                        q.type === 'notes' ? 'focus-within:bg-blue-50/50' : ''
+                        q.type === 'notes' ? ' focus-within:bg-blue-50/50' : ''
                       }`}
                     >
                       {q.type === 'titre' ? (
@@ -490,7 +276,15 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                           <Label className="text-sm font-medium">
                             {q.titre}
                           </Label>
-                          {renderQuestion(q)}
+                          <QuestionRenderer
+                            question={q}
+                            value={local[q.id]}
+                            onChange={(v) => setLocal({ ...local, [q.id]: v })}
+                            error={errors[q.id]}
+                            setError={(msg) =>
+                              setErrors((p) => ({ ...p, [q.id]: msg }))
+                            }
+                          />
                         </>
                       )}
                     </div>

--- a/frontend/src/components/bilan/GroupedQuestionsNav.tsx
+++ b/frontend/src/components/bilan/GroupedQuestionsNav.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+interface QuestionGroup {
+  id: string;
+  title: string;
+  index: number;
+}
+
+interface GroupedQuestionsNavProps {
+  groups: QuestionGroup[];
+  active: number;
+  onNavigate: (index: number) => void;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export function GroupedQuestionsNav({
+  groups,
+  active,
+  onNavigate,
+  onPrev,
+  onNext,
+}: GroupedQuestionsNavProps) {
+  return (
+    <div className="sticky top-0 z-10 bg-white flex items-center gap-2 py-2 shadow mb-4">
+      <Button size="sm" variant="outline" onClick={onPrev}>
+        Prev
+      </Button>
+      <div className="flex-1 flex justify-center gap-2 overflow-x-auto">
+        {groups.map((g, i) => (
+          <button
+            key={g.id}
+            onClick={() => onNavigate(i)}
+            className={`px-2 py-1 text-sm ${i === active ? 'font-bold underline' : ''}`}
+          >
+            {g.title}
+          </button>
+        ))}
+      </div>
+      <Button size="sm" variant="outline" onClick={onNext}>
+        Suiv
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/bilan/QuestionRenderer.tsx
+++ b/frontend/src/components/bilan/QuestionRenderer.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Chip } from './Chip';
+import { TableQuestion } from './TableQuestion';
+import type { Question } from '@/types/question';
+
+const FIELD_BASE =
+  'rounded-lg border border-gray-300 bg-white shadow-sm focus-visible:ring-2 focus-visible:ring-primary-500/40 focus-visible:outline-none';
+const FIELD_DENSE = 'h-9 px-3';
+
+interface QuestionRendererProps {
+  question: Question;
+  value: any;
+  onChange: (value: any) => void;
+  error?: string;
+  setError: (msg: string) => void;
+}
+
+export function QuestionRenderer({
+  question,
+  value,
+  onChange,
+  error,
+  setError,
+}: QuestionRendererProps) {
+  switch (question.type) {
+    case 'notes':
+      return (
+        <Textarea
+          value={String(value ?? '')}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={question.contenu}
+          className={`min-h-20 ${FIELD_BASE}`}
+        />
+      );
+    case 'choix-multiple':
+      return (
+        <div className="flex flex-wrap gap-2">
+          {question.options?.map((opt) => (
+            <Chip
+              key={opt}
+              selected={value === opt}
+              onClick={() => onChange(opt)}
+            >
+              {opt}
+            </Chip>
+          ))}
+        </div>
+      );
+    case 'echelle':
+      return (
+        <div className="space-y-1">
+          <Input
+            type="number"
+            value={String(value ?? '')}
+            min={question.echelle?.min}
+            max={question.echelle?.max}
+            onChange={(e) => {
+              const v = e.target.value;
+              onChange(v);
+              if (!question.echelle) return;
+              if (v === '') {
+                setError('');
+                return;
+              }
+              const num = Number(v);
+              if (
+                isNaN(num) ||
+                num < question.echelle.min ||
+                num > question.echelle.max
+              ) {
+                setError(
+                  `Valeur entre ${question.echelle.min} et ${question.echelle.max}`,
+                );
+              } else {
+                setError('');
+              }
+            }}
+            className={`${FIELD_BASE} ${FIELD_DENSE}`}
+          />
+          {error && <p className="text-xs text-red-600">{error}</p>}
+        </div>
+      );
+    case 'tableau':
+      return (
+        <TableQuestion question={question} value={value} onChange={onChange} />
+      );
+    case 'titre':
+      return null;
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/bilan/TableQuestion.tsx
+++ b/frontend/src/components/bilan/TableQuestion.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import type { Question, ColumnDef } from '@/types/question';
+
+const FIELD_BASE =
+  'rounded-lg border border-gray-300 bg-white shadow-sm focus-visible:ring-2 focus-visible:ring-primary-500/40 focus-visible:outline-none';
+const FIELD_DENSE = 'h-9 px-3';
+
+interface TableQuestionProps {
+  question: Question;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}
+
+export function TableQuestion({
+  question,
+  value,
+  onChange,
+}: TableQuestionProps) {
+  let data: Record<string, Record<string, unknown>> & { commentaire?: string } =
+    {};
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    data = value as Record<string, Record<string, unknown>> & {
+      commentaire?: string;
+    };
+  }
+
+  const renderCell = (rowId: string, col: ColumnDef) => {
+    const cellValue = data[rowId]?.[col.id];
+    const update = (v: unknown) => {
+      const row = data[rowId] || {};
+      const updatedRow = { ...row, [col.id]: v };
+      const updated = { ...data, [rowId]: updatedRow };
+      onChange(updated);
+    };
+    switch (col.valueType) {
+      case 'number':
+        return (
+          <Input
+            type="number"
+            size="sm"
+            value={(cellValue as number | string | undefined) ?? ''}
+            onChange={(e) =>
+              update(e.target.value === '' ? '' : Number(e.target.value))
+            }
+            className={`${FIELD_BASE} ${FIELD_DENSE}`}
+          />
+        );
+      case 'choice':
+        return (
+          <Select
+            value={(cellValue as string) ?? ''}
+            onValueChange={(v) => update(v)}
+          >
+            <SelectTrigger className="h-8 w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {col.options?.map((opt) => (
+                <SelectItem key={opt} value={opt}>
+                  {opt}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+      case 'bool':
+        return (
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500/40"
+            checked={Boolean(cellValue)}
+            onChange={(e) => update(e.target.checked)}
+          />
+        );
+      case 'image':
+        return (
+          <Input
+            size="sm"
+            value={(cellValue as string) ?? ''}
+            onChange={(e) => update(e.target.value)}
+            placeholder="URL"
+            className={`${FIELD_BASE} ${FIELD_DENSE}`}
+          />
+        );
+      default:
+        return (
+          <Input
+            size="sm"
+            value={(cellValue as string) ?? ''}
+            onChange={(e) => update(e.target.value)}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {question.tableau?.rowsGroups?.map((rowsGroup) => (
+        <div key={rowsGroup.id} className="mb-4">
+          {rowsGroup.title && (
+            <div className="px-2 py-1 font-bold text-sm">{rowsGroup.title}</div>
+          )}
+          <table className="w-full table-fixed border-collapse">
+            <thead>
+              <tr>
+                <th className="px-2 py-1"></th>
+                {question.tableau?.columns?.map((col) => (
+                  <th
+                    key={col.id}
+                    className="px-2 py-1 text-xs font-medium text-left"
+                  >
+                    {col.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rowsGroup.rows.map((row) => (
+                <tr key={row.id}>
+                  <td className="px-2 py-1 text-xs font-medium">{row.label}</td>
+                  {question.tableau?.columns?.map((col) => (
+                    <td key={col.id} className="px-2 py-1">
+                      {renderCell(row.id, col)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+      {question.tableau?.commentaire && (
+        <div>
+          <Label className="text-sm font-medium">Commentaire</Label>
+          <Textarea
+            value={data.commentaire || ''}
+            onChange={(e) => onChange({ ...data, commentaire: e.target.value })}
+          />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- split DataEntry into modular pieces with grouped navigation
- add Chip for multiple choice, QuestionRenderer and TableQuestion for rendering logic

## Testing
- `pnpm --filter frontend run lint` *(fails: FileText is defined but never used)*
- `pnpm --filter frontend run test` *(fails: 18 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6899fa3d39708329b90fc764367cfe85