### PR TITLE
[frontend] show loading modal during generation

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from './ui/textarea';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import GeneratingModal from '@/components/ui/generating-modal';
 import type { TrameOption, TrameExample } from './bilan/TrameSelector';
 import type { Answers, Question } from '@/types/question';
 import {
@@ -206,7 +207,6 @@ export default function AiRightPanel({
     rawNotes?: string,
     imageBase64?: string,
   ) => {
-
     await generateSection({
       mode: 'direct',
       section,
@@ -449,6 +449,7 @@ export default function AiRightPanel({
 
   return (
     <div className="w-full max-w-md bg-wood-50 rounded-lg shadow-lg">
+      <GeneratingModal open={isGenerating} />
       <div className="flex flex-col h-full">
         {/*         {selection?.text && (
           <div className="bg-blue-50 text-blue-800 text-sm p-2 border-b border-blue-100">

--- a/frontend/src/components/ui/generating-modal.tsx
+++ b/frontend/src/components/ui/generating-modal.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Loader2 } from 'lucide-react';
+
+interface GeneratingModalProps {
+  open: boolean;
+}
+
+export default function GeneratingModal({ open }: GeneratingModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent
+        showCloseButton={false}
+        className="flex flex-col items-center gap-4"
+      >
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p>Génération en cours...</p>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GeneratingModal` component with spinner and "Génération en cours..." message
- integrate generating modal into AI right panel to display during section generation

## Testing
- `pnpm --filter frontend run lint` *(fails: numerous lint errors across unrelated files)*
- `pnpm --filter frontend run test` *(fails: Not implemented: window.alert)*

------
https://chatgpt.com/codex/tasks/task_e_68ac01975f908329984840adf95c228c