### PR TITLE
[frontend] add admin import modal

### DIFF
--- a/frontend/src/components/AdminImport.tsx
+++ b/frontend/src/components/AdminImport.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { Tabs } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useSectionStore } from '@/store/sections';
+import { useSectionTemplateStore } from '@/store/sectionTemplates';
+import type { Question } from '@/types/Typequestion';
+import type { SectionTemplate } from '@/types/template';
+
+interface Props {
+  sectionId: string;
+  onClose: () => void;
+  onSchemaImported?: (schema: Question[]) => void;
+  onTemplateImported?: (tpl: SectionTemplate) => void;
+}
+
+export default function AdminImport({
+  sectionId,
+  onClose,
+  onSchemaImported,
+  onTemplateImported,
+}: Props) {
+  const [tab, setTab] = useState<'section' | 'template'>('section');
+  const [schemaText, setSchemaText] = useState('');
+  const [jsonText, setJsonText] = useState('');
+  const [slotsText, setSlotsText] = useState('');
+  const updateSection = useSectionStore((s) => s.update);
+  const createTemplate = useSectionTemplateStore((s) => s.create);
+
+  const handleSchema = async () => {
+    try {
+      const schema = JSON.parse(schemaText) as Question[];
+      await updateSection(sectionId, { schema });
+      onSchemaImported?.(schema);
+      onClose();
+    } catch (e) {
+      alert('Sch\u00e9ma invalide');
+    }
+  };
+
+  const handleTemplate = async () => {
+    try {
+      const content = JSON.parse(jsonText);
+      const slots = JSON.parse(slotsText);
+      const tpl = await createTemplate({
+        id: Date.now().toString(),
+        label: 'Template import\u00e9',
+        version: 1,
+        content,
+        slotsSpec: slots,
+        stylePrompt: '',
+        isDeprecated: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      await updateSection(sectionId, { templateRefId: tpl.id });
+      onTemplateImported?.(tpl);
+      onClose();
+    } catch (e) {
+      alert('Template invalide');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Tabs
+        tabs={[
+          { key: 'section', label: 'Section' },
+          { key: 'template', label: 'Template' },
+        ]}
+        active={tab}
+        onChange={(k) => setTab(k as 'section' | 'template')}
+      />
+
+      {tab === 'section' && (
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="admin-schema">Sch\u00e9ma</Label>
+            <Textarea
+              id="admin-schema"
+              value={schemaText}
+              onChange={(e) => setSchemaText(e.target.value)}
+              placeholder="Collez le sch\u00e9ma JSON de la section"
+            />
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={handleSchema}>Enregistrer</Button>
+          </div>
+        </div>
+      )}
+
+      {tab === 'template' && (
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="admin-json">JSON</Label>
+            <Textarea
+              id="admin-json"
+              value={jsonText}
+              onChange={(e) => setJsonText(e.target.value)}
+              placeholder="Collez le template JSON"
+            />
+          </div>
+          <div>
+            <Label htmlFor="admin-slots">SlotSpecs</Label>
+            <Textarea
+              id="admin-slots"
+              value={slotsText}
+              onChange={(e) => setSlotsText(e.target.value)}
+              placeholder="Collez les SlotSpecs"
+            />
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={handleTemplate}>Enregistrer</Button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button variant="outline" onClick={onClose}>
+          Fermer
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TrameHeader.tsx
+++ b/frontend/src/components/TrameHeader.tsx
@@ -22,6 +22,8 @@ interface Props {
   onSave: () => void;
   onImport: () => void;
   onBack: () => void;
+  onAdminImport?: () => void;
+  showAdminImport?: boolean;
 }
 
 export default function TrameHeader(p?: Partial<Props>) {
@@ -36,6 +38,8 @@ export default function TrameHeader(p?: Partial<Props>) {
     onSave = () => {},
     onImport = () => {},
     onBack = () => {},
+    onAdminImport = () => {},
+    showAdminImport = false,
   } = p ?? {};
   return (
     <div className="flex flex-wrap items-center gap-4 mb-6">
@@ -78,6 +82,11 @@ export default function TrameHeader(p?: Partial<Props>) {
       <Button variant="outline" onClick={onImport}>
         Import Magique
       </Button>
+      {showAdminImport && (
+        <Button variant="outline" onClick={onAdminImport}>
+          Admin Import
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/CreationTrame.test.tsx
+++ b/frontend/src/pages/CreationTrame.test.tsx
@@ -14,7 +14,14 @@ const tplCreate = vi.fn().mockResolvedValue({
   stylePrompt: '',
 });
 
+const originalDisplay = import.meta.env.VITE_DISPLAY_IMPORT_BUTTON;
+
+afterEach(() => {
+  import.meta.env.VITE_DISPLAY_IMPORT_BUTTON = originalDisplay;
+});
+
 it('shows navigation tabs', async () => {
+  import.meta.env.VITE_DISPLAY_IMPORT_BUTTON = 'false';
   useSectionStore.setState({
     fetchOne: vi.fn().mockResolvedValue({ title: '', kind: '', schema: [] }),
     update: vi.fn(),
@@ -44,6 +51,7 @@ it('shows navigation tabs', async () => {
 });
 
 it('shows table specific options', async () => {
+  import.meta.env.VITE_DISPLAY_IMPORT_BUTTON = 'false';
   useSectionStore.setState({
     fetchOne: vi.fn().mockResolvedValue({
       title: '',
@@ -81,6 +89,7 @@ it('shows table specific options', async () => {
 });
 
 it('prompts to save when leaving and saves on confirm', async () => {
+  import.meta.env.VITE_DISPLAY_IMPORT_BUTTON = 'false';
   const update = vi.fn().mockResolvedValue(undefined);
   useSectionStore.setState({
     fetchOne: vi.fn().mockResolvedValue({ title: '', kind: '', schema: [] }),
@@ -111,4 +120,23 @@ it('prompts to save when leaving and saves on confirm', async () => {
 
   await waitFor(() => expect(update).toHaveBeenCalled());
   expect(tplCreate).toHaveBeenCalled();
+});
+
+it('shows admin import button when enabled', async () => {
+  import.meta.env.VITE_DISPLAY_IMPORT_BUTTON = 'true';
+  useSectionStore.setState({
+    fetchOne: vi.fn().mockResolvedValue({ title: '', kind: '', schema: [] }),
+    update: vi.fn(),
+  });
+  useSectionTemplateStore.setState({ create: tplCreate });
+  render(
+    <MemoryRouter initialEntries={['/creation-trame/1']}>
+      <Routes>
+        <Route path="/creation-trame/:sectionId" element={<CreationTrame />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  expect(
+    screen.getByRole('button', { name: /admin import/i }),
+  ).toBeInTheDocument();
 });

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -15,6 +15,7 @@ import QuestionList from '@/components/QuestionList';
 import { DataEntry } from '@/components/bilan/DataEntry';
 import SaisieExempleTrame from '@/components/SaisieExempleTrame';
 import ImportMagique from '@/components/ImportMagique';
+import AdminImport from '@/components/AdminImport';
 import ExitConfirmation from '@/components/ExitConfirmation';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import TemplateEditor from '@/components/TemplateEditor';
@@ -46,6 +47,7 @@ export default function CreationTrame() {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
+  const [showAdminImport, setShowAdminImport] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const createTemplate = useSectionTemplateStore((s) => s.create);
   const getTemplate = useSectionTemplateStore((s) => s.get);
@@ -63,6 +65,9 @@ export default function CreationTrame() {
     updatedAt: new Date().toISOString(),
   });
   const [loadingTemplate, setLoadingTemplate] = useState(false);
+
+  const SHOW_ADMIN_IMPORT =
+    import.meta.env.VITE_DISPLAY_IMPORT_BUTTON === 'true';
 
   const createDefaultNote = (): Question => ({
     id: Date.now().toString(),
@@ -206,6 +211,8 @@ export default function CreationTrame() {
           onSave={save}
           onImport={() => setShowImport(true)}
           onBack={() => setShowConfirm(true)}
+          onAdminImport={() => setShowAdminImport(true)}
+          showAdminImport={SHOW_ADMIN_IMPORT}
         />
 
         <div className="border-b mb-4">
@@ -387,6 +394,22 @@ export default function CreationTrame() {
                 );
                 setLoadingTemplate(false);
               }
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+      <Dialog open={showAdminImport} onOpenChange={setShowAdminImport}>
+        <DialogContent>
+          <AdminImport
+            sectionId={sectionId ?? ''}
+            onClose={() => setShowAdminImport(false)}
+            onSchemaImported={(schema) => {
+              setQuestions(schema);
+              setSelectedId(schema[0]?.id ?? null);
+            }}
+            onTemplateImported={(tpl) => {
+              setTemplate(tpl);
+              setTemplateRefId(tpl.id);
             }}
           />
         </DialogContent>


### PR DESCRIPTION
## Summary
- gate new Admin Import button with `VITE_DISPLAY_IMPORT_BUTTON`
- allow admins to import schema or template via new modal

## Testing
- `pnpm --filter frontend run lint` *(fails: 95 errors)*
- `pnpm --filter frontend run test` *(fails: 12 failed test files)*

------
https://chatgpt.com/codex/tasks/task_e_68aa32555a3c8329bc9c88f34bf11935