### PR TITLE
[frontend] Add font customization options to rich text editor

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@lexical/list": "^0.33.1",
     "@lexical/react": "^0.33.1",
     "@lexical/rich-text": "^0.33.1",
+    "@lexical/selection": "^0.33.1",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/frontend/src/components/RichTextEditor.test.tsx
+++ b/frontend/src/components/RichTextEditor.test.tsx
@@ -2,6 +2,8 @@ import { render, waitFor } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import React from 'react';
 import RichTextEditor, { type RichTextEditorHandle } from './RichTextEditor';
+import { setFontFamily, setFontSize } from './RichTextToolbar';
+import { $getRoot, TextNode, type LexicalEditor } from 'lexical';
 
 describe('RichTextEditor', () => {
   it('converts markdown to HTML when inserting', async () => {
@@ -14,6 +16,38 @@ describe('RichTextEditor', () => {
     await waitFor(() => {
       const textbox = container.querySelector('[contenteditable="true"]');
       expect(textbox?.innerHTML).toMatch(/<strong[^>]*>bold<\/strong>/);
+    });
+  });
+
+  it('changes font size and family on selection', async () => {
+    const { container } = render(
+      <RichTextEditor initialHtml="<p>Hello</p>" onChange={() => {}} />,
+    );
+    const textbox = container.querySelector(
+      '[contenteditable="true"]',
+    ) as HTMLElement & {
+      __lexicalEditor: LexicalEditor;
+    };
+    const editor = textbox.__lexicalEditor;
+    await waitFor(() => expect(editor).toBeTruthy());
+
+    editor.update(() => {
+      const root = $getRoot();
+      const paragraph = root.getFirstChild();
+      const text = paragraph?.getFirstChild();
+      if (text instanceof TextNode) {
+        text.select(0, text.getTextContentSize());
+      }
+    });
+
+    setFontSize(editor, '24');
+    setFontFamily(editor, 'Arial');
+
+    await waitFor(() => {
+      const span = textbox.querySelector('span');
+      expect(span).not.toBeNull();
+      expect(span?.getAttribute('style')).toContain('font-size: 24px');
+      expect(span?.getAttribute('style')).toContain('font-family: Arial');
     });
   });
 });

--- a/frontend/src/components/RichTextToolbar.tsx
+++ b/frontend/src/components/RichTextToolbar.tsx
@@ -1,13 +1,43 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { FORMAT_TEXT_COMMAND } from 'lexical';
+import {
+  FORMAT_TEXT_COMMAND,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from 'lexical';
 import {
   INSERT_UNORDERED_LIST_COMMAND,
   INSERT_ORDERED_LIST_COMMAND,
 } from '@lexical/list';
-import { TOGGLE_LINK_COMMAND } from '@lexical/link';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
+import { $patchStyleText } from '@lexical/selection';
 import { Save } from 'lucide-react';
 import { Button } from './ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select';
+
+export function setFontSize(editor: LexicalEditor, size: string) {
+  editor.update(() => {
+    const selection = $getSelection();
+    if ($isRangeSelection(selection)) {
+      $patchStyleText(selection, { 'font-size': `${size}px` });
+    }
+  });
+}
+
+export function setFontFamily(editor: LexicalEditor, family: string) {
+  editor.update(() => {
+    const selection = $getSelection();
+    if ($isRangeSelection(selection)) {
+      $patchStyleText(selection, { 'font-family': family || null });
+    }
+  });
+}
 
 interface Props {
   onSave?: () => void;
@@ -15,6 +45,24 @@ interface Props {
 
 export function ToolbarPlugin({ onSave }: Props) {
   const [editor] = useLexicalComposerContext();
+  const [fontSize, setFontSizeState] = useState('16');
+  const [fontFamily, setFontFamilyState] = useState('default');
+
+  const changeFontSize = useCallback(
+    (size: string) => {
+      setFontSizeState(size);
+      setFontSize(editor, size);
+    },
+    [editor],
+  );
+
+  const changeFontFamily = useCallback(
+    (family: string) => {
+      setFontFamilyState(family);
+      setFontFamily(editor, family === 'default' ? '' : family);
+    },
+    [editor],
+  );
 
   const format = useCallback(
     (format: 'bold' | 'italic' | 'underline') => {
@@ -22,11 +70,6 @@ export function ToolbarPlugin({ onSave }: Props) {
     },
     [editor],
   );
-
-  const insertLink = useCallback(() => {
-    const url = prompt('URL');
-    if (url) editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
-  }, [editor]);
 
   const insertList = useCallback(
     (ordered: boolean) => {
@@ -40,17 +83,37 @@ export function ToolbarPlugin({ onSave }: Props) {
 
   return (
     <div className="sticky top-0 z-10 flex space-x-2 bg-wood-50 border-b border-wood-200 p-2">
+      <Select value={fontSize} onValueChange={changeFontSize}>
+        <SelectTrigger data-testid="font-size">
+          <SelectValue placeholder="Taille" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="12">12</SelectItem>
+          <SelectItem value="14">14</SelectItem>
+          <SelectItem value="16">16</SelectItem>
+          <SelectItem value="18">18</SelectItem>
+          <SelectItem value="24">24</SelectItem>
+          <SelectItem value="32">32</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select value={fontFamily} onValueChange={changeFontFamily}>
+        <SelectTrigger data-testid="font-family">
+          <SelectValue placeholder="Police" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="default">Défaut</SelectItem>
+          <SelectItem value="'Times New Roman'">Times New Roman</SelectItem>
+          <SelectItem value="Calibri">Calibri</SelectItem>
+          <SelectItem value="Arial">Arial</SelectItem>
+        </SelectContent>
+      </Select>
       <Button type="button" onClick={() => format('bold')} variant="editor">
         B
       </Button>
-      <Button
-        type="button"
-        onClick={() => format('italic')}
-        variant="editor"
-      >
+      <Button type="button" onClick={() => format('italic')} variant="editor">
         I
       </Button>
-{/*       <Button
+      {/*       <Button
         type="button"
         onClick={() => format('underline')}
         variant="editor"
@@ -58,18 +121,10 @@ export function ToolbarPlugin({ onSave }: Props) {
         U
       </Button> */}
       <div className="w-px self-stretch bg-wood-200 mx-1" />
-      <Button
-        type="button"
-        onClick={() => insertList(false)}
-        variant="editor"
-      >
+      <Button type="button" onClick={() => insertList(false)} variant="editor">
         •
       </Button>
-      <Button
-        type="button"
-        onClick={() => insertList(true)}
-        variant="editor"
-      >
+      <Button type="button" onClick={() => insertList(true)} variant="editor">
         1.
       </Button>
       <div className="w-px self-stretch bg-wood-200 mx-1" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@lexical/rich-text':
         specifier: ^0.33.1
         version: 0.33.1
+      '@lexical/selection':
+        specifier: ^0.33.1
+        version: 0.33.1
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.7))(@types/react@19.1.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
## Summary
- allow changing font size and font family via dropdowns in toolbar
- add tests verifying font styling
- include @lexical/selection dependency

## Testing
- `pnpm exec eslint src/components/RichTextToolbar.tsx src/components/RichTextEditor.test.tsx`
- `pnpm exec vitest run src/components/RichTextEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a431c2408832983a78b5cf6757a85