### PR TITLE
[frontend] add field presets and default values

### DIFF
--- a/backend/src/types/template.ts
+++ b/backend/src/types/template.ts
@@ -3,6 +3,17 @@
 export type SlotMode = 'user' | 'computed' | 'llm';
 export type SlotType = 'text' | 'number' | 'list' | 'table';
 
+export type FieldPresetKey = 'desc_facts' | 'score' | 'conclusion';
+
+// Optional default value typed loosely (UI will gate by field.type)
+export type DefaultValue =
+  | string
+  | number
+  | string[]
+  | number[]
+  | Record<string, any>
+  | null;
+
 
 export interface SectionTemplate {
   id: string;
@@ -28,6 +39,19 @@ export type FieldSpec = {
   prompt?: string;
   template?: string;
   optional?: boolean;           // Pour la compatibilité avec plan.service.ts
+
+  /** NEW: valeur initiale pré-remplie dans l’UI/AST quand on “Insère” */
+  defaultValue?: DefaultValue;
+
+  /** NEW: rattachement à un préréglage (pour reset/détacher) */
+  preset?: {
+    key: FieldPresetKey;
+    version: number;
+    /** props verrouillées tant que non détaché (ex: mode/type d’un "Score") */
+    locked?: Array<'type' | 'mode' | 'pattern' | 'deps' | 'template'>;
+    /** si true, on garde les valeurs actuelles mais on perd le lien au preset */
+    detached?: boolean;
+  };
 };
 
 export type GroupSpec = {

--- a/frontend/src/templates/fieldPresets.ts
+++ b/frontend/src/templates/fieldPresets.ts
@@ -1,0 +1,92 @@
+import type { FieldSpec, FieldPresetKey } from '../types/template';
+
+export const FIELD_PRESETS: Record<
+  FieldPresetKey,
+  { label: string; defaults: Omit<FieldSpec, 'id' | 'kind' | 'label'> }
+> = {
+  desc_facts: {
+    label: 'Description factuelle',
+    defaults: {
+      mode: 'llm',
+      type: 'text',
+      prompt:
+        "Rédige une description factuelle, brève et neutre, sans interprétation. Phrases courtes. Pas de métaphore, pas d’adjectifs subjectifs.",
+      defaultValue: '',
+      optional: false,
+      template: undefined,
+      pattern: undefined,
+      deps: [],
+      preset: {
+        key: 'desc_facts',
+        version: 1,
+        locked: [], // on autorise à changer type/mode si tu veux
+      },
+    },
+  },
+
+  score: {
+    label: 'Score',
+    defaults: {
+      mode: 'user', // saisie manuelle par défaut (simple et robuste)
+      type: 'number',
+      prompt: '',
+      defaultValue: null,
+      optional: false,
+      template: undefined,
+      pattern: undefined,
+      deps: [],
+      preset: {
+        key: 'score',
+        version: 1,
+        locked: ['type', 'mode'], // un score reste un nombre saisi par l’utilisateur
+      },
+    },
+  },
+
+  conclusion: {
+    label: 'Conclusion',
+    defaults: {
+      mode: 'llm',
+      type: 'text',
+      prompt:
+        "Rédige une conclusion synthétique, factuelle et orientée recommandations. 4–6 lignes. Évite le jargon, pas d’affirmations diagnostiques.",
+      defaultValue: '',
+      optional: false,
+      template: undefined,
+      pattern: undefined,
+      deps: [],
+      preset: {
+        key: 'conclusion',
+        version: 1,
+        locked: [], // libre
+      },
+    },
+  },
+};
+
+export function makeFieldFromPreset(
+  key: FieldPresetKey,
+  opts?: { id?: string; label?: string; overrides?: Partial<Omit<FieldSpec, 'id' | 'kind' | 'preset'>> }
+): FieldSpec {
+  const base = FIELD_PRESETS[key];
+  const id = opts?.id ?? `field-${Date.now()}`;
+  const label = opts?.label ?? base.label;
+
+  return {
+    kind: 'field',
+    id,
+    label,
+    ...base.defaults,
+    ...(opts?.overrides ?? {}),
+    // IMPORTANT: garder la trace du preset même si overrides
+    preset: {
+      ...base.defaults.preset!,
+      detached: false,
+    },
+  };
+}
+
+export function isLockedByPreset(field: FieldSpec, prop: FieldSpec['type'] extends never ? never : keyof FieldSpec): boolean {
+  if (!field.preset || field.preset.detached) return false;
+  return (field.preset.locked ?? []).includes(prop as any);
+}

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -2,6 +2,17 @@ export type SlotType = 'text' | 'number' | 'list' | 'table';
 
 export type SlotMode = 'user' | 'computed' | 'llm';
 
+export type FieldPresetKey = 'desc_facts' | 'score' | 'conclusion';
+
+// Optional default value typed loosely (UI will gate by field.type)
+export type DefaultValue =
+  | string
+  | number
+  | string[]
+  | number[]
+  | Record<string, any>
+  | null;
+
 export interface SectionTemplate {
   id: string;
   label: string;
@@ -26,6 +37,19 @@ export type FieldSpec = {
   prompt?: string;
   template?: string; // optional moustache for rendering
   optional?: boolean; // <- AJOUTÉ pour cohérence avec backend
+
+  /** NEW: valeur initiale pré-remplie dans l’UI/AST quand on “Insère” */
+  defaultValue?: DefaultValue;
+
+  /** NEW: rattachement à un préréglage (pour reset/détacher) */
+  preset?: {
+    key: FieldPresetKey;
+    version: number;
+    /** props verrouillées tant que non détaché (ex: mode/type d’un "Score") */
+    locked?: Array<'type' | 'mode' | 'pattern' | 'deps' | 'template'>;
+    /** si true, on garde les valeurs actuelles mais on perd le lien au preset */
+    detached?: boolean;
+  };
 };
 
 // 2) Groups (organization only)


### PR DESCRIPTION
## Summary
- expand FieldSpec with preset linkage and defaultValue support
- add field preset catalog and factory helpers
- enhance SlotEditor with preset selection, default value input, and preset-aware slot insertion

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test` *(fails: Not implemented window.alert; TypeError: el.scrollIntoView is not a function, etc.)*
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test` *(fails: TypeError: slots.forEach is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e38d519c83298853ad907d14f0b5