### PR TITLE
[frontend] Add table context menu for table editing

### DIFF
--- a/frontend/src/components/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, {
   useMemo,
   useImperativeHandle,
@@ -47,6 +47,7 @@ import { useVirtualSelection } from '../hooks/useVirtualSelection';
 import { SlotNode, $createSlotNode, $isSlotNode } from '../nodes/SlotNode';
 import type { SlotType, FieldSpec } from '../types/template';
 import { scanAndInsertSlots as runScanAndInsertSlots } from '../utils/scanAndInsertSlots';
+import TableContextMenuPlugin from './TableContextMenuPlugin';
 
 export interface RichTextEditorHandle {
   importHtml: (html: string) => void;
@@ -382,6 +383,7 @@ const RichTextEditor = forwardRef<RichTextEditorHandle, Props>(
                 <LinkPlugin />
                 <TablePlugin hasCellMerge hasCellBackgroundColor />
                 <TableDeletePlugin />
+                <TableContextMenuPlugin />
                 <OnChangePlugin
                   onChange={(state, editor) => {
                     state.read(() => {

--- a/frontend/src/components/TableContextMenuPlugin.tsx
+++ b/frontend/src/components/TableContextMenuPlugin.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  NodeContextMenuPlugin,
+  NodeContextMenuOption,
+} from '@lexical/react/LexicalNodeContextMenuPlugin';
+import {
+  $insertTableRowAtSelection,
+  $insertTableColumnAtSelection,
+  $deleteTableRowAtSelection,
+  $deleteTableColumnAtSelection,
+  $isTableCellNode,
+} from '@lexical/table';
+
+export function TableContextMenuPlugin(): JSX.Element | null {
+  const [editor] = useLexicalComposerContext();
+
+  const items = React.useMemo(
+    () => [
+      new NodeContextMenuOption('➕ Ajouter ligne', {
+        $onSelect: () =>
+          editor.update(() => {
+            $insertTableRowAtSelection();
+          }),
+        $showOn: $isTableCellNode,
+      }),
+      new NodeContextMenuOption('➕ Ajouter colonne', {
+        $onSelect: () =>
+          editor.update(() => {
+            $insertTableColumnAtSelection();
+          }),
+        $showOn: $isTableCellNode,
+      }),
+      new NodeContextMenuOption('🗑️ Supprimer ligne', {
+        $onSelect: () =>
+          editor.update(() => {
+            $deleteTableRowAtSelection();
+          }),
+        $showOn: $isTableCellNode,
+      }),
+      new NodeContextMenuOption('🗑️ Supprimer colonne', {
+        $onSelect: () =>
+          editor.update(() => {
+            $deleteTableColumnAtSelection();
+          }),
+        $showOn: $isTableCellNode,
+      }),
+    ],
+    [editor],
+  );
+
+  return <NodeContextMenuPlugin items={items} />;
+}
+
+export default TableContextMenuPlugin;


### PR DESCRIPTION
## Summary
- add TableContextMenuPlugin to handle row/column insertion and deletion
- wire table context menu into RichTextEditor and rely on TablePlugin for column resize

## Testing
- `pnpm exec eslint src/components/TableContextMenuPlugin.tsx src/components/RichTextEditor.tsx src/components/RichTextEditor.test.tsx`
- `pnpm run test src/components/RichTextEditor.test.tsx -t "loads and exposes JSON editor state"`


------
https://chatgpt.com/codex/tasks/task_e_68ab412cfb1c83299b923457e62fa578