### PR TITLE
[frontend] convert comment test results files to HTML

### DIFF
--- a/backend/src/controllers/bilan.controller.ts
+++ b/backend/src/controllers/bilan.controller.ts
@@ -113,14 +113,12 @@ export const BilanController = {
 
   async commentTestResults(req: Request, res: Response, next: NextFunction) {
     try {
-      const file = req.body.file;
-      if (typeof file !== 'string') {
-        res.status(400).json({ error: 'file required' });
+      const html = req.body.html;
+      if (typeof html !== 'string') {
+        res.status(400).json({ error: 'html required' });
         return;
       }
-      const buffer = Buffer.from(file, 'base64');
-      const textContent = buffer.toString('utf-8');
-      const text = await commentTestResultsService(textContent);
+      const text = await commentTestResultsService(html);
       res.json({ text });
     } catch (e) {
       next(e);

--- a/backend/tests/bilan.routes.test.ts
+++ b/backend/tests/bilan.routes.test.ts
@@ -12,7 +12,11 @@ jest.mock("../src/services/ai/generate.service");
 jest.mock("../src/services/ai/refineSelection.service");
 jest.mock("../src/services/ai/commentTestResults.service");
 jest.mock("../src/middlewares/requireAuth", () => ({
-  requireAuth: (req: any, _res: any, next: () => void) => {
+  requireAuth: (
+    req: { user?: { id: string } },
+    _res: unknown,
+    next: () => void,
+  ) => {
     req.user = { id: "demo-user" };
     next();
   },
@@ -109,12 +113,12 @@ describe("POST /api/v1/bilans/:id/comment-test-results", () => {
   it("calls comment service with file content", async () => {
     mockedComment.mockResolvedValueOnce("comment");
     const id = "11111111-1111-1111-1111-111111111111";
-    const body = { file: Buffer.from("data").toString("base64") };
+    const body = { html: "<p>data</p>" };
     const res = await request(app)
       .post(`/api/v1/bilans/${id}/comment-test-results`)
       .send(body);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ text: "comment" });
-    expect(mockedComment).toHaveBeenCalledWith("data");
+    expect(mockedComment).toHaveBeenCalledWith("<p>data</p>");
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,6 +78,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "vite": "^7.1.0",
+    "mammoth": "^1.8.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "zustand": "^5.0.5"
   }

--- a/frontend/src/components/AiRightPanel.test.tsx
+++ b/frontend/src/components/AiRightPanel.test.tsx
@@ -54,14 +54,16 @@ describe('AiRightPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Valider' }));
 
     await waitFor(() => expect(mockedApi).toHaveBeenCalled());
-    expect(mockedApi).toHaveBeenCalledWith(
-      '/api/v1/bilans/123/comment-test-results',
+    const [url, options] = mockedApi.mock.calls[0];
+    expect(url).toBe('/api/v1/bilans/123/comment-test-results');
+    expect(options).toEqual(
       expect.objectContaining({
         method: 'POST',
-        body: expect.stringContaining('promptCommentTestResults'),
         headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
       }),
     );
+    expect(options.body).toContain('promptCommentTestResults');
+    expect(options.body).toContain('"html":"test"');
     expect(onInsertText).toHaveBeenCalledWith('Un commentaire');
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       lucide-react:
         specifier: ^0.515.0
         version: 0.515.0(react@19.1.0)
+      mammoth:
+        specifier: ^1.8.0
+        version: 1.10.0
       marked:
         specifier: ^16.1.1
         version: 16.1.1
@@ -2453,6 +2456,10 @@ packages:
   '@vitest/utils@3.2.3':
     resolution: {integrity: sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==}
 
+  '@xmldom/xmldom@0.8.10':
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+    engines: {node: '>=10.0.0'}
+
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
 
@@ -2643,9 +2650,15 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
@@ -3064,6 +3077,9 @@ packages:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
+  dingbat-to-unicode@1.0.1:
+    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -3088,6 +3104,9 @@ packages:
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
+
+  duck@0.1.12:
+    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4160,6 +4179,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lop@0.4.2:
+    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
+
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
@@ -4190,6 +4212,11 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  mammoth@1.10.0:
+    resolution: {integrity: sha512-9HOmqt8uJ5rz7q8XrECU5gRjNftCq4GNG0YIrA6f9iQPCeLgpvgcmRBHi9NQWJQIpT/MAXeg1oKliAK1xoB3eg==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   marked@16.1.1:
     resolution: {integrity: sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==}
@@ -4453,6 +4480,9 @@ packages:
         optional: true
       zod:
         optional: true
+
+  option@0.2.4:
+    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5426,6 +5456,9 @@ packages:
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
+  underscore@1.13.7:
+    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
@@ -5667,6 +5700,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xmlbuilder@10.1.1:
+    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
+    engines: {node: '>=4.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -7919,6 +7956,8 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@xmldom/xmldom@0.8.10': {}
+
   '@zeit/schemas@2.36.0': {}
 
   accepts@1.3.8:
@@ -8150,7 +8189,11 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   binary-extensions@2.3.0: {}
+
+  bluebird@3.4.7: {}
 
   body-parser@2.2.0:
     dependencies:
@@ -8555,6 +8598,8 @@ snapshots:
 
   diff@7.0.0: {}
 
+  dingbat-to-unicode@1.0.1: {}
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -8575,6 +8620,10 @@ snapshots:
   dotenv@16.5.0: {}
 
   dotenv@16.6.1: {}
+
+  duck@0.1.12:
+    dependencies:
+      underscore: 1.13.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -9996,6 +10045,12 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lop@0.4.2:
+    dependencies:
+      duck: 0.1.12
+      option: 0.2.4
+      underscore: 1.13.7
+
   loupe@3.1.3: {}
 
   lru-cache@10.4.3: {}
@@ -10023,6 +10078,19 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  mammoth@1.10.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.10
+      argparse: 1.0.10
+      base64-js: 1.5.1
+      bluebird: 3.4.7
+      dingbat-to-unicode: 1.0.1
+      jszip: 3.10.1
+      lop: 0.4.2
+      path-is-absolute: 1.0.1
+      underscore: 1.13.7
+      xmlbuilder: 10.1.1
 
   marked@16.1.1: {}
 
@@ -10249,6 +10317,8 @@ snapshots:
     optionalDependencies:
       ws: 8.18.2
       zod: 3.25.63
+
+  option@0.2.4: {}
 
   optionator@0.9.4:
     dependencies:
@@ -11322,6 +11392,8 @@ snapshots:
 
   undefsafe@2.0.5: {}
 
+  underscore@1.13.7: {}
+
   undici-types@7.8.0: {}
 
   unicorn-magic@0.1.0: {}
@@ -11571,6 +11643,8 @@ snapshots:
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz: {}
 
   xml-name-validator@5.0.0: {}
+
+  xmlbuilder@10.1.1: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
## Summary
- convert uploaded Word or Excel files to HTML before sending to AI comment endpoint
- update backend to accept raw HTML for comment test results
- adjust related tests and add mammoth dependency

## Testing
- `pnpm --filter frontend exec eslint src/components/AiRightPanel.tsx src/components/AiRightPanel.test.tsx`
- `pnpm --filter backend run lint`
- `pnpm --filter frontend exec vitest run src/components/AiRightPanel.test.tsx`
- `pnpm --filter frontend run test` *(fails: Missing Description or aria-describedby for DialogContent, TypeError scrollIntoView, etc.)*
- `pnpm --filter backend run test` *(fails: SyntaxError: Unexpected token 'export' in jose module)*

------
https://chatgpt.com/codex/tasks/task_e_689ad0b4dc68832991b92227e9568067