### PR TITLE
[frontend] add bilan types page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import MonCompteV2 from './pages/MonCompte';
 import Patients from './pages/Patients';
 import VuePatient from './pages/VuePatient';
 import Bibliotheque from './pages/Bibliothèque';
+import BilanTypes from './pages/BilanTypes';
+import BilanType from './pages/BilanType';
 import CreationTrame from './pages/CreationTrame';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
@@ -212,6 +214,8 @@ export default function App() {
         <Route path="/patients/:patientId" element={<VuePatient />} />
         <Route path="/agenda" element={<Agenda />} />
         <Route path="/bibliotheque" element={<Bibliotheque />} />
+        <Route path="/bilan-types" element={<BilanTypes />} />
+        <Route path="/bilan-types/:bilanTypeId" element={<BilanType />} />
         <Route path="/abonnement" element={<Abonnement />} />
         <Route path="/compte" element={<MonCompteV2 />} />
       </Route>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -7,6 +7,7 @@ import {
   Library,
   LogOut,
   LayoutDashboard,
+  FileText,
 } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import {
@@ -54,6 +55,12 @@ const items: {
     page: 'Bibliotheque',
     path: '/bibliotheque',
     icon: Library,
+  },
+  {
+    title: 'Bilans types',
+    page: 'BilanTypes',
+    path: '/bilan-types',
+    icon: FileText,
   },
   { title: 'Mes Patients', page: 'Patients', path: '/patients', icon: User },
   {

--- a/frontend/src/components/BilanTypeCard.test.tsx
+++ b/frontend/src/components/BilanTypeCard.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import BilanTypeCard from './BilanTypeCard';
+
+describe('BilanTypeCard', () => {
+  it('displays info and handles delete', () => {
+    const onDelete = vi.fn();
+    render(
+      <BilanTypeCard
+        bilanType={{ id: '1', name: 'Bilan', description: 'Desc' }}
+        onDelete={onDelete}
+      />,
+    );
+    expect(screen.getByText('Bilan')).toBeInTheDocument();
+    const btn = screen.getByRole('button', { name: /supprimer/i });
+    fireEvent.click(btn);
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/BilanTypeCard.tsx
+++ b/frontend/src/components/BilanTypeCard.tsx
@@ -1,0 +1,60 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Trash2 } from 'lucide-react';
+
+export interface BilanTypeInfo {
+  id: string;
+  name: string;
+  description?: string | null;
+  authorPrenom?: string | null;
+}
+
+interface BilanTypeCardProps {
+  bilanType: BilanTypeInfo;
+  onOpen?: () => void;
+  onDelete?: () => void;
+}
+
+export default function BilanTypeCard({
+  bilanType,
+  onOpen,
+  onDelete,
+}: BilanTypeCardProps) {
+  return (
+    <Card
+      onClick={onOpen}
+      className="relative group hover:shadow-md hover:bg-wood-100 transition-shadow cursor-pointer max-w-60 w-full"
+    >
+      {onDelete && (
+        <Button
+          size="icon"
+          variant="ghost"
+          className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          aria-label="Supprimer"
+          title="Supprimer"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      )}
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-medium text-gray-900">
+          {bilanType.name}
+        </CardTitle>
+        {bilanType.authorPrenom && (
+          <p className="text-xs text-gray-500">
+            Partagé par {bilanType.authorPrenom}
+          </p>
+        )}
+      </CardHeader>
+      {bilanType.description && (
+        <CardContent className="space-y-1">
+          <p className="text-sm text-gray-600">{bilanType.description}</p>
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/pages/BilanType.tsx
+++ b/frontend/src/pages/BilanType.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import {
+  useBilanTypeStore,
+  type BilanType as BilanTypeModel,
+} from '@/store/bilanTypes';
+
+export default function BilanType() {
+  const { bilanTypeId } = useParams();
+  const { fetchOne } = useBilanTypeStore();
+  const [item, setItem] = useState<BilanTypeModel | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!bilanTypeId) return;
+    fetchOne(bilanTypeId)
+      .then(setItem)
+      .finally(() => setLoading(false));
+  }, [bilanTypeId, fetchOne]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-40">
+        <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+      </div>
+    );
+  }
+
+  if (!item) {
+    return <div className="p-4">Bilan type introuvable.</div>;
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">{item.name}</h1>
+      {item.description && <p className="text-gray-600">{item.description}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/BilanTypes.test.tsx
+++ b/frontend/src/pages/BilanTypes.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import BilanTypes from './BilanTypes';
+import { useBilanTypeStore } from '../store/bilanTypes';
+import { useAuth, type AuthState } from '../store/auth';
+
+describe('BilanTypes page', () => {
+  it('renders and lists bilan types', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    const fetchAll = vi.fn().mockResolvedValue(undefined);
+    useBilanTypeStore.setState({
+      items: [{ id: '1', name: 'BT' }],
+      fetchAll,
+    } as Partial<ReturnType<typeof useBilanTypeStore.getState>>);
+
+    render(
+      <MemoryRouter initialEntries={['/bilan-types']}>
+        <Routes>
+          <Route path="/bilan-types" element={<BilanTypes />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(fetchAll).toHaveBeenCalled();
+    expect(await screen.findByText('BT')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/BilanTypes.tsx
+++ b/frontend/src/pages/BilanTypes.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
+import BilanTypeCard from '@/components/BilanTypeCard';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useBilanTypeStore, type BilanType } from '@/store/bilanTypes';
+
+export default function BilanTypes() {
+  const navigate = useNavigate();
+  const { items, fetchAll, remove } = useBilanTypeStore();
+  const [toDelete, setToDelete] = useState<BilanType | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    fetchAll().finally(() => setIsLoading(false));
+  }, [fetchAll]);
+
+  return (
+    <div className="min-h-screen bg-wood-50 p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            Bilans types
+          </h1>
+          <p className="text-gray-600">Vos bilans préconfigurés</p>
+        </div>
+        {isLoading ? (
+          <div className="flex justify-center items-center h-40">
+            <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+          </div>
+        ) : items.length === 0 ? (
+          <p className="text-gray-600">Aucun bilan type pour le moment.</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {items.map((bt) => (
+              <BilanTypeCard
+                key={bt.id}
+                bilanType={{
+                  id: bt.id,
+                  name: bt.name,
+                  description: bt.description,
+                  authorPrenom:
+                    bt.isPublic && bt.author?.prenom
+                      ? bt.author.prenom
+                      : undefined,
+                }}
+                onOpen={() => navigate(`/bilan-types/${bt.id}`)}
+                onDelete={() => setToDelete(bt)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      <AlertDialog open={!!toDelete} onOpenChange={() => setToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Supprimer ce bilan type ?</AlertDialogTitle>
+            <p className="text-sm text-gray-600 mt-2">
+              Cette action est irréversible. Le bilan type &ldquo;
+              {toDelete?.name}&rdquo; sera définitivement supprimé.
+            </p>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700"
+              disabled={isDeleting}
+              onClick={async () => {
+                if (toDelete && !isDeleting) {
+                  setIsDeleting(true);
+                  try {
+                    await remove(toDelete.id);
+                  } finally {
+                    setIsDeleting(false);
+                    setToDelete(null);
+                  }
+                }
+              }}
+            >
+              Supprimer
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/frontend/src/store/bilanTypes.ts
+++ b/frontend/src/store/bilanTypes.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import { apiFetch } from '../utils/api';
+import { useAuth } from './auth';
+
+export interface BilanType {
+  id: string;
+  name: string;
+  description?: string | null;
+  isPublic?: boolean;
+  authorId?: string | null;
+  author?: { prenom?: string | null } | null;
+  layoutJson?: unknown;
+}
+
+interface BilanTypeState {
+  items: BilanType[];
+  fetchAll: () => Promise<void>;
+  fetchOne: (id: string) => Promise<BilanType>;
+  remove: (id: string) => Promise<void>;
+}
+
+const endpoint = '/api/v1/bilan-types';
+
+export const useBilanTypeStore = create<BilanTypeState>((set) => ({
+  items: [],
+
+  async fetchAll() {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const items = await apiFetch<BilanType[]>(endpoint, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set({ items });
+  },
+
+  async fetchOne(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const bilanType = await apiFetch<BilanType>(`${endpoint}/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({
+      items: state.items.some((s) => s.id === id)
+        ? state.items.map((s) => (s.id === id ? bilanType : s))
+        : [...state.items, bilanType],
+    }));
+    return bilanType;
+  },
+
+  async remove(id) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    await apiFetch(`${endpoint}/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    set((state) => ({ items: state.items.filter((s) => s.id !== id) }));
+  },
+}));

--- a/frontend/src/store/pageContext.tsx
+++ b/frontend/src/store/pageContext.tsx
@@ -9,7 +9,8 @@ export type Page =
   | 'Resultats'
   | 'Abonnement'
   | 'MonCompte'
-  | 'Bibliotheque';
+  | 'Bibliotheque'
+  | 'BilanTypes';
 
 interface PageState {
   currentPage: Page;


### PR DESCRIPTION
## Summary
- add store and components for managing Bilan Types
- list, open and delete Bilan Types from new page
- expose page through sidebar and routing

## Testing
- `pnpm --filter frontend run lint` *(fails: Unexpected any & other lint errors)*
- `pnpm --filter frontend run test` *(fails: various act() and DOM warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aff8c64e888329a84acf487c53b2cf