### PR TITLE
[frontend] Allow table deletion via selection

### DIFF
--- a/frontend/src/components/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor.tsx
@@ -41,6 +41,8 @@ import {
   TableRowNode,
   TableCellNode,
   $isTableNode,
+  $isTableSelection,
+  $findTableNode,
 } from '@lexical/table';
 import { TablePlugin } from '@lexical/react/LexicalTablePlugin';
 import { useVirtualSelection } from '../hooks/useVirtualSelection';
@@ -242,6 +244,22 @@ function TableDeletePlugin() {
   useEffect(() => {
     const removeTable = () => {
       const selection = $getSelection();
+      if ($isTableSelection(selection)) {
+        const nodes = selection.getNodes();
+        if (nodes.length > 0) {
+          const tableNode = $findTableNode(nodes[0]);
+          if (tableNode) {
+            const totalCells = tableNode
+              .getChildren()
+              .reduce((sum, row) => sum + row.getChildren().length, 0);
+            if (nodes.length === totalCells) {
+              tableNode.remove();
+              return true;
+            }
+          }
+        }
+        return false;
+      }
       const nodes = selection ? selection.getNodes() : [];
       let removed = false;
       nodes.forEach((node) => {


### PR DESCRIPTION
## Summary
- support removing an entire table in RichTextEditor when the whole table is selected and backspace/delete is pressed
- test table deletion via full selection

## Testing
- `pnpm --filter frontend exec eslint src/components/RichTextEditor.tsx src/components/RichTextEditor.test.tsx`
- `pnpm --filter frontend run lint` *(fails: numerous existing lint errors across unrelated files)*
- `pnpm --filter frontend run test` *(fails: multiple unrelated test failures, see logs)*
- `pnpm --filter frontend run test src/components/RichTextEditor.test.tsx` *(fails: existing test assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4531eb6083299896899a89380834