### PR TITLE
[frontend] Simplify slot sidebar and add detail view

### DIFF
--- a/frontend/src/components/SlotDetails.tsx
+++ b/frontend/src/components/SlotDetails.tsx
@@ -1,0 +1,36 @@
+import type { SlotSpec, FieldSpec } from '../types/template';
+import SlotEditor from './SlotEditor';
+import { Button } from './ui/button';
+
+interface Props {
+  slot: SlotSpec;
+  onChange: (updated: SlotSpec) => void;
+  onRemove: () => void;
+  onAddSlot?: (slot: FieldSpec) => void;
+  onUpdateSlot?: (slotId: string, slotLabel: string) => void;
+  onBack: () => void;
+}
+
+export default function SlotDetails({
+  slot,
+  onChange,
+  onRemove,
+  onAddSlot,
+  onUpdateSlot,
+  onBack,
+}: Props) {
+  return (
+    <div className="space-y-2">
+      <Button size="sm" variant="ghost" onClick={onBack}>
+        Retour
+      </Button>
+      <SlotEditor
+        slot={slot}
+        onChange={onChange}
+        onRemove={onRemove}
+        onAddSlot={onAddSlot}
+        onUpdateSlot={onUpdateSlot}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/SlotSidebar.test.tsx
+++ b/frontend/src/components/SlotSidebar.test.tsx
@@ -1,16 +1,39 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import SlotSidebar from './SlotSidebar';
-import type { SlotSpec } from '../types/template';
+import type { FieldSpec } from '../types/template';
 
-test('adds slot and calls callbacks', () => {
-  const onChange = vi.fn();
+function createField(id: string): FieldSpec {
+  return {
+    kind: 'field',
+    id,
+    type: 'text',
+    mode: 'llm',
+    label: id,
+    prompt: '',
+    pattern: '',
+    deps: [],
+    preset: 'description',
+  };
+}
+
+test('insert button calls onAddSlot', () => {
+  const field = createField('field-1');
   const onAddSlot = vi.fn();
-  const slots: SlotSpec[] = [];
   render(
-    <SlotSidebar slots={slots} onChange={onChange} onAddSlot={onAddSlot} />,
+    <SlotSidebar slots={[field]} onChange={vi.fn()} onAddSlot={onAddSlot} />,
   );
-  fireEvent.click(screen.getByRole('button', { name: /ajouter/i }));
-  expect(onChange).toHaveBeenCalled();
-  expect(onAddSlot).toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: /insérer/i }));
+  expect(onAddSlot).toHaveBeenCalledWith(field);
+});
+
+test('opens detail view and returns on back', () => {
+  const field = createField('field-1');
+  render(<SlotSidebar slots={[field]} onChange={vi.fn()} />);
+  fireEvent.click(screen.getByText('field-1'));
+  expect(screen.getByRole('button', { name: /retour/i })).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /retour/i }));
+  expect(
+    screen.queryByRole('button', { name: /retour/i }),
+  ).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- show slot list with label, preset and insert/remove actions
- open dedicated detail view for editing a slot
- cover new sidebar behaviors with tests

## Testing
- `pnpm --filter frontend run lint` *(fails: 112 errors in unrelated files)*
- `pnpm --filter frontend run test` *(fails: 12 files failed, 22 tests failed in unrelated areas)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ed8120208329bcb50b1f4353ee81