### PR TITLE
[frontend] Add field presets for description, score and conclusion

### DIFF
--- a/frontend/src/components/SlotEditor.tsx
+++ b/frontend/src/components/SlotEditor.tsx
@@ -4,7 +4,9 @@ import type {
   GroupSpec,
   RepeatSpec,
   SlotType,
+  FieldPreset,
 } from '../types/template';
+import { FIELD_PRESETS } from '../types/template';
 import { Card, CardHeader, CardContent } from './ui/card';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -27,6 +29,7 @@ interface Props {
 }
 
 const types: SlotType[] = ['text', 'number', 'list', 'table'];
+const presets: FieldPreset[] = ['description', 'score', 'conclusion'];
 
 export default function SlotEditor({
   slot,
@@ -92,6 +95,37 @@ export default function SlotEditor({
               {types.map((t) => (
                 <SelectItem key={t} value={t}>
                   {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label htmlFor={`preset-${field.id}`} className="text-xs">
+            Préset
+          </Label>
+          <Select
+            value={field.preset}
+            onValueChange={(value) => {
+              const preset = value as FieldPreset;
+              onChange({
+                ...field,
+                preset,
+                prompt: FIELD_PRESETS[preset].prompt,
+              });
+            }}
+          >
+            <SelectTrigger
+              id={`preset-${field.id}`}
+              className="mt-0.5 h-8 text-sm"
+            >
+              <SelectValue placeholder="Sélectionner" />
+            </SelectTrigger>
+            <SelectContent>
+              {presets.map((p) => (
+                <SelectItem key={p} value={p}>
+                  {p}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/frontend/src/components/SlotSidebar.tsx
+++ b/frontend/src/components/SlotSidebar.tsx
@@ -4,6 +4,7 @@ import type {
   GroupSpec,
   RepeatSpec,
 } from '../types/template';
+import { FIELD_PRESETS } from '../types/template';
 import SlotEditor from './SlotEditor';
 import { Button } from './ui/button';
 import { Card, CardHeader, CardContent } from './ui/card';
@@ -63,9 +64,10 @@ export default function SlotSidebar({
       type: 'text',
       mode: 'llm',
       label: 'Nouveau champ',
-      prompt: '',
+      prompt: FIELD_PRESETS.description.prompt,
       pattern: '',
       deps: [],
+      preset: 'description',
     };
     onChange([...(slots || []), slot]);
     onAddSlot?.(slot);
@@ -79,9 +81,10 @@ export default function SlotSidebar({
       type: 'text',
       mode: 'llm',
       label: 'Champ',
-      prompt: '',
+      prompt: FIELD_PRESETS.description.prompt,
       pattern: '',
       deps: [],
+      preset: 'description',
     };
     const group: GroupSpec = {
       kind: 'group',
@@ -108,6 +111,8 @@ export default function SlotSidebar({
           type: 'text',
           mode: 'llm',
           label: 'Champ_1',
+          prompt: FIELD_PRESETS.description.prompt,
+          preset: 'description',
         },
       ],
     };

--- a/frontend/src/types/template.ts
+++ b/frontend/src/types/template.ts
@@ -2,6 +2,20 @@ export type SlotType = 'text' | 'number' | 'list' | 'table';
 
 export type SlotMode = 'user' | 'computed' | 'llm';
 
+export type FieldPreset = 'description' | 'score' | 'conclusion';
+
+export const FIELD_PRESETS: Record<FieldPreset, { prompt: string }> = {
+  description: {
+    prompt: 'description factuelle simple',
+  },
+  score: {
+    prompt: '',
+  },
+  conclusion: {
+    prompt: '',
+  },
+};
+
 export interface SectionTemplate {
   id: string;
   label: string;
@@ -26,6 +40,7 @@ export type FieldSpec = {
   prompt?: string;
   template?: string; // optional moustache for rendering
   optional?: boolean; // <- AJOUTÉ pour cohérence avec backend
+  preset?: FieldPreset;
 };
 
 // 2) Groups (organization only)


### PR DESCRIPTION
## Summary
- add FIELD_PRESETS with default prompts
- allow selecting preset in SlotEditor
- default new fields to description preset in SlotSidebar

## Testing
- `pnpm run lint` (fails: Unexpected any and other lint errors)
- `pnpm run test` (fails: 23 failed, 32 passed)


------
https://chatgpt.com/codex/tasks/task_e_68a9eb4b5aec8329a195a8ae980eb793