### PR TITLE
[backend] Add BilanType CRUD endpoints

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import dotenv from 'dotenv';
 import { profileRouter } from './routes/profile.routes';
 import { patientRouter } from './routes/patient.routes';
 import { bilanRouter } from './routes/bilan.routes';
+import { bilanTypeRouter } from './routes/bilanType.routes';
 import { sectionRouter } from './routes/section.routes';
 import { sectionExampleRouter } from './routes/sectionExample.routes';
 import { sectionTemplateRouter } from './routes/sectionTemplate.routes';
@@ -97,6 +98,7 @@ app.use(requireAuth);
 
 app.use('/api/v1/patients', patientRouter);
 app.use('/api/v1/bilans', bilanRouter);
+app.use('/api/v1/bilan-types', bilanTypeRouter);
 app.use('/api/v1/profile', profileRouter);
 app.use('/api/v1/sections', sectionRouter);
 app.use('/api/v1/section-examples', sectionExampleRouter);

--- a/backend/src/controllers/bilanType.controller.ts
+++ b/backend/src/controllers/bilanType.controller.ts
@@ -1,0 +1,57 @@
+import type { Request, Response, NextFunction } from 'express';
+import { BilanTypeService } from '../services/bilanType.service';
+
+export const BilanTypeController = {
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bilanType = await BilanTypeService.create(req.user.id, req.body);
+      res.status(201).json(bilanType);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await BilanTypeService.list(req.user.id));
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async get(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bilanType = await BilanTypeService.get(req.user.id, req.params.bilanTypeId);
+      if (!bilanType) {
+        res.sendStatus(404);
+        return;
+      }
+      res.json(bilanType);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const bilanType = await BilanTypeService.update(
+        req.user.id,
+        req.params.bilanTypeId,
+        req.body,
+      );
+      res.json(bilanType);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      await BilanTypeService.remove(req.user.id, req.params.bilanTypeId);
+      res.sendStatus(204);
+    } catch (e) {
+      next(e);
+    }
+  },
+};
+

--- a/backend/src/routes/bilanType.routes.ts
+++ b/backend/src/routes/bilanType.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { BilanTypeController } from '../controllers/bilanType.controller';
+import { validateBody, validateParams } from '../middlewares/validate.middleware';
+import {
+  createBilanTypeSchema,
+  updateBilanTypeSchema,
+  bilanTypeIdParam,
+} from '../schemas/bilanType.schema';
+
+export const bilanTypeRouter = Router();
+
+bilanTypeRouter
+  .route('/')
+  .post(validateBody(createBilanTypeSchema), BilanTypeController.create)
+  .get(BilanTypeController.list);
+
+bilanTypeRouter
+  .route('/:bilanTypeId')
+  .get(validateParams(bilanTypeIdParam), BilanTypeController.get)
+  .put(
+    validateParams(bilanTypeIdParam),
+    validateBody(updateBilanTypeSchema),
+    BilanTypeController.update,
+  )
+  .delete(validateParams(bilanTypeIdParam), BilanTypeController.remove);
+

--- a/backend/src/schemas/bilanType.schema.ts
+++ b/backend/src/schemas/bilanType.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const createBilanTypeSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  isPublic: z.boolean().optional(),
+  layoutJson: z.any().optional(),
+});
+
+export const updateBilanTypeSchema = createBilanTypeSchema.partial();
+
+export const bilanTypeIdParam = z.object({ bilanTypeId: z.string().uuid() });
+

--- a/backend/src/services/bilanType.service.ts
+++ b/backend/src/services/bilanType.service.ts
@@ -1,0 +1,65 @@
+import { prisma } from '../prisma';
+import { NotFoundError } from './profile.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db = prisma as any;
+
+export type BilanTypeData = {
+  name: string;
+  description?: string | null;
+  isPublic?: boolean;
+  layoutJson?: unknown;
+};
+
+export const BilanTypeService = {
+  async create(userId: string, data: BilanTypeData) {
+    const profile = await db.profile.findUnique({ where: { userId } });
+    if (!profile) throw new Error('Profile not found for user');
+    return db.bilanType.create({
+      data: { ...data, authorId: profile.id },
+    });
+  },
+
+  list(userId: string) {
+    return db.bilanType.findMany({
+      where: {
+        OR: [
+          { isPublic: true },
+          { author: { userId } },
+        ],
+      },
+      orderBy: { createdAt: 'desc' },
+      include: { author: { select: { prenom: true } }, sections: true },
+    });
+  },
+
+  get(userId: string, id: string) {
+    return db.bilanType.findFirst({
+      where: {
+        id,
+        OR: [
+          { isPublic: true },
+          { author: { userId } },
+        ],
+      },
+      include: { author: { select: { prenom: true } }, sections: true },
+    });
+  },
+
+  async update(userId: string, id: string, data: Partial<BilanTypeData>) {
+    const { count } = await db.bilanType.updateMany({
+      where: { id, author: { userId } },
+      data,
+    });
+    if (count === 0) throw new NotFoundError();
+    return db.bilanType.findUnique({ where: { id } });
+  },
+
+  async remove(userId: string, id: string) {
+    const { count } = await db.bilanType.deleteMany({
+      where: { id, author: { userId } },
+    });
+    if (count === 0) throw new NotFoundError();
+  },
+};
+

--- a/backend/tests/bilanType.routes.test.ts
+++ b/backend/tests/bilanType.routes.test.ts
@@ -1,0 +1,40 @@
+import request from 'supertest';
+import app from '../src/app';
+import { BilanTypeService } from '../src/services/bilanType.service';
+
+jest.mock('../src/services/bilanType.service');
+
+interface BilanTypeStub {
+  id: string;
+  name: string;
+}
+
+const mockedService = BilanTypeService as jest.Mocked<typeof BilanTypeService>;
+
+describe('GET /api/v1/bilan-types', () => {
+  it('returns bilan types from service', async () => {
+    mockedService.list.mockResolvedValueOnce([
+      { id: '1', name: 'BT' } as BilanTypeStub,
+    ]);
+
+    const res = await request(app).get('/api/v1/bilan-types');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(mockedService.list).toHaveBeenCalledWith('demo-user');
+  });
+});
+
+describe('POST /api/v1/bilan-types', () => {
+  it('creates a bilan type using the service', async () => {
+    const body = { name: 'BT' };
+    mockedService.create.mockResolvedValueOnce({
+      id: '2',
+      name: 'BT',
+    } as BilanTypeStub);
+
+    const res = await request(app).post('/api/v1/bilan-types').send(body);
+    expect(res.status).toBe(201);
+    expect(mockedService.create).toHaveBeenCalledWith('demo-user', body);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add service, controller, router and schema for BilanType CRUD
- register `/api/v1/bilan-types` endpoints and cover with tests

## Testing
- `pnpm --filter backend run lint` *(fails: Unexpected any in existing files)*
- `pnpm --filter backend run test`


------
https://chatgpt.com/codex/tasks/task_e_68aff20df5208329bcd9f3611d3078e0