### PR TITLE
[frontend] Set default RichTextEditor font to Calibri 11

### DIFF
--- a/frontend/src/components/RichTextEditor.test.tsx
+++ b/frontend/src/components/RichTextEditor.test.tsx
@@ -37,7 +37,7 @@ describe('RichTextEditor', () => {
         version: 1,
       },
     };
-    const { container } = render(
+    render(
       <RichTextEditor
         ref={ref}
         initialStateJson={initialState}
@@ -108,5 +108,15 @@ describe('RichTextEditor', () => {
       expect(span?.getAttribute('style')).toContain('font-size: 24px');
       expect(span?.getAttribute('style')).toContain('font-family: Arial');
     });
+  });
+
+  it('applies Calibri 11 as default font', async () => {
+    const { container } = render(<RichTextEditor onChange={() => {}} />);
+    const textbox = container.querySelector(
+      '[contenteditable="true"]',
+    ) as HTMLElement;
+    await waitFor(() => expect(textbox).toBeTruthy());
+    expect(textbox.style.fontFamily).toContain('Calibri');
+    expect(textbox.style.fontSize).toBe('11pt');
   });
 });

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -75,6 +75,10 @@ html, body, #root {
 }
 
 /* styles globaux (ex: index.css) */
+.editor-content {
+  font-family: Calibri, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 11pt;
+}
 .editor-content u,
 .editor-content [style*="text-decoration: underline"] {
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- apply `editor-content` theme with Calibri 11 default
- style editor content with Calibri 11 fonts
- test default font initialization

## Testing
- `pnpm --filter frontend exec eslint src/components/RichTextEditor.tsx src/components/RichTextEditor.test.tsx`
- `pnpm --filter frontend run test` *(fails: Unable to find element "John Doe" in MesBilans.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f43e575c8329ad4d5ac91a9a0923