### PR TITLE
[frontend] Add template empty state and unified generation flow

### DIFF
--- a/frontend/src/components/AiRightPanel.tsx
+++ b/frontend/src/components/AiRightPanel.tsx
@@ -95,6 +95,7 @@ const useTrames = () => {
           isPublic: s.isPublic,
           authorId: s.authorId,
           author: s.author,
+          templateRefId: s.templateRefId,
         }));
     });
     return res;

--- a/frontend/src/components/EmptyTemplateState.tsx
+++ b/frontend/src/components/EmptyTemplateState.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@/components/ui/button';
+
+interface EmptyTemplateStateProps {
+  onAdd: () => void;
+}
+
+export default function EmptyTemplateState({ onAdd }: EmptyTemplateStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center p-8 text-center border border-dashed rounded-md">
+      <p className="mb-4 text-sm text-gray-600">
+        Aucun template n'est associé à cette section.
+      </p>
+      <Button type="button" onClick={onAdd}>
+        Ajouter un template
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/WizardAIRightPanel.test.tsx
+++ b/frontend/src/components/WizardAIRightPanel.test.tsx
@@ -51,6 +51,12 @@ const mockedApiFetch = apiFetch as unknown as vi.Mock;
 
 const sectionInfo = { id: 's1', title: 'Section 1' } as any;
 const trame = { value: 't1', label: 'Trame 1' } as any;
+const trameWithTemplate = {
+  value: 't1',
+  label: 'Trame 1',
+  templateRefId: 'tpl1',
+} as any;
+const trameWithoutTemplate = { value: 't2', label: 'Trame 2' } as any;
 
 test('fetches latest notes on entering step 2', async () => {
   mockedApiFetch.mockResolvedValueOnce([{ id: 'i1', contentNotes: { a: 1 } }]);
@@ -85,7 +91,7 @@ test('fetches latest notes on entering step 2', async () => {
   );
 });
 
-test('saves notes when generating from template', async () => {
+test('saves notes when generating with template', async () => {
   mockedApiFetch.mockResolvedValueOnce([]); // initial fetch
 
   const onGenerateFromTemplate = vi.fn();
@@ -93,8 +99,8 @@ test('saves notes when generating from template', async () => {
   render(
     <WizardAIRightPanel
       sectionInfo={sectionInfo}
-      trameOptions={[trame]}
-      selectedTrame={trame}
+      trameOptions={[trameWithTemplate]}
+      selectedTrame={trameWithTemplate}
       onTrameChange={() => {}}
       examples={[]}
       onAddExample={() => {}}
@@ -116,7 +122,7 @@ test('saves notes when generating from template', async () => {
   mockedApiFetch.mockClear();
   mockedApiFetch.mockResolvedValueOnce({ id: 'inst1' });
 
-  fireEvent.click(screen.getByText('Generate from template'));
+  fireEvent.click(screen.getByText('Générer'));
 
   await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
   expect(mockedApiFetch).toHaveBeenCalledWith(
@@ -124,4 +130,39 @@ test('saves notes when generating from template', async () => {
     expect.objectContaining({ method: 'POST' }),
   );
   expect(onGenerateFromTemplate).toHaveBeenCalled();
+});
+
+test('calls direct generate when no template', async () => {
+  mockedApiFetch.mockResolvedValueOnce([]); // initial fetch
+  const onGenerate = vi.fn();
+  render(
+    <WizardAIRightPanel
+      sectionInfo={sectionInfo}
+      trameOptions={[trameWithoutTemplate]}
+      selectedTrame={trameWithoutTemplate}
+      onTrameChange={() => {}}
+      examples={[]}
+      onAddExample={() => {}}
+      onRemoveExample={() => {}}
+      questions={[]}
+      answers={{}}
+      onAnswersChange={() => {}}
+      onGenerate={onGenerate}
+      onGenerateFromTemplate={() => {}}
+      isGenerating={false}
+      bilanId="b1"
+      onCancel={() => {}}
+    />,
+  );
+
+  fireEvent.click(screen.getByText('Étape suivante'));
+  await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
+
+  mockedApiFetch.mockClear();
+  mockedApiFetch.mockResolvedValueOnce({ id: 'inst2' });
+
+  fireEvent.click(screen.getByText('Générer'));
+
+  await waitFor(() => expect(mockedApiFetch).toHaveBeenCalled());
+  expect(onGenerate).toHaveBeenCalled();
 });

--- a/frontend/src/components/bilan/TrameSelector.tsx
+++ b/frontend/src/components/bilan/TrameSelector.tsx
@@ -28,6 +28,7 @@ export interface TrameOption {
   isPublic?: boolean;
   authorId?: string | null;
   author?: { prenom?: string | null } | null;
+  templateRefId?: string | null;
 }
 
 export interface TrameExample {

--- a/frontend/src/pages/CreationTrame.test.tsx
+++ b/frontend/src/pages/CreationTrame.test.tsx
@@ -119,7 +119,41 @@ it('prompts to save when leaving and saves on confirm', async () => {
   fireEvent.click(screen.getByRole('button', { name: 'Oui' }));
 
   await waitFor(() => expect(update).toHaveBeenCalled());
-  expect(tplCreate).toHaveBeenCalled();
+  expect(tplCreate).not.toHaveBeenCalled();
+});
+
+it('shows empty template state and creates template on demand', async () => {
+  import.meta.env.VITE_DISPLAY_IMPORT_BUTTON = 'false';
+  const update = vi.fn().mockResolvedValue(undefined);
+  useSectionStore.setState({
+    fetchOne: vi.fn().mockResolvedValue({
+      title: 'Section',
+      kind: '',
+      schema: [],
+      templateRefId: null,
+    }),
+    update,
+  });
+  useSectionTemplateStore.setState({ create: tplCreate });
+
+  render(
+    <MemoryRouter initialEntries={['/creation-trame/1']}>
+      <Routes>
+        <Route path="/creation-trame/:sectionId" element={<CreationTrame />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  await screen.findByRole('button', { name: /Template/i });
+  fireEvent.click(screen.getByRole('button', { name: /Template/i }));
+
+  expect(
+    await screen.findByRole('button', { name: /Ajouter un template/i }),
+  ).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Ajouter un template/i }));
+  await waitFor(() => expect(tplCreate).toHaveBeenCalled());
+  expect(update).toHaveBeenCalled();
 });
 
 it('shows admin import button when enabled', async () => {

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -19,6 +19,7 @@ import AdminImport from '@/components/AdminImport';
 import ExitConfirmation from '@/components/ExitConfirmation';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import TemplateEditor from '@/components/TemplateEditor';
+import EmptyTemplateState from '@/components/EmptyTemplateState';
 import { useSectionTemplateStore } from '../store/sectionTemplates';
 import type { SectionTemplate } from '../types/template';
 import { apiFetch } from '@/utils/api';
@@ -71,10 +72,19 @@ export default function CreationTrame() {
 
   const transformTemplateToQuestions = async (content: string) => {
     try {
-      console.log('[DEBUG] transformTemplateToQuestions - Received content:', content);
-      console.log('[DEBUG] transformTemplateToQuestions - Content length:', content.length);
-      console.log('[DEBUG] transformTemplateToQuestions - Content type:', typeof content);
-      
+      console.log(
+        '[DEBUG] transformTemplateToQuestions - Received content:',
+        content,
+      );
+      console.log(
+        '[DEBUG] transformTemplateToQuestions - Content length:',
+        content.length,
+      );
+      console.log(
+        '[DEBUG] transformTemplateToQuestions - Content type:',
+        typeof content,
+      );
+
       const res = await apiFetch<{ result: Question[] }>(
         '/api/v1/import/transform',
         {
@@ -87,26 +97,58 @@ export default function CreationTrame() {
         },
       );
       console.log('[DEBUG] transformTemplateToQuestions - API response:', res);
-      console.log('[DEBUG] transformTemplateToQuestions - res.result:', res.result);
-      console.log('[DEBUG] transformTemplateToQuestions - res.result.length:', res.result?.length);
-      console.log('[DEBUG] transformTemplateToQuestions - res.result type:', typeof res.result);
-      console.log('[DEBUG] transformTemplateToQuestions - res.result[0]:', res.result?.[0]);
-      
+      console.log(
+        '[DEBUG] transformTemplateToQuestions - res.result:',
+        res.result,
+      );
+      console.log(
+        '[DEBUG] transformTemplateToQuestions - res.result.length:',
+        res.result?.length,
+      );
+      console.log(
+        '[DEBUG] transformTemplateToQuestions - res.result type:',
+        typeof res.result,
+      );
+      console.log(
+        '[DEBUG] transformTemplateToQuestions - res.result[0]:',
+        res.result?.[0],
+      );
+
       const questionsArray = res.result?.result || res.result;
-    
-      if (questionsArray && Array.isArray(questionsArray) && questionsArray.length > 0) {
-        console.log('[DEBUG] transformTemplateToQuestions - Setting questions:', questionsArray);
-        console.log('[DEBUG] transformTemplateToQuestions - Current questions before update:', questions);
-        
+
+      if (
+        questionsArray &&
+        Array.isArray(questionsArray) &&
+        questionsArray.length > 0
+      ) {
+        console.log(
+          '[DEBUG] transformTemplateToQuestions - Setting questions:',
+          questionsArray,
+        );
+        console.log(
+          '[DEBUG] transformTemplateToQuestions - Current questions before update:',
+          questions,
+        );
+
         setQuestions(questionsArray);
         setSelectedId(questionsArray[0].id);
         setTab('preview');
-        
-        console.log('[DEBUG] transformTemplateToQuestions - Should switch to preview tab');
+
+        console.log(
+          '[DEBUG] transformTemplateToQuestions - Should switch to preview tab',
+        );
       } else {
-        console.warn('[DEBUG] transformTemplateToQuestions - No valid result received');
-        console.warn('[DEBUG] transformTemplateToQuestions - questionsArray is:', questionsArray);
-        console.warn('[DEBUG] transformTemplateToQuestions - res.result is:', res.result);
+        console.warn(
+          '[DEBUG] transformTemplateToQuestions - No valid result received',
+        );
+        console.warn(
+          '[DEBUG] transformTemplateToQuestions - questionsArray is:',
+          questionsArray,
+        );
+        console.warn(
+          '[DEBUG] transformTemplateToQuestions - res.result is:',
+          res.result,
+        );
       }
     } catch (e) {
       console.error('Failed to transform template', e);
@@ -224,20 +266,15 @@ export default function CreationTrame() {
 
   const save = async () => {
     if (!sectionId) return;
-    let tplId = templateRefId;
-    if (tplId) {
-      await updateTemplate(tplId, { ...template, label: nomTrame });
-    } else {
-      const created = await createTemplate({ ...template, label: nomTrame });
-      tplId = created.id;
-      setTemplateRefId(tplId);
+    if (templateRefId) {
+      await updateTemplate(templateRefId, { ...template, label: nomTrame });
     }
     await updateSection(sectionId, {
       title: nomTrame,
       kind: categorie,
       schema: questions,
       isPublic,
-      templateRefId: tplId,
+      templateRefId,
     });
     for (const content of newExamples) {
       await createExample({ sectionId, content });
@@ -286,7 +323,9 @@ export default function CreationTrame() {
               </button>
               <button
                 className={`pb-2 px-1 border-b-2 ${
-                  tab === 'preview' ? 'border-primary-600' : 'border-transparent'
+                  tab === 'preview'
+                    ? 'border-primary-600'
+                    : 'border-transparent'
                 }`}
                 onClick={() => setTab('preview')}
               >
@@ -294,7 +333,9 @@ export default function CreationTrame() {
               </button>
               <button
                 className={`pb-2 px-1 border-b-2 ${
-                  tab === 'examples' ? 'border-primary-600' : 'border-transparent'
+                  tab === 'examples'
+                    ? 'border-primary-600'
+                    : 'border-transparent'
                 }`}
                 onClick={() => setTab('examples')}
               >
@@ -302,7 +343,9 @@ export default function CreationTrame() {
               </button>
               <button
                 className={`pb-2 px-1 border-b-2 ${
-                  tab === 'template' ? 'border-primary-600' : 'border-transparent'
+                  tab === 'template'
+                    ? 'border-primary-600'
+                    : 'border-transparent'
                 }`}
                 onClick={() => setTab('template')}
               >
@@ -355,12 +398,33 @@ export default function CreationTrame() {
                     </span>
                   </div>
                 </div>
-              )}              
-              <TemplateEditor
-                template={template}
-                onChange={setTemplate}
-                onTransformToQuestions={transformTemplateToQuestions}
-              />
+              )}
+              {templateRefId ? (
+                <TemplateEditor
+                  template={template}
+                  onChange={setTemplate}
+                  onTransformToQuestions={transformTemplateToQuestions}
+                />
+              ) : (
+                <EmptyTemplateState
+                  onAdd={async () => {
+                    if (!sectionId) return;
+                    const created = await createTemplate({
+                      ...template,
+                      label: nomTrame,
+                    });
+                    setTemplate(created);
+                    setTemplateRefId(created.id);
+                    await updateSection(sectionId, {
+                      title: nomTrame,
+                      kind: categorie,
+                      schema: questions,
+                      isPublic,
+                      templateRefId: created.id,
+                    });
+                  }}
+                />
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- show empty state when no section template and allow creating one
- route single "Générer" button to template or direct flow based on template presence
- propagate template references through trame options

## Testing
- `pnpm run lint` (failed: Use "@ts-expect-error" instead of "@ts-ignore" etc.)
- `pnpm run test` (failed: TypeError: Cannot read properties of undefined (reading 'length'))


------
https://chatgpt.com/codex/tasks/task_e_68ac0a7c5b5083299d9af08887fad679