### PR TITLE
[frontend] Add conclusion generation button

### DIFF
--- a/backend/src/controllers/bilan.controller.ts
+++ b/backend/src/controllers/bilan.controller.ts
@@ -4,6 +4,7 @@ import { sanitizeHtml } from "../utils/sanitize";
 import { generateText } from "../services/ai/generate.service";
 import { promptConfigs } from "../services/ai/prompts/promptconfig";
 import { refineSelection } from "../services/ai/refineSelection.service";
+import { concludeBilan } from "../services/ai/conclude.service";
 
 export const BilanController = {
   async create(req: Request, res: Response, next: NextFunction) {
@@ -89,6 +90,20 @@ export const BilanController = {
         refineInstruction: req.body.refineInstruction,
         selectedText: req.body.selectedText,
       });
+      res.json({ text });
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async conclude(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bilan = await BilanService.get(req.user.id, req.params.bilanId);
+      if (!bilan || !bilan.descriptionHtml) {
+        res.status(404).json({ error: 'bilan not found' });
+        return;
+      }
+      const text = await concludeBilan(bilan.descriptionHtml);
       res.json({ text });
     } catch (e) {
       next(e);

--- a/backend/src/routes/bilan.routes.ts
+++ b/backend/src/routes/bilan.routes.ts
@@ -35,3 +35,9 @@ bilanRouter.post(
   validateParams(bilanIdParam),
   BilanController.refine,
 );
+
+bilanRouter.post(
+  '/:bilanId/conclude',
+  validateParams(bilanIdParam),
+  BilanController.conclude,
+);

--- a/backend/src/services/ai/conclude.service.ts
+++ b/backend/src/services/ai/conclude.service.ts
@@ -1,0 +1,11 @@
+import { ChatCompletionCreateParams, ChatCompletionMessageParam } from 'openai/resources/index';
+import { openaiProvider } from './providers/openai.provider';
+import * as guardrails from './guardrails';
+import { promptConclure } from './prompts/promptConclure';
+
+export async function concludeBilan(text: string) {
+  const sanitized = guardrails.pre(text);
+  const messages = promptConclure(sanitized) as unknown as ChatCompletionMessageParam[];
+  const result = await openaiProvider.chat({ messages } as ChatCompletionCreateParams);
+  return guardrails.post(result || '');
+}

--- a/backend/src/services/ai/prompts/promptConclure.ts
+++ b/backend/src/services/ai/prompts/promptConclure.ts
@@ -1,0 +1,12 @@
+import { SingleMessage, DEFAULT_SYSTEM } from './promptbuilder';
+
+export function promptConclure(bilanText: string): readonly SingleMessage[] {
+  const msgs: SingleMessage[] = [];
+  msgs.push({ role: 'system', content: DEFAULT_SYSTEM });
+  msgs.push({
+    role: 'system',
+    content: `INSTRUCTIONS\nRédige une synthèse et une conclusion du bilan psychomoteur suivant. Utilise un ton descriptif, nuancé et factuel.`,
+  });
+  msgs.push({ role: 'user', content: bilanText });
+  return msgs;
+}

--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -12,7 +12,7 @@ import { Textarea } from './ui/textarea';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import type { TrameOption, TrameExample } from './bilan/TrameSelector';
 import type { Answers, Question } from '@/types/question';
-import { FileText, Eye, Brain, Activity } from 'lucide-react';
+import { FileText, Eye, Brain, Activity, Flag } from 'lucide-react';
 import { apiFetch } from '@/utils/api';
 import { useAuth } from '@/store/auth';
 
@@ -331,6 +331,22 @@ export default function AiRightPanel({
     }
   };
 
+  const handleConclude = async () => {
+    setIsGenerating(true);
+    try {
+      const res = await apiFetch<{ text: string }>(
+        `/api/v1/bilans/${bilanId}/conclude`,
+        {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      );
+      onInsertText(res.text);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
   return (
     <div className="w-full max-w-md bg-wood-50 rounded-lg shadow-lg">
       <div className="flex flex-col h-full">
@@ -466,6 +482,30 @@ export default function AiRightPanel({
           ) : (
             <ScrollArea className="h-[calc(100vh-120px)]">
               <div className="space-y-4">
+                <Card>
+                  <CardContent className="p-4">
+                    <div className="flex items-start gap-3">
+                      <div className="p-2 rounded-lg bg-gray-100">
+                        <Flag className="h-4 w-4 text-gray-600" />
+                      </div>
+                      <div className="flex-1">
+                        <h3 className="font-medium text-sm mb-1">Conclure</h3>
+                        <p className="text-xs text-gray-500 mb-4">
+                          Génère une synthèse et une conclusion du bilan complet
+                        </p>
+                        <Button
+                          size="sm"
+                          variant="default"
+                          className="w-full text-xs"
+                          onClick={handleConclude}
+                          disabled={isGenerating}
+                        >
+                          {isGenerating ? 'Génération...' : 'Conclure'}
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
                 {sections.map((section) => {
                   const trameOpts = trames[section.id];
                   const selected = trameOpts.find(
@@ -479,10 +519,7 @@ export default function AiRightPanel({
                         open={true}
                         onOpenChange={(open) => !open && setWizardSection(null)}
                       >
-                        <DialogContent
-                          showCloseButton={false}
-                          fullscreen
-                        >
+                        <DialogContent showCloseButton={false} fullscreen>
                           <WizardAIRightPanel
                             sectionInfo={section}
                             trameOptions={trameOpts}


### PR DESCRIPTION
## Summary
- add backend conclude endpoint with promptConclure to summarize full report
- expose conclude action via new "Conclure" button in AiRightPanel

## Testing
- `pnpm --filter frontend run lint` *(fails: @typescript-eslint/no-unused-vars, etc.)*
- `pnpm --filter frontend run test` *(fails: 5 test files failed, 18 tests failed)*
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689a54124a9c8329b15c052d3976ae03