### PR TITLE
[frontend] add template editor for sections

### DIFF
--- a/frontend/src/components/SlotSidebar.tsx
+++ b/frontend/src/components/SlotSidebar.tsx
@@ -1,0 +1,107 @@
+import type { Slot, SlotType } from '../types/template';
+
+interface Props {
+  slots: Slot[];
+  onChange: (slots: Slot[]) => void;
+}
+
+const types: SlotType[] = ['text', 'number', 'choice', 'table'];
+
+export default function SlotSidebar({ slots, onChange }: Props) {
+  const updateSlot = (index: number, partial: Partial<Slot>) => {
+    const next = [...slots];
+    next[index] = { ...next[index], ...partial };
+    onChange(next);
+  };
+
+  const addSlot = () => {
+    onChange([
+      ...slots,
+      {
+        id: Date.now().toString(),
+        type: 'text',
+        label: '',
+        options: [],
+        prompt: '',
+      },
+    ]);
+  };
+
+  const removeSlot = (id: string) => {
+    onChange(slots.filter((s) => s.id !== id));
+  };
+
+  return (
+    <aside className="w-64 border-l pl-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h3 className="font-semibold">Slots</h3>
+        <button
+          type="button"
+          className="text-sm text-primary-600"
+          onClick={addSlot}
+        >
+          Ajouter
+        </button>
+      </div>
+      {slots.map((slot, idx) => (
+        <div key={slot.id} className="border-b pb-2 last:border-b-0">
+          <div className="flex justify-between items-center">
+            <span className="text-xs font-mono">{slot.id}</span>
+            <button
+              type="button"
+              className="text-xs text-red-600"
+              onClick={() => removeSlot(slot.id)}
+            >
+              Supprimer
+            </button>
+          </div>
+          <label className="block text-xs mt-2">Label</label>
+          <input
+            className="w-full border rounded p-1"
+            value={slot.label ?? ''}
+            onChange={(e) => updateSlot(idx, { label: e.target.value })}
+          />
+          <label className="block text-xs mt-2">Type</label>
+          <select
+            className="w-full border rounded p-1"
+            value={slot.type}
+            onChange={(e) =>
+              updateSlot(idx, { type: e.target.value as SlotType })
+            }
+          >
+            {types.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          {slot.type === 'choice' && (
+            <>
+              <label className="block text-xs mt-2">
+                Options (séparées par des virgules)
+              </label>
+              <input
+                className="w-full border rounded p-1"
+                value={(slot.options ?? []).join(',')}
+                onChange={(e) =>
+                  updateSlot(idx, {
+                    options: e.target.value
+                      .split(',')
+                      .map((s) => s.trim())
+                      .filter(Boolean),
+                  })
+                }
+              />
+            </>
+          )}
+          <label className="block text-xs mt-2">Prompt</label>
+          <textarea
+            className="w-full border rounded p-1"
+            value={slot.prompt ?? ''}
+            onChange={(e) => updateSlot(idx, { prompt: e.target.value })}
+          />
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/frontend/src/components/TemplateEditor.tsx
+++ b/frontend/src/components/TemplateEditor.tsx
@@ -1,0 +1,38 @@
+import { useRef } from 'react';
+import RichTextEditor, { RichTextEditorHandle } from './RichTextEditor';
+import SlotSidebar from './SlotSidebar';
+import type { SectionTemplate } from '../types/template';
+
+interface Props {
+  template: SectionTemplate;
+  onChange: (t: SectionTemplate) => void;
+}
+
+export default function TemplateEditor({ template, onChange }: Props) {
+  const editorRef = useRef<RichTextEditorHandle>(null);
+  return (
+    <div className="flex gap-4">
+      <div className="flex-1">
+        <RichTextEditor
+          ref={editorRef}
+          initialStateJson={template.ast}
+          onChange={(ast) => onChange({ ...template, ast })}
+        />
+        <div className="mt-4">
+          <label className="block text-sm font-medium mb-1">Style prompt</label>
+          <textarea
+            className="w-full border rounded p-2"
+            value={template.stylePrompt ?? ''}
+            onChange={(e) =>
+              onChange({ ...template, stylePrompt: e.target.value })
+            }
+          />
+        </div>
+      </div>
+      <SlotSidebar
+        slots={template.slots}
+        onChange={(slots) => onChange({ ...template, slots })}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/CreationTrame.test.tsx
+++ b/frontend/src/pages/CreationTrame.test.tsx
@@ -3,13 +3,23 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import CreationTrame from './CreationTrame';
 import { useSectionStore } from '../store/sections';
 import { useSectionExampleStore } from '../store/sectionExamples';
+import { useSectionTemplateStore } from '../store/sectionTemplates';
 import { vi } from 'vitest';
+
+const tplCreate = vi.fn().mockResolvedValue({
+  id: 'tpl',
+  label: '',
+  ast: null,
+  slots: [],
+  stylePrompt: '',
+});
 
 it('shows navigation tabs', async () => {
   useSectionStore.setState({
     fetchOne: vi.fn().mockResolvedValue({ title: '', kind: '', schema: [] }),
     update: vi.fn(),
   });
+  useSectionTemplateStore.setState({ create: tplCreate });
   render(
     <MemoryRouter initialEntries={['/creation-trame/1']}>
       <Routes>
@@ -27,6 +37,7 @@ it('shows navigation tabs', async () => {
     screen.getByRole('button', { name: /Pré-visualisation/i }),
   ).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /Exemples/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Template/i })).toBeInTheDocument();
   expect(
     await screen.findByRole('button', { name: /Déplacer la question/i }),
   ).toBeInTheDocument();
@@ -51,6 +62,7 @@ it('shows table specific options', async () => {
     }),
     update: vi.fn(),
   });
+  useSectionTemplateStore.setState({ create: tplCreate });
   render(
     <MemoryRouter initialEntries={['/creation-trame/1']}>
       <Routes>
@@ -75,6 +87,7 @@ it('prompts to save when leaving and saves on confirm', async () => {
     update,
   });
   useSectionExampleStore.setState({ create: vi.fn() });
+  useSectionTemplateStore.setState({ create: tplCreate });
 
   render(
     <MemoryRouter initialEntries={['/creation-trame/1']}>
@@ -97,4 +110,5 @@ it('prompts to save when leaving and saves on confirm', async () => {
   fireEvent.click(screen.getByRole('button', { name: 'Oui' }));
 
   await waitFor(() => expect(update).toHaveBeenCalled());
+  expect(tplCreate).toHaveBeenCalled();
 });

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -13,6 +13,9 @@ import SaisieExempleTrame from '@/components/SaisieExempleTrame';
 import ImportMagique from '@/components/ImportMagique';
 import ExitConfirmation from '@/components/ExitConfirmation';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import TemplateEditor from '@/components/TemplateEditor';
+import { useSectionTemplateStore } from '../store/sectionTemplates';
+import type { SectionTemplate } from '../types/template';
 
 interface ImportResponse {
   result: Question[][];
@@ -28,9 +31,9 @@ export default function CreationTrame() {
   const updateSection = useSectionStore((s) => s.update);
   const createExample = useSectionExampleStore((s) => s.create);
 
-  const [tab, setTab] = useState<'questions' | 'preview' | 'examples'>(
-    'questions',
-  );
+  const [tab, setTab] = useState<
+    'questions' | 'preview' | 'examples' | 'template'
+  >('questions');
   const [previewAnswers, setPreviewAnswers] = useState<Record<string, unknown>>(
     {},
   );
@@ -42,6 +45,14 @@ export default function CreationTrame() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
+  const createTemplate = useSectionTemplateStore((s) => s.create);
+  const [template, setTemplate] = useState<SectionTemplate>({
+    id: Date.now().toString(),
+    label: '',
+    ast: null,
+    slots: [],
+    stylePrompt: '',
+  });
 
   const createDefaultNote = (): Question => ({
     id: Date.now().toString(),
@@ -56,6 +67,7 @@ export default function CreationTrame() {
       setNomTrame(section.title);
       setCategorie(section.kind);
       setIsPublic(section.isPublic ?? false);
+      setTemplate((t) => ({ ...t, label: section.title }));
       const loaded: Question[] =
         Array.isArray(section.schema) && section.schema.length > 0
           ? (section.schema as Question[])
@@ -129,11 +141,13 @@ export default function CreationTrame() {
 
   const save = async () => {
     if (!sectionId) return;
+    const created = await createTemplate({ ...template, label: nomTrame });
     await updateSection(sectionId, {
       title: nomTrame,
       kind: categorie,
       schema: questions,
       isPublic,
+      templateRefId: created.id,
     });
     for (const content of newExamples) {
       await createExample({ sectionId, content });
@@ -192,6 +206,14 @@ export default function CreationTrame() {
             >
               Exemples
             </button>
+            <button
+              className={`pb-2 px-1 border-b-2 ${
+                tab === 'template' ? 'border-primary-600' : 'border-transparent'
+              }`}
+              onClick={() => setTab('template')}
+            >
+              Template
+            </button>
           </nav>
         </div>
 
@@ -222,6 +244,10 @@ export default function CreationTrame() {
             examples={newExamples}
             onAdd={(c) => setNewExamples((p) => [...p, c])}
           />
+        )}
+
+        {tab === 'template' && (
+          <TemplateEditor template={template} onChange={setTemplate} />
         )}
       </div>
       <Dialog open={showImport} onOpenChange={setShowImport}>

--- a/frontend/src/store/sectionTemplates.ts
+++ b/frontend/src/store/sectionTemplates.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import { apiFetch } from '../utils/api';
+import { useAuth } from './auth';
+import type { SectionTemplate } from '../types/template';
+
+interface SectionTemplateState {
+  items: SectionTemplate[];
+  create: (data: SectionTemplate) => Promise<SectionTemplate>;
+}
+
+const endpoint = '/api/v1/section-templates';
+
+export const useSectionTemplateStore = create<SectionTemplateState>((set) => ({
+  items: [],
+  async create(data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const payload = {
+      id: data.id,
+      label: data.label,
+      content: data.ast,
+      slotsSpec: { slots: data.slots, stylePrompt: data.stylePrompt },
+    };
+    const item = await apiFetch<SectionTemplate>(endpoint, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(payload),
+    });
+    set((state) => ({ items: [...state.items, item] }));
+    return item;
+  },
+}));

--- a/frontend/src/store/sections.ts
+++ b/frontend/src/store/sections.ts
@@ -15,6 +15,7 @@ export interface Section {
   isPublic?: boolean;
   authorId?: string | null;
   author?: { prenom?: string | null } | null;
+  templateRefId?: string | null;
 }
 
 export type SectionInput = Omit<Section, 'id' | 'author'>;

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -1,0 +1,21 @@
+export type SlotType = 'text' | 'number' | 'choice' | 'table';
+
+export interface Slot {
+  id: string;
+  type: SlotType;
+  label?: string;
+  options?: string[];
+  prompt?: string;
+}
+
+export interface SectionTemplate {
+  id: string;
+  label: string;
+  ast: unknown;
+  slots: Slot[];
+  stylePrompt?: string;
+}
+
+export type SlotAnswer = string | number | string[] | Record<string, unknown>;
+
+export type SlotAnswers = Record<string, SlotAnswer>;


### PR DESCRIPTION
## Summary
- add SectionTemplate types and store
- implement TemplateEditor with slot sidebar
- integrate template tab and saving logic in CreationTrame

## Testing
- `pnpm --filter frontend exec eslint src/components/TemplateEditor.tsx src/components/SlotSidebar.tsx src/pages/CreationTrame.tsx src/pages/CreationTrame.test.tsx src/store/sectionTemplates.ts src/types/template.ts`
- `pnpm --filter frontend run test` *(fails: window.alert not implemented, scrollIntoView not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a798d6b88329a86d2289a8b236cf