### PR TITLE
[frontend] Add enter key trigger for repeat items

### DIFF
--- a/frontend/src/components/SlotEditor.test.tsx
+++ b/frontend/src/components/SlotEditor.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import SlotEditor from './SlotEditor';
+import type { RepeatSpec } from '../types/template';
+
+describe('SlotEditor repeat items', () => {
+  const createRepeat = (): RepeatSpec => ({
+    kind: 'repeat',
+    id: 'rep-1',
+    from: { enum: [{ key: 'key_1', label: 'value_1' }] },
+    ctx: 'item',
+    namePattern: '',
+    slots: [],
+  });
+
+  test('pressing Enter in item label adds new item', () => {
+    const onChange = vi.fn();
+    render(
+      <SlotEditor
+        slot={createRepeat()}
+        onChange={onChange}
+        onRemove={() => {}}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Label de l'item");
+    fireEvent.change(input, { target: { value: 'Label 1' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    // first call from change, second from addItem
+    expect(onChange).toHaveBeenCalledTimes(2);
+    const updated: RepeatSpec = onChange.mock.calls[1][0];
+    expect(updated.from.enum).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/SlotEditor.tsx
+++ b/frontend/src/components/SlotEditor.tsx
@@ -468,6 +468,12 @@ export default function SlotEditor({
                     <Input
                       value={it.label}
                       onChange={(e) => updateItem(i, { label: e.target.value })}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          addItem();
+                        }
+                      }}
                       placeholder="Label de l'item"
                       className="text-xs h-7"
                     />


### PR DESCRIPTION
## Summary
- Trigger adding a new repeat item when pressing Enter on an item's label
- Test that pressing Enter adds a new item in repeat editors

## Testing
- `pnpm --filter frontend run lint` *(fails: 108 errors)*
- `pnpm --filter frontend run test` *(fails: 13 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac04195c5c832984607c5cbc39b76f