### PR TITLE
[frontend][backend] Upsert bilan section instance

### DIFF
--- a/backend/src/controllers/bilanSectionInstance.controller.ts
+++ b/backend/src/controllers/bilanSectionInstance.controller.ts
@@ -61,6 +61,18 @@ export const BilanSectionInstanceController = {
     }
   },
 
+  async upsert(req: Request, res: Response, next: NextFunction) {
+    try {
+      const result = await BilanSectionInstanceService.upsert(
+        req.user.id,
+        req.body,
+      );
+      res.json(result);
+    } catch (e) {
+      next(e);
+    }
+  },
+
   async generateFromTemplate(req: Request, res: Response, next: NextFunction) {
     try {
       const { instanceId, trameId, answers, stylePrompt, rawNotes, contentNotes, userSlots, imageBase64 } = req.body as {

--- a/backend/src/routes/bilanSectionInstance.routes.ts
+++ b/backend/src/routes/bilanSectionInstance.routes.ts
@@ -6,6 +6,7 @@ import {
   updateBilanSectionInstanceSchema,
   bilanSectionInstanceIdParam,
   bilanSectionInstanceListQuery,
+  upsertBilanSectionInstanceSchema,
 } from '../schemas/bilanSectionInstance.schema';
 import { generateFromTemplateSchema } from '../schemas/bilanSectionInstance.schema';
 
@@ -21,6 +22,12 @@ bilanSectionInstanceRouter
     validateQuery(bilanSectionInstanceListQuery),
     BilanSectionInstanceController.list,
   );
+
+bilanSectionInstanceRouter.post(
+  '/upsert',
+  validateBody(upsertBilanSectionInstanceSchema),
+  BilanSectionInstanceController.upsert,
+);
 
 bilanSectionInstanceRouter
   .route('/:bilanSectionInstanceId')

--- a/backend/src/schemas/bilanSectionInstance.schema.ts
+++ b/backend/src/schemas/bilanSectionInstance.schema.ts
@@ -13,6 +13,12 @@ export const createBilanSectionInstanceSchema = z.object({
 
 export const updateBilanSectionInstanceSchema = createBilanSectionInstanceSchema.partial();
 
+export const upsertBilanSectionInstanceSchema = z.object({
+  bilanId: z.string().uuid(),
+  sectionId: z.string().uuid(),
+  contentNotes: z.any(),
+});
+
 export const bilanSectionInstanceIdParam = z.object({
   bilanSectionInstanceId: z.string().uuid(),
 });

--- a/backend/tests/bilanSectionInstance.routes.test.ts
+++ b/backend/tests/bilanSectionInstance.routes.test.ts
@@ -31,3 +31,25 @@ describe('GET /api/v1/bilan-section-instances', () => {
   });
 });
 
+describe('POST /api/v1/bilan-section-instances/upsert', () => {
+  it('delegates to service and returns id', async () => {
+    mockedService.upsert.mockResolvedValueOnce({ id: 'abc' } as InstanceStub);
+
+    const res = await request(app)
+      .post('/api/v1/bilan-section-instances/upsert')
+      .send({
+        bilanId: '00000000-0000-0000-0000-000000000001',
+        sectionId: '00000000-0000-0000-0000-000000000002',
+        contentNotes: {},
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 'abc' });
+    expect(mockedService.upsert).toHaveBeenCalledWith('demo-user', {
+      bilanId: '00000000-0000-0000-0000-000000000001',
+      sectionId: '00000000-0000-0000-0000-000000000002',
+      contentNotes: {},
+    });
+  });
+});
+

--- a/frontend/src/components/WizardAIRightPanel.test.tsx
+++ b/frontend/src/components/WizardAIRightPanel.test.tsx
@@ -120,7 +120,7 @@ test('saves notes when generating from template', async () => {
 
   await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
   expect(mockedApiFetch).toHaveBeenCalledWith(
-    '/api/v1/bilan-section-instances',
+    '/api/v1/bilan-section-instances/upsert',
     expect.objectContaining({ method: 'POST' }),
   );
   expect(onGenerateFromTemplate).toHaveBeenCalled();

--- a/frontend/src/components/WizardAIRightPanel.tsx
+++ b/frontend/src/components/WizardAIRightPanel.tsx
@@ -313,25 +313,20 @@ export default function WizardAIRightPanel({
     notes: Answers | undefined,
   ): Promise<string | null> => {
     if (!selectedTrame) return null;
-    const body = instanceId
-      ? { contentNotes: notes }
-      : {
+    const res = await apiFetch<{ id: string }>(
+      `/api/v1/bilan-section-instances/upsert`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
           bilanId,
           sectionId: selectedTrame.value,
-          order: 0,
           contentNotes: notes,
-        };
-    const path = instanceId
-      ? `/api/v1/bilan-section-instances/${instanceId}`
-      : '/api/v1/bilan-section-instances';
-    const method = instanceId ? 'PUT' : 'POST';
-    const res = await apiFetch<{ id: string }>(path, {
-      method,
-      headers: { Authorization: `Bearer ${token}` },
-      body: JSON.stringify(body),
-    });
-    if (!instanceId) setInstanceId(res.id);
-    return instanceId || res.id || null;
+        }),
+      },
+    );
+    setInstanceId(res.id);
+    return res.id;
   };
 
   // Autosave on answers change (debounced) while on step 2


### PR DESCRIPTION
## Summary
- call new backend upsert endpoint when saving section notes from the wizard
- add backend upsert route to update or create bilan section instances and cover with tests

## Testing
- `pnpm --filter backend run lint` *(fails: Unexpected any and other lint errors)*
- `pnpm --filter backend run test` *(fails: type errors in unrelated modules)*
- `pnpm --filter frontend run lint` *(fails: numerous lint errors across project)*
- `pnpm --filter frontend run test` *(fails: many failing tests and React warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aa19a194f08329ad2dc381cf89b2aa