### PR TITLE
[frontend] Add table insertion dialog

### DIFF
--- a/frontend/src/components/RichTextEditor.test.tsx
+++ b/frontend/src/components/RichTextEditor.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import RichTextEditor, { type RichTextEditorHandle } from './RichTextEditor';
 import { setFontFamily, setFontSize } from './RichTextToolbar';
@@ -118,5 +118,27 @@ describe('RichTextEditor', () => {
     await waitFor(() => expect(textbox).toBeTruthy());
     expect(textbox.style.fontFamily).toContain('Calibri');
     expect(textbox.style.fontSize).toBe('11pt');
+  });
+
+  it('inserts a table with chosen dimensions', async () => {
+    const { container } = render(<RichTextEditor onChange={() => {}} />);
+
+    fireEvent.click(screen.getByText('+Insert'));
+    fireEvent.click(screen.getByText('Tableau'));
+
+    const rowsInput = screen.getByLabelText('Lignes');
+    const colsInput = screen.getByLabelText('Colonnes');
+    fireEvent.change(rowsInput, { target: { value: '2' } });
+    fireEvent.change(colsInput, { target: { value: '3' } });
+
+    fireEvent.click(screen.getByText('Insérer'));
+
+    await waitFor(() => {
+      const table = container.querySelector('table');
+      expect(table).not.toBeNull();
+      const rows = table!.querySelectorAll('tr');
+      expect(rows.length).toBe(2);
+      expect(rows[0].querySelectorAll('td').length).toBe(3);
+    });
   });
 });

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -92,3 +92,15 @@ html, body, #root {
 .editor-content ul { list-style: disc; padding-left: 1.25rem; }
 .editor-content ol { list-style: decimal; padding-left: 1.25rem; }
 .editor-content li { margin-left: 0.25rem; }
+
+/* Tableau avec bordures noires par défaut */
+.editor-content table {
+  border-collapse: collapse;
+  border: 1px solid black;
+}
+
+.editor-content th,
+.editor-content td {
+  border: 1px solid black;
+}
+


### PR DESCRIPTION
## Summary
- allow inserting tables via new "+Insert" dropdown and modal
- render tables with default black borders
- enable removing selected tables with delete key

## Testing
- `pnpm --filter frontend run lint` *(fails: 106 errors in existing code)*
- `pnpm --filter frontend exec eslint src/components/RichTextToolbar.tsx src/components/RichTextEditor.tsx src/components/RichTextEditor.test.tsx src/global.css`
- `pnpm --filter frontend run test` *(fails: unhandled errors and missing browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fa729e0c8329be28489914d2a78b