### PR TITLE
[frontend] support per-row multi-choice columns

### DIFF
--- a/frontend/src/components/ChoixTypeDeValeurTableau.tsx
+++ b/frontend/src/components/ChoixTypeDeValeurTableau.tsx
@@ -16,16 +16,18 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { X } from 'lucide-react';
-import type { ColumnDef, ValueType } from '@/types/question';
+import type { ColumnDef, ValueType, Row } from '@/types/question';
 
 interface Props {
   column: ColumnDef | null;
+  rows: Row[];
   onClose: () => void;
   onChange: (col: ColumnDef) => void;
 }
 
 export default function ChoixTypeDeValeurTableau({
   column,
+  rows,
   onClose,
   onChange,
 }: Props) {
@@ -72,6 +74,10 @@ export default function ChoixTypeDeValeurTableau({
                   options: ['choice', 'multi-choice'].includes(v)
                     ? local.options || []
                     : undefined,
+                  rowOptions:
+                    v === 'multi-choice-row'
+                      ? local.rowOptions || {}
+                      : undefined,
                 })
               }
             >
@@ -84,6 +90,9 @@ export default function ChoixTypeDeValeurTableau({
                 <SelectItem value="bool">Case à cocher</SelectItem>
                 <SelectItem value="choice">Liste déroulante</SelectItem>
                 <SelectItem value="multi-choice">Choix multiples</SelectItem>
+                <SelectItem value="multi-choice-row">
+                  Choix multiples par ligne
+                </SelectItem>
                 <SelectItem value="image">Image</SelectItem>
               </SelectContent>
             </Select>
@@ -119,6 +128,86 @@ export default function ChoixTypeDeValeurTableau({
                   e.currentTarget.value = '';
                 }}
               />
+            </div>
+          )}
+          {local.valueType === 'multi-choice-row' && (
+            <div className="space-y-4">
+              {rows.map((row) => (
+                <div key={row.id} className="space-y-2">
+                  <Label>{row.label}</Label>
+                  {(local.rowOptions?.[row.id] || []).map((opt, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <Input
+                        value={opt}
+                        onChange={(e) => {
+                          const current = local.rowOptions?.[row.id] || [];
+                          const updated = [...current];
+                          updated[idx] = e.target.value;
+                          setLocal({
+                            ...local,
+                            rowOptions: {
+                              ...(local.rowOptions || {}),
+                              [row.id]: updated,
+                            },
+                          });
+                        }}
+                      />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          const current = local.rowOptions?.[row.id] || [];
+                          const updated = current.filter((_, i) => i !== idx);
+                          const newRowOptions = {
+                            ...(local.rowOptions || {}),
+                          };
+                          if (updated.length > 0) {
+                            newRowOptions[row.id] = updated;
+                          } else {
+                            delete newRowOptions[row.id];
+                          }
+                          setLocal({ ...local, rowOptions: newRowOptions });
+                        }}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))}
+                  <Input
+                    placeholder="Ajouter une option"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        const val = e.currentTarget.value.trim();
+                        if (val) {
+                          const current = local.rowOptions?.[row.id] || [];
+                          setLocal({
+                            ...local,
+                            rowOptions: {
+                              ...(local.rowOptions || {}),
+                              [row.id]: [...current, val],
+                            },
+                          });
+                        }
+                        e.currentTarget.value = '';
+                      }
+                    }}
+                    onBlur={(e) => {
+                      const val = e.currentTarget.value.trim();
+                      if (val) {
+                        const current = local.rowOptions?.[row.id] || [];
+                        setLocal({
+                          ...local,
+                          rowOptions: {
+                            ...(local.rowOptions || {}),
+                            [row.id]: [...current, val],
+                          },
+                        });
+                      }
+                      e.currentTarget.value = '';
+                    }}
+                  />
+                </div>
+              ))}
             </div>
           )}
           <div className="flex justify-end">

--- a/frontend/src/components/Editors.tsx
+++ b/frontend/src/components/Editors.tsx
@@ -198,13 +198,29 @@ export function TableEditor({ q, onPatch }: EditorProps) {
   };
 
   const removeLine = (groupId: string, idx: number) => {
+    const group = tableau.rowsGroups.find((g) => g.id === groupId);
+    const rowId = group?.rows[idx]?.id;
+    const updatedRowsGroups = tableau.rowsGroups.map((g) =>
+      g.id === groupId ? { ...g, rows: g.rows.filter((_, i) => i !== idx) } : g,
+    );
+    const updatedCols = rowId
+      ? tableau.columns.map((c) =>
+          c.valueType === 'multi-choice-row'
+            ? {
+                ...c,
+                rowOptions: Object.fromEntries(
+                  Object.entries(c.rowOptions || {}).filter(
+                    ([rid]) => rid !== rowId,
+                  ),
+                ),
+              }
+            : c,
+        )
+      : tableau.columns;
     setTable({
       ...tableau,
-      rowsGroups: tableau.rowsGroups.map((g) =>
-        g.id === groupId
-          ? { ...g, rows: g.rows.filter((_, i) => i !== idx) }
-          : g,
-      ),
+      rowsGroups: updatedRowsGroups,
+      columns: updatedCols,
     });
   };
 
@@ -542,6 +558,7 @@ export function TableEditor({ q, onPatch }: EditorProps) {
           column={
             editingColIdx !== null ? tableau.columns[editingColIdx] : null
           }
+          rows={tableau.rowsGroups.flatMap((g) => g.rows)}
           onClose={() => setEditingColIdx(null)}
           onChange={handleColumnTypeChange}
         />

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import { DataEntry, type DataEntryHandle } from './DataEntry';
@@ -94,6 +94,32 @@ const tableMultiQuestion: Question = {
   },
 };
 
+const tableMultiRowQuestion: Question = {
+  id: '10',
+  type: 'tableau',
+  titre: 'Table',
+  tableau: {
+    columns: [
+      {
+        id: 'c1',
+        label: 'C1',
+        valueType: 'multi-choice-row',
+        rowOptions: { r1: ['A', 'B'], r2: ['C'] },
+      },
+    ],
+    sections: [
+      {
+        id: 's1',
+        title: '',
+        rows: [
+          { id: 'r1', label: 'L1' },
+          { id: 'r2', label: 'L2' },
+        ],
+      },
+    ],
+  },
+};
+
 const tableCheckQuestion: Question = {
   id: '8',
   type: 'tableau',
@@ -116,6 +142,22 @@ describe('DataEntry', () => {
     fireEvent.click(screen.getByText(/ajouter/i));
     expect(screen.getByRole('button', { name: 'Opt1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Opt2' })).toBeInTheDocument();
+  });
+
+  it('renders per-row multiple choice options', () => {
+    render(
+      <DataEntry
+        questions={[tableMultiRowQuestion]}
+        answers={{}}
+        onChange={noop}
+      />,
+    );
+    fireEvent.click(screen.getByText(/ajouter/i));
+    const row1 = screen.getByText('L1').closest('tr')!;
+    expect(within(row1).getByRole('button', { name: 'A' })).toBeInTheDocument();
+    expect(within(row1).getByRole('button', { name: 'B' })).toBeInTheDocument();
+    const row2 = screen.getByText('L2').closest('tr')!;
+    expect(within(row2).getByRole('button', { name: 'C' })).toBeInTheDocument();
   });
 
   it('validates scale input', () => {

--- a/frontend/src/components/bilan/TableQuestion.tsx
+++ b/frontend/src/components/bilan/TableQuestion.tsx
@@ -75,12 +75,17 @@ export function TableQuestion({
           </Select>
         );
       case 'multi-choice':
+      case 'multi-choice-row':
         const selected = Array.isArray(cellValue)
           ? (cellValue as string[])
           : [];
+        const opts =
+          col.valueType === 'multi-choice-row'
+            ? col.rowOptions?.[rowId] || []
+            : col.options || [];
         return (
           <div className="flex flex-wrap gap-2">
-            {col.options?.map((opt) => {
+            {opts.map((opt) => {
               const isSelected = selected.includes(opt);
               return (
                 <Chip

--- a/frontend/src/services/generation.ts
+++ b/frontend/src/services/generation.ts
@@ -36,7 +36,10 @@ function markdownifyTable(q: Question, ansTable: TableAnswers): string {
 
   const isNonEmpty = (v: unknown, col?: { valueType?: string }) => {
     if (col?.valueType === 'bool') return v === true || v === false;
-    if (col?.valueType === 'multi-choice')
+    if (
+      col?.valueType === 'multi-choice' ||
+      col?.valueType === 'multi-choice-row'
+    )
       return Array.isArray(v) && v.length > 0;
     if (typeof v === 'number') return true;
     if (typeof v === 'string') return (v as string).trim() !== '';
@@ -50,7 +53,10 @@ function markdownifyTable(q: Question, ansTable: TableAnswers): string {
   ) => {
     if (col?.valueType === 'bool')
       return v === true ? (col.label ?? 'true') : '';
-    if (col?.valueType === 'multi-choice')
+    if (
+      col?.valueType === 'multi-choice' ||
+      col?.valueType === 'multi-choice-row'
+    )
       return Array.isArray(v) ? (v as string[]).join(', ') : '';
     if (v == null) return '';
     if (typeof v === 'string') return (v as string).trim();

--- a/frontend/src/types/Typequestion.ts
+++ b/frontend/src/types/Typequestion.ts
@@ -26,6 +26,7 @@ export type ValueType =
   | 'text'
   | 'choice'
   | 'multi-choice'
+  | 'multi-choice-row'
   | 'image';
 
 export type ColumnDef = {
@@ -34,6 +35,7 @@ export type ColumnDef = {
   valueType: ValueType;
   /** Facultatif: enum pour 'choice' */
   options?: string[];
+  rowOptions?: Record<string, string[]>;
 };
 
 export type Row = {

--- a/frontend/src/types/question.ts
+++ b/frontend/src/types/question.ts
@@ -4,6 +4,7 @@ export type ValueType =
   | 'text'
   | 'choice'
   | 'multi-choice'
+  | 'multi-choice-row'
   | 'image';
 
 export interface ColumnDef {
@@ -11,6 +12,7 @@ export interface ColumnDef {
   label: string;
   valueType: ValueType;
   options?: string[];
+  rowOptions?: Record<string, string[]>;
 }
 
 export interface Row {


### PR DESCRIPTION
## Summary
- allow defining row-specific options for table columns
- render per-row multi-choice chips in data entry
- add tests for per-row multi-choice tables

## Testing
- `pnpm --filter frontend run lint` *(fails: @typescript-eslint errors)*
- `pnpm --filter frontend run test` *(fails: 13 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac84cf3ef08329acef97eff4bd25a6