### PR TITLE
[frontend] add import notes tab and raw notes support

### DIFF
--- a/backend/src/services/ai/prompts/extractStylePrompt.ts
+++ b/backend/src/services/ai/prompts/extractStylePrompt.ts
@@ -1,5 +1,9 @@
 import type { SingleMessage } from './promptbuilder';
 import { openaiProvider } from '../providers/openai.provider';
+import {
+  ChatCompletionCreateParams,
+  ChatCompletionMessageParam,
+} from 'openai/resources/index';
 
 export interface ExtractStyleParams {
   texts: string[]; // 1..n exemples de texte
@@ -37,8 +41,9 @@ export function buildExtractStylePrompt(params: ExtractStyleParams): readonly Si
 }
 
 export async function extractStyle(params: ExtractStyleParams): Promise<string> {
-  const messages = buildExtractStylePrompt(params) as any;
-  const res = await openaiProvider.chat({ messages } as any);
+  const messages =
+    buildExtractStylePrompt(params) as unknown as ChatCompletionMessageParam[];
+  const res = await openaiProvider.chat({ messages } as ChatCompletionCreateParams);
   return (res || '').toString();
 }
 

--- a/backend/src/services/ai/prompts/promptbuilder.ts
+++ b/backend/src/services/ai/prompts/promptbuilder.ts
@@ -15,6 +15,8 @@ export interface PromptParams {
   examples?: string[];
   /** Un guide de style compact (extrait des exemples) */
   stylePrompt?: string;
+  /** Notes brutes importées */
+  rawNotes?: string;
 }
 
 /** Valeur par défaut pour ton system prompt */
@@ -87,6 +89,13 @@ export function buildPrompt(params: PromptParams & { job?: 'PSYCHOMOTRICIEN' | '
 
   // 6. Données utilisateur
   msgs.push({ role: 'user', content: `Données du patient actuel (Markdown):\n${params.userContent.trim()}` });
+
+  if (params.rawNotes && params.rawNotes.trim().length > 0) {
+    msgs.push({
+      role: 'user',
+      content: `Notes brutes importées:\n${params.rawNotes.trim()}`,
+    });
+  }
 
 
   return msgs ;

--- a/backend/tests/bilan.routes.test.js
+++ b/backend/tests/bilan.routes.test.js
@@ -4,10 +4,15 @@ import { BilanService } from "../src/services/bilan.service";
 import { generateText } from "../src/services/ai/generate.service";
 import { promptConfigs } from "../src/services/ai/prompts/promptconfig";
 import { sanitizeHtml } from "../src/utils/sanitize";
+import { ProfileService } from "../src/services/profile.service";
 jest.mock("../src/services/bilan.service");
 jest.mock("../src/services/ai/generate.service");
+jest.mock("../src/services/profile.service", () => ({
+    ProfileService: { list: jest.fn() },
+}));
 const mockedService = BilanService;
 const mockedGenerate = generateText;
+const mockedProfile = ProfileService;
 describe("GET /api/v1/bilans", () => {
     it("returns bilans from service", async () => {
         mockedService.list.mockResolvedValueOnce([
@@ -41,11 +46,14 @@ describe("PUT /api/v1/bilans/:id", () => {
 describe("POST /api/v1/bilans/:id/generate", () => {
     it("calls ai service with prompt params", async () => {
         mockedGenerate.mockResolvedValueOnce("texte");
+        mockedService.get.mockResolvedValueOnce(null);
+        mockedProfile.list.mockResolvedValueOnce([]);
         const id = "11111111-1111-1111-1111-111111111111";
         const body = {
             section: "anamnese",
             answers: { foo: "bar" },
             examples: ["demo"],
+            rawNotes: "notes",
         };
         const res = await request(app)
             .post(`/api/v1/bilans/${id}/generate`)
@@ -56,6 +64,7 @@ describe("POST /api/v1/bilans/:id/generate", () => {
             instructions: promptConfigs.anamnese.instructions,
             userContent: JSON.stringify(body.answers),
             examples: ["demo"],
+            rawNotes: "notes",
         });
     });
 });

--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -278,7 +278,11 @@ export default function AiRightPanel({
     }
   }
 
-  const handleGenerate = async (section: SectionInfo, newAnswers?: Answers) => {
+  const handleGenerate = async (
+    section: SectionInfo,
+    newAnswers?: Answers,
+    rawNotes?: string,
+  ) => {
     setIsGenerating(true);
     setSelectedSection(section.id);
 
@@ -322,7 +326,7 @@ export default function AiRightPanel({
 
       // Ne jamais couper une question en deux: on chunk par blocs/questions déjà construits
       const chunks = splitBlocksIntoStringChunks(mdBlocks, { maxChars: 1800 });
-      const body = {
+      const body: any = {
         section: kindMap[section.id],
         answers: chunks,
         // N'envoie plus le texte entier de l'exemple, seulement le stylePrompt si dispo
@@ -332,6 +336,9 @@ export default function AiRightPanel({
           .filter((s) => typeof s === 'string' && (s as string).trim().length > 0)
           .slice(0, 1)[0],
       };
+      if (rawNotes && rawNotes.trim()) {
+        body.rawNotes = rawNotes;
+      }
 
       console.log('body', body);
 
@@ -658,8 +665,8 @@ export default function AiRightPanel({
                             onAnswersChange={(a) =>
                               setAnswers({ ...answers, [section.id]: a })
                             }
-                            onGenerate={(latest) =>
-                              handleGenerate(section, latest)
+                            onGenerate={(latest, notes) =>
+                              handleGenerate(section, latest, notes)
                             }
                             isGenerating={
                               isGenerating && selectedSection === section.id

--- a/frontend/src/components/ImportNotes.tsx
+++ b/frontend/src/components/ImportNotes.tsx
@@ -1,0 +1,144 @@
+import { useRef, useState, useEffect } from 'react';
+import { read, utils } from 'xlsx';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { apiFetch } from '@/utils/api';
+import { useAuth } from '@/store/auth';
+
+interface ImportNotesProps {
+  onChange: (text: string) => void;
+}
+
+export default function ImportNotes({ onChange }: ImportNotesProps) {
+  const [mode, setMode] = useState<'text' | 'excel' | 'image'>('text');
+  const [text, setText] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [image, setImage] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const token = useAuth((s) => s.token);
+
+  useEffect(() => {
+    if (mode === 'text') {
+      onChange(text);
+    } else if (mode === 'excel' && file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const data = reader.result as ArrayBuffer;
+          const workbook = read(data, { type: 'array' });
+          const csv = workbook.SheetNames.map((name) =>
+            utils.sheet_to_csv(workbook.Sheets[name]),
+          ).join('\n');
+          onChange(csv);
+        } catch {
+          onChange('');
+        }
+      };
+      reader.readAsArrayBuffer(file);
+    } else if (mode === 'image' && image) {
+      const reader = new FileReader();
+      reader.onload = async () => {
+        const res = reader.result as string;
+        const base64 = res.split(',')[1] || '';
+        try {
+          const r = await apiFetch<{
+            result: Array<{ tableau?: { columns: any[]; rowsGroups: any[] } }>;
+          }>('/api/v1/import/transform-image', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ image: base64 }),
+          });
+          const q = r.result[0];
+          if (q?.tableau?.columns && q.tableau.rowsGroups) {
+            const header = q.tableau.columns
+              .map((c: any) => c.label)
+              .join(' | ');
+            const sep = q.tableau.columns.map(() => '---').join(' | ');
+            const rows = q.tableau.rowsGroups
+              .flatMap((g: any) => g.rows || [])
+              .map((row: any) => row.label)
+              .join(' | ');
+            const md = `| ${header} |\n| ${sep} |\n| ${rows} |`;
+            onChange(md);
+          } else {
+            onChange(base64);
+          }
+        } catch {
+          onChange(base64);
+        }
+      };
+      reader.readAsDataURL(image);
+    }
+  }, [mode, text, file, image, onChange, token]);
+
+  return (
+    <div className="space-y-4 w-full">
+      <RadioGroup
+        value={mode}
+        onValueChange={(v) => {
+          setMode(v as 'text' | 'excel' | 'image');
+          setFile(null);
+          setImage(null);
+          setText('');
+        }}
+        className="flex gap-4"
+      >
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="text" id="notes-text" />
+          <label htmlFor="notes-text">Texte</label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="excel" id="notes-excel" />
+          <label htmlFor="notes-excel">Excel</label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <RadioGroupItem value="image" id="notes-image" />
+          <label htmlFor="notes-image">Image</label>
+        </div>
+      </RadioGroup>
+
+      {mode === 'text' && (
+        <Textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Collez vos notes ici"
+          className="h-64"
+        />
+      )}
+
+      {mode === 'excel' && (
+        <div className="space-y-2">
+          <Button type="button" onClick={() => fileInputRef.current?.click()}>
+            Importer un fichier Excel
+          </Button>
+          <input
+            type="file"
+            accept=".xlsx,.xls"
+            ref={fileInputRef}
+            className="hidden"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+          {file && <div className="text-sm text-gray-600">{file.name}</div>}
+        </div>
+      )}
+
+      {mode === 'image' && (
+        <div className="space-y-2">
+          <Button type="button" onClick={() => imageInputRef.current?.click()}>
+            Ajouter une image
+          </Button>
+          <input
+            type="file"
+            accept="image/*"
+            ref={imageInputRef}
+            className="hidden"
+            onChange={(e) => setImage(e.target.files?.[0] || null)}
+          />
+          {image && <div className="text-sm text-gray-600">{image.name}</div>}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ImportNotes component with text, Excel or image import options
- add Saisie manuelle/Import des notes tabs to wizard step 2 and send raw notes to generation
- accept rawNotes in AI generate service and tests

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test -- tests/bilan.routes.test.ts`
- `pnpm --filter frontend exec eslint src/components/ImportNotes.tsx src/components/WizardAIRightPanel.tsx src/components/AiRightPanel.tsx` *(fails: many style errors)*
- `pnpm --filter frontend run test -- -t "AiRightPanel"` *(fails: multiple runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a57ae510e48329a2b301d4f1677915