### PR TITLE
[frontend] Preload and persist wizard notes

### DIFF
--- a/frontend/src/components/WizardAIRightPanel.test.tsx
+++ b/frontend/src/components/WizardAIRightPanel.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports, react/display-name */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import WizardAIRightPanel from './WizardAIRightPanel';
 import { vi } from 'vitest';
+import React from 'react';
+import { apiFetch } from '@/utils/api';
 
 vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
 vi.mock('@/components/ui/button', () => ({
@@ -28,20 +31,70 @@ vi.mock('@/components/ui/tabs', () => ({
 vi.mock('@/store/userProfile', () => ({
   useUserProfileStore: () => ({ profile: null, fetchProfile: vi.fn() }),
 }));
-vi.mock('./bilan/DataEntry', () => ({
-  DataEntry: (props: any) => <div>{props.children}</div>,
-}));
+vi.mock('./bilan/DataEntry', () => {
+  const React = require('react');
+  return {
+    DataEntry: React.forwardRef((_props: any, ref: any) => {
+      React.useImperativeHandle(ref, () => ({
+        save: () => ({}),
+        load: () => {},
+        clear: () => {},
+        getAnswers: () => ({}),
+      }));
+      return <div />;
+    }),
+  };
+});
 vi.mock('./ImportNotes', () => ({ default: () => <div /> }));
 
-const sectionInfo = { id: 's1', title: 'Section 1' } as any;
+const mockedApiFetch = apiFetch as unknown as vi.Mock;
 
-function setup(cb?: any) {
-  const onGenerateFromTemplate = vi.fn();
+const sectionInfo = { id: 's1', title: 'Section 1' } as any;
+const trame = { value: 't1', label: 'Trame 1' } as any;
+
+test('fetches latest notes on entering step 2', async () => {
+  mockedApiFetch.mockResolvedValueOnce([{ id: 'i1', contentNotes: { a: 1 } }]);
+
   render(
     <WizardAIRightPanel
       sectionInfo={sectionInfo}
-      trameOptions={[]}
-      selectedTrame={undefined}
+      trameOptions={[trame]}
+      selectedTrame={trame}
+      onTrameChange={() => {}}
+      examples={[]}
+      onAddExample={() => {}}
+      onRemoveExample={() => {}}
+      questions={[]}
+      answers={{}}
+      onAnswersChange={() => {}}
+      onGenerate={() => {}}
+      onGenerateFromTemplate={() => {}}
+      isGenerating={false}
+      bilanId="b1"
+      onCancel={() => {}}
+    />,
+  );
+
+  fireEvent.click(screen.getByText('Étape suivante'));
+
+  await waitFor(() =>
+    expect(mockedApiFetch).toHaveBeenCalledWith(
+      '/api/v1/bilan-section-instances?bilanId=b1&sectionId=t1&latest=true',
+      expect.any(Object),
+    ),
+  );
+});
+
+test('saves notes when generating from template', async () => {
+  mockedApiFetch.mockResolvedValueOnce([]); // initial fetch
+
+  const onGenerateFromTemplate = vi.fn();
+
+  render(
+    <WizardAIRightPanel
+      sectionInfo={sectionInfo}
+      trameOptions={[trame]}
+      selectedTrame={trame}
       onTrameChange={() => {}}
       examples={[]}
       onAddExample={() => {}}
@@ -56,13 +109,19 @@ function setup(cb?: any) {
       onCancel={() => {}}
     />,
   );
-  fireEvent.click(screen.getByText('Étape suivante'));
-  const btn = screen.getByText('Generate from template');
-  fireEvent.click(btn);
-  return onGenerateFromTemplate;
-}
 
-test('calls onGenerateFromTemplate when button clicked', () => {
-  const fn = setup();
-  expect(fn).toHaveBeenCalled();
+  fireEvent.click(screen.getByText('Étape suivante'));
+  await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
+
+  mockedApiFetch.mockClear();
+  mockedApiFetch.mockResolvedValueOnce({ id: 'inst1' });
+
+  fireEvent.click(screen.getByText('Generate from template'));
+
+  await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
+  expect(mockedApiFetch).toHaveBeenCalledWith(
+    '/api/v1/bilan-section-instances',
+    expect.objectContaining({ method: 'POST' }),
+  );
+  expect(onGenerateFromTemplate).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- Load latest BilanSectionInstance notes when entering wizard step 2
- Persist section notes before generation actions
- Test fetching and saving notes in wizard flow

## Testing
- `pnpm --filter frontend run lint` *(fails: Unexpected any etc.)*
- `pnpm --filter frontend run test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68aa154739008329adc5d94096f33248