### PR TITLE
[frontend] Add slot editor and template loading

### DIFF
--- a/frontend/src/components/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor.tsx
@@ -5,7 +5,13 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
-import { $getRoot, $getSelection, $insertNodes, $createParagraphNode, $createTextNode } from 'lexical';
+import {
+  $getRoot,
+  $getSelection,
+  $insertNodes,
+  $createParagraphNode,
+  $createTextNode,
+} from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { ToolbarPlugin } from './RichTextToolbar';
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
@@ -14,12 +20,15 @@ import { ListNode, ListItemNode } from '@lexical/list';
 import { useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
 // HTML/Markdown parsing removed: we now work exclusively with Lexical JSON editor state
 import { HeadingNode, QuoteNode } from '@lexical/rich-text';
+import { SlotNode, $createSlotNode } from '../nodes/SlotNode';
 import { useVirtualSelection } from '../hooks/useVirtualSelection';
+import type { SlotType } from '../types/template';
 
 export interface RichTextEditorHandle {
   setEditorStateJson: (state: unknown) => void;
   getEditorStateJson: () => unknown;
   insertPlainText: (text: string) => void;
+  insertSlot: (slotId: string, slotType: SlotType) => void;
 }
 
 interface Props {
@@ -39,7 +48,7 @@ function JsonStatePlugin({ state }: { state: unknown }) {
     hasLoaded.current = true;
 
     try {
-      const parsed = editor.parseEditorState(state as any);
+      const parsed = editor.parseEditorState(state as string);
       editor.setEditorState(parsed);
     } catch {
       // fallback: empty document
@@ -55,56 +64,73 @@ function JsonStatePlugin({ state }: { state: unknown }) {
   return null;
 }
 
-const ImperativeHandlePlugin = forwardRef<
-  RichTextEditorHandle,
-  object
->(function ImperativeHandlePlugin(_, ref) {
-  const [editor] = useLexicalComposerContext();
+const ImperativeHandlePlugin = forwardRef<RichTextEditorHandle, object>(
+  function ImperativeHandlePlugin(_, ref) {
+    const [editor] = useLexicalComposerContext();
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      setEditorStateJson(state: unknown) {
-        try {
-          const parsed = editor.parseEditorState(state as any);
-          editor.setEditorState(parsed);
-        } catch {
-          // ignore invalid state
-        }
-      },
-      getEditorStateJson() {
-        try {
-          return editor.getEditorState().toJSON();
-        } catch {
-          return null;
-        }
-      },
-      insertPlainText(text: string) {
-        editor.update(() => {
-          const lines = (text ?? '').split(/\r?\n/);
-          const nodes = lines.map((line) => {
-            const p = $createParagraphNode();
-            p.append($createTextNode(line));
-            return p;
-          });
-          const selection = $getSelection();
-          if (selection) {
-            $insertNodes(nodes);
-          } else {
-            $getRoot().append(...nodes);
+    useImperativeHandle(
+      ref,
+      () => ({
+        setEditorStateJson(state: unknown) {
+          try {
+            const parsed = editor.parseEditorState(state as string);
+            editor.setEditorState(parsed);
+          } catch {
+            // ignore invalid state
           }
-          editor.focus();
-        });
-      },
-    }),
-    [editor],
-  );
+        },
+        getEditorStateJson() {
+          try {
+            return editor.getEditorState().toJSON();
+          } catch {
+            return null;
+          }
+        },
+        insertPlainText(text: string) {
+          editor.update(() => {
+            const lines = (text ?? '').split(/\r?\n/);
+            const nodes = lines.map((line) => {
+              const p = $createParagraphNode();
+              p.append($createTextNode(line));
+              return p;
+            });
+            const selection = $getSelection();
+            if (selection) {
+              $insertNodes(nodes);
+            } else {
+              $getRoot().append(...nodes);
+            }
+            editor.focus();
+          });
+        },
+        insertSlot(slotId: string, slotType: SlotType) {
+          editor.update(() => {
+            const node = $createSlotNode(slotId, slotType, false, '…');
+            const selection = $getSelection();
+            if (selection) {
+              $insertNodes([node]);
+            } else {
+              $getRoot().append(node);
+            }
+            editor.focus();
+          });
+        },
+      }),
+      [editor],
+    );
 
-  return null;
-});
+    return null;
+  },
+);
 
 function EditorCore(
-  { initialStateJson = null, readOnly = false, onChange = () => {}, onSave, exportFileName }: Props = {
+  {
+    initialStateJson = null,
+    readOnly = false,
+    onChange = () => {},
+    onSave,
+    exportFileName,
+  }: Props = {
     initialStateJson: null,
     readOnly: false,
     onChange: () => {},
@@ -131,13 +157,18 @@ function EditorCore(
         bold: 'font-bold',
       },
     },
-    nodes: [ListNode, ListItemNode, LinkNode, HeadingNode, QuoteNode],
+    nodes: [ListNode, ListItemNode, LinkNode, HeadingNode, QuoteNode, SlotNode],
   };
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      {!readOnly && <ToolbarPlugin onSave={onSave} exportFileName={exportFileName} />}
+      {!readOnly && (
+        <ToolbarPlugin onSave={onSave} exportFileName={exportFileName} />
+      )}
       <div className="relative h-full">
-        <div ref={editorRef as unknown as React.RefObject<HTMLDivElement>} className="h-full bg-wood-100 p-8 overflow-auto">
+        <div
+          ref={editorRef as unknown as React.RefObject<HTMLDivElement>}
+          className="h-full bg-wood-100 p-8 overflow-auto"
+        >
           <div className="flex justify-center">
             <div className="bg-paper-50 border border-gray-300 rounded shadow p-16 w-full max-w-3xl min-h-[100vh] flex flex-col">
               <RichTextPlugin
@@ -159,7 +190,7 @@ function EditorCore(
                 }}
               />
               <JsonStatePlugin state={initialStateJson} />
-              <ImperativeHandlePlugin ref={ref as any} />
+              <ImperativeHandlePlugin ref={ref} />
             </div>
           </div>
         </div>

--- a/frontend/src/components/SlotEditor.tsx
+++ b/frontend/src/components/SlotEditor.tsx
@@ -1,0 +1,69 @@
+import type { Slot, SlotType } from '../types/template';
+
+interface Props {
+  slot: Slot;
+  onChange: (partial: Partial<Slot>) => void;
+  onRemove: () => void;
+}
+
+const types: SlotType[] = ['text', 'number', 'choice', 'table'];
+
+export default function SlotEditor({ slot, onChange, onRemove }: Props) {
+  return (
+    <div className="border-b pb-2 last:border-b-0">
+      <div className="flex justify-between items-center">
+        <span className="text-xs font-mono">{slot.id}</span>
+        <button
+          type="button"
+          className="text-xs text-red-600"
+          onClick={onRemove}
+        >
+          Supprimer
+        </button>
+      </div>
+      <label className="block text-xs mt-2">Label</label>
+      <input
+        className="w-full border rounded p-1"
+        value={slot.label ?? ''}
+        onChange={(e) => onChange({ label: e.target.value })}
+      />
+      <label className="block text-xs mt-2">Type</label>
+      <select
+        className="w-full border rounded p-1"
+        value={slot.type}
+        onChange={(e) => onChange({ type: e.target.value as SlotType })}
+      >
+        {types.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      {slot.type === 'choice' && (
+        <>
+          <label className="block text-xs mt-2">
+            Options (séparées par des virgules)
+          </label>
+          <input
+            className="w-full border rounded p-1"
+            value={(slot.options ?? []).join(',')}
+            onChange={(e) =>
+              onChange({
+                options: e.target.value
+                  .split(',')
+                  .map((s) => s.trim())
+                  .filter(Boolean),
+              })
+            }
+          />
+        </>
+      )}
+      <label className="block text-xs mt-2">Prompt</label>
+      <textarea
+        className="w-full border rounded p-1"
+        value={slot.prompt ?? ''}
+        onChange={(e) => onChange({ prompt: e.target.value })}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/SlotSidebar.test.tsx
+++ b/frontend/src/components/SlotSidebar.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import SlotSidebar from './SlotSidebar';
+import type { Slot } from '../types/template';
+
+test('adds slot and calls callbacks', () => {
+  const onChange = vi.fn();
+  const onAddSlot = vi.fn();
+  const slots: Slot[] = [];
+  render(
+    <SlotSidebar slots={slots} onChange={onChange} onAddSlot={onAddSlot} />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /ajouter/i }));
+  expect(onChange).toHaveBeenCalled();
+  expect(onAddSlot).toHaveBeenCalled();
+});

--- a/frontend/src/components/SlotSidebar.tsx
+++ b/frontend/src/components/SlotSidebar.tsx
@@ -1,13 +1,13 @@
-import type { Slot, SlotType } from '../types/template';
+import type { Slot } from '../types/template';
+import SlotEditor from './SlotEditor';
 
 interface Props {
   slots: Slot[];
   onChange: (slots: Slot[]) => void;
+  onAddSlot?: (slot: Slot) => void;
 }
 
-const types: SlotType[] = ['text', 'number', 'choice', 'table'];
-
-export default function SlotSidebar({ slots, onChange }: Props) {
+export default function SlotSidebar({ slots, onChange, onAddSlot }: Props) {
   const updateSlot = (index: number, partial: Partial<Slot>) => {
     const next = [...slots];
     next[index] = { ...next[index], ...partial };
@@ -15,16 +15,15 @@ export default function SlotSidebar({ slots, onChange }: Props) {
   };
 
   const addSlot = () => {
-    onChange([
-      ...slots,
-      {
-        id: Date.now().toString(),
-        type: 'text',
-        label: '',
-        options: [],
-        prompt: '',
-      },
-    ]);
+    const slot: Slot = {
+      id: Date.now().toString(),
+      type: 'text',
+      label: '',
+      options: [],
+      prompt: '',
+    };
+    onChange([...slots, slot]);
+    onAddSlot?.(slot);
   };
 
   const removeSlot = (id: string) => {
@@ -44,63 +43,12 @@ export default function SlotSidebar({ slots, onChange }: Props) {
         </button>
       </div>
       {slots.map((slot, idx) => (
-        <div key={slot.id} className="border-b pb-2 last:border-b-0">
-          <div className="flex justify-between items-center">
-            <span className="text-xs font-mono">{slot.id}</span>
-            <button
-              type="button"
-              className="text-xs text-red-600"
-              onClick={() => removeSlot(slot.id)}
-            >
-              Supprimer
-            </button>
-          </div>
-          <label className="block text-xs mt-2">Label</label>
-          <input
-            className="w-full border rounded p-1"
-            value={slot.label ?? ''}
-            onChange={(e) => updateSlot(idx, { label: e.target.value })}
-          />
-          <label className="block text-xs mt-2">Type</label>
-          <select
-            className="w-full border rounded p-1"
-            value={slot.type}
-            onChange={(e) =>
-              updateSlot(idx, { type: e.target.value as SlotType })
-            }
-          >
-            {types.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-          {slot.type === 'choice' && (
-            <>
-              <label className="block text-xs mt-2">
-                Options (séparées par des virgules)
-              </label>
-              <input
-                className="w-full border rounded p-1"
-                value={(slot.options ?? []).join(',')}
-                onChange={(e) =>
-                  updateSlot(idx, {
-                    options: e.target.value
-                      .split(',')
-                      .map((s) => s.trim())
-                      .filter(Boolean),
-                  })
-                }
-              />
-            </>
-          )}
-          <label className="block text-xs mt-2">Prompt</label>
-          <textarea
-            className="w-full border rounded p-1"
-            value={slot.prompt ?? ''}
-            onChange={(e) => updateSlot(idx, { prompt: e.target.value })}
-          />
-        </div>
+        <SlotEditor
+          key={slot.id}
+          slot={slot}
+          onChange={(partial) => updateSlot(idx, partial)}
+          onRemove={() => removeSlot(slot.id)}
+        />
       ))}
     </aside>
   );

--- a/frontend/src/components/TemplateEditor.tsx
+++ b/frontend/src/components/TemplateEditor.tsx
@@ -32,6 +32,7 @@ export default function TemplateEditor({ template, onChange }: Props) {
       <SlotSidebar
         slots={template.slots}
         onChange={(slots) => onChange({ ...template, slots })}
+        onAddSlot={(slot) => editorRef.current?.insertSlot(slot.id, slot.type)}
       />
     </div>
   );

--- a/frontend/src/nodes/SlotNode.tsx
+++ b/frontend/src/nodes/SlotNode.tsx
@@ -1,0 +1,105 @@
+import { DecoratorNode, type LexicalNode, type NodeKey } from 'lexical';
+import type { SlotType } from '../types/template';
+import React from 'react';
+
+export type SerializedSlotNode = {
+  type: 'slot';
+  slotId: string;
+  slotType: SlotType;
+  optional: boolean;
+  placeholder: string;
+  version: 1;
+};
+
+export class SlotNode extends DecoratorNode<JSX.Element> {
+  __slotId: string;
+  __slotType: SlotType;
+  __optional: boolean;
+  __placeholder: string;
+
+  constructor(
+    slotId: string,
+    slotType: SlotType,
+    optional: boolean,
+    placeholder: string,
+    key?: NodeKey,
+  ) {
+    super(key);
+    this.__slotId = slotId;
+    this.__slotType = slotType;
+    this.__optional = optional;
+    this.__placeholder = placeholder;
+  }
+
+  static getType(): string {
+    return 'slot';
+  }
+
+  static clone(node: SlotNode): SlotNode {
+    return new SlotNode(
+      node.__slotId,
+      node.__slotType,
+      node.__optional,
+      node.__placeholder,
+      node.__key,
+    );
+  }
+
+  createDOM(): HTMLElement {
+    const span = document.createElement('span');
+    span.className = 'bg-yellow-200 text-yellow-800 px-1 rounded';
+    span.textContent = this.__slotId;
+    span.contentEditable = 'false';
+    return span;
+  }
+
+  updateDOM(): boolean {
+    return false;
+  }
+
+  static importJSON(json: SerializedSlotNode): SlotNode {
+    return new SlotNode(
+      json.slotId,
+      json.slotType,
+      json.optional,
+      json.placeholder,
+    );
+  }
+
+  exportJSON(): SerializedSlotNode {
+    return {
+      type: 'slot',
+      slotId: this.__slotId,
+      slotType: this.__slotType,
+      optional: this.__optional,
+      placeholder: this.__placeholder,
+      version: 1,
+    };
+  }
+
+  decorate(): JSX.Element {
+    return (
+      <span
+        className="bg-yellow-200 text-yellow-800 px-1 rounded"
+        contentEditable={false}
+      >
+        {this.__slotId}
+      </span>
+    );
+  }
+}
+
+export function $createSlotNode(
+  slotId: string,
+  slotType: SlotType,
+  optional = false,
+  placeholder = '…',
+): SlotNode {
+  return new SlotNode(slotId, slotType, optional, placeholder);
+}
+
+export function $isSlotNode(
+  node: LexicalNode | null | undefined,
+): node is SlotNode {
+  return node instanceof SlotNode;
+}

--- a/frontend/src/store/sectionTemplates.ts
+++ b/frontend/src/store/sectionTemplates.ts
@@ -1,11 +1,20 @@
 import { create } from 'zustand';
 import { apiFetch } from '../utils/api';
 import { useAuth } from './auth';
-import type { SectionTemplate } from '../types/template';
+import type { SectionTemplate, Slot } from '../types/template';
+
+interface ApiSectionTemplate {
+  id: string;
+  label: string;
+  content: unknown;
+  slotsSpec?: { slots?: Slot[]; stylePrompt?: string };
+}
 
 interface SectionTemplateState {
   items: SectionTemplate[];
   create: (data: SectionTemplate) => Promise<SectionTemplate>;
+  get: (id: string) => Promise<SectionTemplate>;
+  update: (id: string, data: SectionTemplate) => Promise<SectionTemplate>;
 }
 
 const endpoint = '/api/v1/section-templates';
@@ -21,12 +30,64 @@ export const useSectionTemplateStore = create<SectionTemplateState>((set) => ({
       content: data.ast,
       slotsSpec: { slots: data.slots, stylePrompt: data.stylePrompt },
     };
-    const item = await apiFetch<SectionTemplate>(endpoint, {
+    const apiItem = await apiFetch<ApiSectionTemplate>(endpoint, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
       body: JSON.stringify(payload),
     });
+    const item: SectionTemplate = {
+      id: apiItem.id,
+      label: apiItem.label,
+      ast: apiItem.content,
+      slots: apiItem.slotsSpec?.slots ?? [],
+      stylePrompt: apiItem.slotsSpec?.stylePrompt,
+    };
     set((state) => ({ items: [...state.items, item] }));
+    return item;
+  },
+  async get(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const apiItem = await apiFetch<ApiSectionTemplate>(`${endpoint}/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const item: SectionTemplate = {
+      id: apiItem.id,
+      label: apiItem.label,
+      ast: apiItem.content,
+      slots: apiItem.slotsSpec?.slots ?? [],
+      stylePrompt: apiItem.slotsSpec?.stylePrompt,
+    };
+    set((state) => ({
+      items: state.items.some((s) => s.id === id)
+        ? state.items.map((s) => (s.id === id ? item : s))
+        : [...state.items, item],
+    }));
+    return item;
+  },
+  async update(id, data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const payload = {
+      label: data.label,
+      content: data.ast,
+      slotsSpec: { slots: data.slots, stylePrompt: data.stylePrompt },
+    };
+    const apiItem = await apiFetch<ApiSectionTemplate>(`${endpoint}/${id}`, {
+      method: 'PUT',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(payload),
+    });
+    const item: SectionTemplate = {
+      id: apiItem.id,
+      label: apiItem.label,
+      ast: apiItem.content,
+      slots: apiItem.slotsSpec?.slots ?? [],
+      stylePrompt: apiItem.slotsSpec?.stylePrompt,
+    };
+    set((state) => ({
+      items: state.items.map((s) => (s.id === id ? item : s)),
+    }));
     return item;
   },
 }));


### PR DESCRIPTION
## Summary
- factor slot editing into new SlotEditor component
- insert SlotNode in editor when adding a slot
- load and update existing section templates

## Testing
- `pnpm --filter frontend exec eslint src/components/SlotEditor.tsx src/components/SlotSidebar.tsx src/nodes/SlotNode.tsx src/components/TemplateEditor.tsx src/components/RichTextEditor.tsx src/store/sectionTemplates.ts src/pages/CreationTrame.tsx src/components/SlotSidebar.test.tsx`
- `pnpm --filter frontend run test` *(fails: el.scrollIntoView is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a5adced7e083298c73d5d87a19f16f