### PR TITLE
[frontend] Allow multiple selection for multi-choice questions

### DIFF
--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -138,9 +138,10 @@ describe('DataEntry', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: 'Opt1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Opt2' }));
     ref.current?.save();
     expect(handle).toHaveBeenCalledWith({
-      [mcQuestion.id]: { option: 'Opt1', commentaire: '' },
+      [mcQuestion.id]: { options: ['Opt1', 'Opt2'], commentaire: '' },
     });
   });
 

--- a/frontend/src/components/bilan/QuestionRenderer.tsx
+++ b/frontend/src/components/bilan/QuestionRenderer.tsx
@@ -38,8 +38,12 @@ export function QuestionRenderer({
     case 'choix-multiple':
       const selected =
         typeof value === 'object' && value !== null
-          ? (value as any).option
-          : value;
+          ? Array.isArray((value as any).options)
+            ? ((value as any).options as string[])
+            : (value as any).option
+            ? [String((value as any).option)]
+            : []
+          : [];
       const comment =
         typeof value === 'object' && value !== null
           ? (value as any).commentaire || ''
@@ -47,15 +51,23 @@ export function QuestionRenderer({
       return (
         <div className="space-y-2">
           <div className="flex flex-wrap gap-2">
-            {question.options?.map((opt) => (
-              <Chip
-                key={opt}
-                selected={selected === opt}
-                onClick={() => onChange({ option: opt, commentaire: comment })}
-              >
-                {opt}
-              </Chip>
-            ))}
+            {question.options?.map((opt) => {
+              const isSelected = selected.includes(opt);
+              return (
+                <Chip
+                  key={opt}
+                  selected={isSelected}
+                  onClick={() => {
+                    const newSelected = isSelected
+                      ? selected.filter((o) => o !== opt)
+                      : [...selected, opt];
+                    onChange({ options: newSelected, commentaire: comment });
+                  }}
+                >
+                  {opt}
+                </Chip>
+              );
+            })}
           </div>
           {question.commentaire !== false && (
             <div className="space-y-1 w-full">
@@ -63,7 +75,7 @@ export function QuestionRenderer({
                 value={comment}
                 onChange={(e) =>
                   onChange({
-                    option: selected || '',
+                    options: selected,
                     commentaire: e.target.value,
                   })
                 }


### PR DESCRIPTION
## Summary
- allow selecting multiple options in `choix-multiple` questions
- cover multi-option saving in DataEntry tests

## Testing
- `pnpm --filter frontend run lint` (fails: 41 errors)
- `pnpm --filter frontend run test` (fails: 6 failed, 23 passed)


------
https://chatgpt.com/codex/tasks/task_e_689ae14bd2f88329ba698bc924d3b330