### PR TITLE
[backend] add section template CRUD

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import { patientRouter } from './routes/patient.routes';
 import { bilanRouter } from './routes/bilan.routes';
 import { sectionRouter } from './routes/section.routes';
 import { sectionExampleRouter } from './routes/sectionExample.routes';
+import { sectionTemplateRouter } from './routes/sectionTemplate.routes';
 import { importRouter } from './routes/import.routes';
 import { bilanSectionInstanceRouter } from './routes/bilanSectionInstance.routes';
 import { errorHandler } from './middlewares/error.middleware';
@@ -99,6 +100,7 @@ app.use('/api/v1/bilans', bilanRouter);
 app.use('/api/v1/profile', profileRouter);
 app.use('/api/v1/sections', sectionRouter);
 app.use('/api/v1/section-examples', sectionExampleRouter);
+app.use('/api/v1/section-templates', sectionTemplateRouter);
 app.use('/api/v1/bilan-section-instances', bilanSectionInstanceRouter);
 app.use('/api/v1/import', importRouter);
 

--- a/backend/src/controllers/sectionTemplate.controller.ts
+++ b/backend/src/controllers/sectionTemplate.controller.ts
@@ -1,0 +1,57 @@
+import type { Request, Response, NextFunction } from 'express';
+import { SectionTemplateService } from '../services/sectionTemplate.service';
+
+export const SectionTemplateController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const template = await SectionTemplateService.create(req.body);
+      res.status(201).json(template);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await SectionTemplateService.list());
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const template = await SectionTemplateService.get(
+        req.params.sectionTemplateId,
+      );
+      if (!template) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(template);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const template = await SectionTemplateService.update(
+        req.params.sectionTemplateId,
+        req.body,
+      );
+      res.json(template);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await SectionTemplateService.remove(req.params.sectionTemplateId);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/backend/src/routes/sectionTemplate.routes.ts
+++ b/backend/src/routes/sectionTemplate.routes.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { SectionTemplateController } from '../controllers/sectionTemplate.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createSectionTemplateSchema,
+  updateSectionTemplateSchema,
+  sectionTemplateIdParam,
+} from '../schemas/sectionTemplate.schema';
+
+export const sectionTemplateRouter = Router();
+
+sectionTemplateRouter
+  .route('/')
+  .post(validateBody(createSectionTemplateSchema), SectionTemplateController.create)
+  .get(SectionTemplateController.list);
+
+sectionTemplateRouter
+  .route('/:sectionTemplateId')
+  .get(validateParams(sectionTemplateIdParam), SectionTemplateController.get)
+  .put(
+    validateBody(updateSectionTemplateSchema),
+    SectionTemplateController.update,
+  )
+  .delete(
+    validateParams(sectionTemplateIdParam),
+    SectionTemplateController.remove,
+  );

--- a/backend/src/schemas/section.schema.ts
+++ b/backend/src/schemas/section.schema.ts
@@ -10,6 +10,9 @@ export const createSectionSchema = z.object({
   schema: z.any().optional(),
   defaultContent: z.any().optional(),
   isPublic: z.boolean().optional(),
+  templateRefId: z.string().optional(),
+  templateOptions: z.any().optional(),
+  version: z.number().int().optional(),
 });
 
 export const updateSectionSchema = createSectionSchema.partial();

--- a/backend/src/schemas/sectionTemplate.schema.ts
+++ b/backend/src/schemas/sectionTemplate.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const createSectionTemplateSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  version: z.number().int().optional(),
+  content: z.any(),
+  slotsSpec: z.any(),
+  isDeprecated: z.boolean().optional(),
+});
+
+export const updateSectionTemplateSchema = createSectionTemplateSchema.partial();
+
+export const sectionTemplateIdParam = z.object({ sectionTemplateId: z.string() });

--- a/backend/src/services/section.service.ts
+++ b/backend/src/services/section.service.ts
@@ -18,6 +18,9 @@ export type SectionData = {
   schema?: unknown;
   defaultContent?: unknown;
   isPublic?: boolean;
+  templateRefId?: string | null;
+  templateOptions?: unknown;
+  version?: number;
 };
 
 
@@ -25,7 +28,10 @@ export const SectionService = {
   async create(userId: string, data: SectionData) {
     const profile = await db.profile.findUnique({ where: { userId } });
     if (!profile) throw new Error('Profile not found for user');
-    return db.section.create({ data: { ...data, authorId: profile.id } });
+    return db.section.create({
+      data: { ...data, authorId: profile.id },
+      include: { templateRef: true },
+    });
   },
 
   list(userId: string) {
@@ -37,7 +43,7 @@ export const SectionService = {
         ],
       },
       orderBy: { createdAt: 'desc' },
-      include: { author: { select: { prenom: true } } },
+      include: { author: { select: { prenom: true } }, templateRef: true },
     });
   },
 
@@ -50,7 +56,7 @@ export const SectionService = {
           { author: { userId } },
         ],
       },
-      include: { author: { select: { prenom: true } } },
+      include: { author: { select: { prenom: true } }, templateRef: true },
     });
   },
 
@@ -77,7 +83,11 @@ export const SectionService = {
         defaultContent: section.defaultContent,
         isPublic: false,
         authorId: profile.id,
+        templateRefId: section.templateRefId,
+        templateOptions: section.templateOptions,
+        version: section.version,
       },
+      include: { templateRef: true },
     });
   },
 
@@ -87,7 +97,7 @@ export const SectionService = {
       data,
     });
     if (count === 0) throw new NotFoundError();
-    return db.section.findUnique({ where: { id } });
+    return db.section.findUnique({ where: { id }, include: { templateRef: true } });
   },
 
   async remove(userId: string, id: string) {

--- a/backend/src/services/sectionTemplate.service.ts
+++ b/backend/src/services/sectionTemplate.service.ts
@@ -1,0 +1,39 @@
+import { prisma } from '../prisma';
+import { NotFoundError } from './profile.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any;
+
+export type SectionTemplateData = {
+  id: string;
+  label: string;
+  version?: number;
+  content: unknown;
+  slotsSpec: unknown;
+  isDeprecated?: boolean;
+};
+
+export const SectionTemplateService = {
+  create(data: SectionTemplateData) {
+    return db.sectionTemplate.create({ data });
+  },
+
+  list() {
+    return db.sectionTemplate.findMany({ orderBy: { createdAt: 'desc' } });
+  },
+
+  get(id: string) {
+    return db.sectionTemplate.findUnique({ where: { id } });
+  },
+
+  async update(id: string, data: Partial<SectionTemplateData>) {
+    const { count } = await db.sectionTemplate.updateMany({ where: { id }, data });
+    if (count === 0) throw new NotFoundError();
+    return db.sectionTemplate.findUnique({ where: { id } });
+  },
+
+  async remove(id: string) {
+    const { count } = await db.sectionTemplate.deleteMany({ where: { id } });
+    if (count === 0) throw new NotFoundError();
+  },
+};

--- a/backend/tests/bilan.routes.test.ts
+++ b/backend/tests/bilan.routes.test.ts
@@ -3,7 +3,6 @@ import app from "../src/app";
 import { BilanService } from "../src/services/bilan.service";
 import { generateText } from "../src/services/ai/generate.service";
 import { promptConfigs } from "../src/services/ai/prompts/promptconfig";
-import { sanitizeHtml } from "../src/utils/sanitize";
 import { refineSelection } from "../src/services/ai/refineSelection.service";
 import { commentTestResults } from "../src/services/ai/commentTestResults.service";
 import { ProfileService } from "../src/services/profile.service";

--- a/backend/tests/section.routes.test.ts
+++ b/backend/tests/section.routes.test.ts
@@ -31,9 +31,10 @@ describe('POST /api/v1/sections/:id/duplicate', () => {
       title: 'Sec copy',
     } as SectionStub);
 
-    const res = await request(app).post('/api/v1/sections/1/duplicate');
+    const id = '11111111-1111-1111-1111-111111111111';
+    const res = await request(app).post(`/api/v1/sections/${id}/duplicate`);
     expect(res.status).toBe(201);
     expect(res.body.id).toBe('2');
-    expect(mockedService.duplicate).toHaveBeenCalledWith('demo-user', '1');
+    expect(mockedService.duplicate).toHaveBeenCalledWith('demo-user', id);
   });
 });

--- a/backend/tests/sectionTemplate.routes.test.ts
+++ b/backend/tests/sectionTemplate.routes.test.ts
@@ -1,0 +1,25 @@
+import request from 'supertest';
+import app from '../src/app';
+import { SectionTemplateService } from '../src/services/sectionTemplate.service';
+
+jest.mock('../src/services/sectionTemplate.service');
+
+interface TemplateStub {
+  id: string;
+  label: string;
+}
+
+const mockedService = SectionTemplateService as jest.Mocked<typeof SectionTemplateService>;
+
+describe('GET /api/v1/section-templates', () => {
+  it('returns templates from service', async () => {
+    mockedService.list.mockResolvedValueOnce([
+      { id: '1', label: 'Temp' } as TemplateStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/section-templates');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -1,2 +1,8 @@
 import '@prisma/client';
 jest.mock('@prisma/client');
+jest.mock('../src/middlewares/requireAuth', () => ({
+  requireAuth: (req: { user?: { id: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 'demo-user' };
+    next();
+  },
+}));


### PR DESCRIPTION
## Summary
- add SectionTemplate schema, service, controller, and routes
- allow sections to reference templates
- test SectionTemplate routes and mock auth in tests

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a0bf6cf483299c6ab7323da038b2