### PR TITLE
[frontend] Add multi-choice table column

### DIFF
--- a/frontend/src/components/ChoixTypeDeValeurTableau.tsx
+++ b/frontend/src/components/ChoixTypeDeValeurTableau.tsx
@@ -69,7 +69,9 @@ export default function ChoixTypeDeValeurTableau({
                 setLocal({
                   ...local,
                   valueType: v as ValueType,
-                  options: v === 'choice' ? local.options || [] : undefined,
+                  options: ['choice', 'multi-choice'].includes(v)
+                    ? local.options || []
+                    : undefined,
                 })
               }
             >
@@ -80,12 +82,14 @@ export default function ChoixTypeDeValeurTableau({
                 <SelectItem value="text">Texte</SelectItem>
                 <SelectItem value="number">Nombre</SelectItem>
                 <SelectItem value="bool">Case à cocher</SelectItem>
-                <SelectItem value="choice">Choix multiples</SelectItem>
+                <SelectItem value="choice">Liste déroulante</SelectItem>
+                <SelectItem value="multi-choice">Choix multiples</SelectItem>
                 <SelectItem value="image">Image</SelectItem>
               </SelectContent>
             </Select>
           </div>
-          {local.valueType === 'choice' && (
+          {(local.valueType === 'choice' ||
+            local.valueType === 'multi-choice') && (
             <div className="space-y-2">
               {local.options?.map((opt, idx) => (
                 <div key={idx} className="flex items-center gap-2">

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -77,6 +77,23 @@ const tableSelectQuestion: Question = {
   },
 };
 
+const tableMultiQuestion: Question = {
+  id: '9',
+  type: 'tableau',
+  titre: 'Table',
+  tableau: {
+    columns: [
+      {
+        id: 'c1',
+        label: 'C1',
+        valueType: 'multi-choice',
+        options: ['A', 'B'],
+      },
+    ],
+    sections: [{ id: 's1', title: '', rows: [{ id: 'r1', label: 'L1' }] }],
+  },
+};
+
 const tableCheckQuestion: Question = {
   id: '8',
   type: 'tableau',
@@ -203,6 +220,18 @@ describe('DataEntry', () => {
       />,
     );
     expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders chips for multi choice column type', () => {
+    render(
+      <DataEntry
+        questions={[tableMultiQuestion]}
+        answers={{}}
+        onChange={noop}
+        inline
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'A' })).toBeInTheDocument();
   });
 
   it('renders checkbox for case a cocher type', () => {

--- a/frontend/src/components/bilan/TableQuestion.tsx
+++ b/frontend/src/components/bilan/TableQuestion.tsx
@@ -10,6 +10,7 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import type { Question, ColumnDef } from '@/types/question';
+import { Chip } from './Chip';
 
 const FIELD_BASE =
   'rounded-lg border border-gray-300 bg-white shadow-sm focus-visible:ring-2 focus-visible:ring-primary-500/40 focus-visible:outline-none';
@@ -72,6 +73,31 @@ export function TableQuestion({
               ))}
             </SelectContent>
           </Select>
+        );
+      case 'multi-choice':
+        const selected = Array.isArray(cellValue)
+          ? (cellValue as string[])
+          : [];
+        return (
+          <div className="flex flex-wrap gap-2">
+            {col.options?.map((opt) => {
+              const isSelected = selected.includes(opt);
+              return (
+                <Chip
+                  key={opt}
+                  selected={isSelected}
+                  onClick={() => {
+                    const newSelected = isSelected
+                      ? selected.filter((o) => o !== opt)
+                      : [...selected, opt];
+                    update(newSelected);
+                  }}
+                >
+                  {opt}
+                </Chip>
+              );
+            })}
+          </div>
         );
       case 'bool':
         return (

--- a/frontend/src/types/Typequestion.ts
+++ b/frontend/src/types/Typequestion.ts
@@ -20,7 +20,13 @@ export type ScaleQuestion = {
   echelle: { min: number; max: number; labels?: { min: string; max: string } };
 };
 
-export type ValueType = 'bool' | 'number' | 'text' | 'choice' | 'image';
+export type ValueType =
+  | 'bool'
+  | 'number'
+  | 'text'
+  | 'choice'
+  | 'multi-choice'
+  | 'image';
 
 export type ColumnDef = {
   id: string;

--- a/frontend/src/types/question.ts
+++ b/frontend/src/types/question.ts
@@ -1,4 +1,10 @@
-export type ValueType = 'bool' | 'number' | 'text' | 'choice' | 'image';
+export type ValueType =
+  | 'bool'
+  | 'number'
+  | 'text'
+  | 'choice'
+  | 'multi-choice'
+  | 'image';
 
 export interface ColumnDef {
   id: string;


### PR DESCRIPTION
## Summary
- support new `multi-choice` column type for table questions
- render multi-choice cells with chip-style selectors
- allow configuring multi-choice columns in table editor

## Testing
- `pnpm --filter frontend exec eslint src/components/bilan/TableQuestion.tsx src/components/ChoixTypeDeValeurTableau.tsx src/types/question.ts src/types/Typequestion.ts src/services/generation.ts src/components/bilan/DataEntry.test.tsx`
- `pnpm --filter frontend run test` *(fails: TypeError: Cannot read properties of undefined (reading 'length'))*

------
https://chatgpt.com/codex/tasks/task_e_68ac7e7a57848329b6bfed7ea97ba892