### PR TITLE
[frontend] Add Bilan type builder CTA and creation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import VuePatient from './pages/VuePatient';
 import Bibliotheque from './pages/Bibliothèque';
 import BilanTypes from './pages/BilanTypes';
 import BilanType from './pages/BilanType';
+import BilanTypeBuilder from './pages/BilanTypeBuilder';
 import CreationTrame from './pages/CreationTrame';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
@@ -215,6 +216,7 @@ export default function App() {
         <Route path="/agenda" element={<Agenda />} />
         <Route path="/bibliotheque" element={<Bibliotheque />} />
         <Route path="/bilan-types" element={<BilanTypes />} />
+        <Route path="/bilan-types/builder" element={<BilanTypeBuilder />} />
         <Route path="/bilan-types/:bilanTypeId" element={<BilanType />} />
         <Route path="/abonnement" element={<Abonnement />} />
         <Route path="/compte" element={<MonCompteV2 />} />

--- a/frontend/src/pages/BilanTypeBuilder.tsx
+++ b/frontend/src/pages/BilanTypeBuilder.tsx
@@ -1,268 +1,140 @@
-"use client"
+"use client";
 
-import type React from "react"
-
-import { useState } from "react"
-import { SectionDisponible } from "@/components/bilan-type-builder/section-disponible"
-import { BilanTypeConstruction } from "@/components/bilan-type-builder/bilan-type-construction"
+import type React from "react";
+import { useState, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { SectionDisponible } from "@/components/bilanType/SectionDisponible";
+import { BilanTypeConstruction } from "@/components/bilanType/BilanTypeConstruction";
+import { useSectionStore } from "@/store/sections";
+import { useBilanTypeStore } from "@/store/bilanTypes";
 
 interface BilanElement {
-  id: string
-  type: "test" | "anamnese" | "conclusion"
-  title: string
-  description: string
-  metier: "psychologue" | "orthophoniste" | "neuropsychologue" | "psychiatre" | "general"
+  id: string;
+  type: "test" | "anamnese" | "conclusion";
+  title: string;
+  description: string;
+  metier:
+    | "psychologue"
+    | "orthophoniste"
+    | "neuropsychologue"
+    | "psychiatre"
+    | "general";
 }
 
 interface SelectedElement extends BilanElement {
-  order: number
+  order: number;
 }
 
-const availableElements: BilanElement[] = [
-  {
-    id: "1",
-    type: "test",
-    title: "Test cognitif MMSE",
-    description: "Évaluation des fonctions cognitives",
-    metier: "neuropsychologue",
-  },
-  {
-    id: "2",
-    type: "test",
-    title: "Test de mémoire",
-    description: "Évaluation de la mémoire à court et long terme",
-    metier: "neuropsychologue",
-  },
-  {
-    id: "3",
-    type: "test",
-    title: "Test d'attention",
-    description: "Mesure de la capacité d'attention et de concentration",
-    metier: "neuropsychologue",
-  },
-  {
-    id: "4",
-    type: "test",
-    title: "WISC-V",
-    description: "Échelle d'intelligence de Wechsler pour enfants",
-    metier: "psychologue",
-  },
-  {
-    id: "5",
-    type: "test",
-    title: "WAIS-IV",
-    description: "Échelle d'intelligence de Wechsler pour adultes",
-    metier: "psychologue",
-  },
-  {
-    id: "6",
-    type: "test",
-    title: "Test de fluence verbale",
-    description: "Évaluation de la fluence phonémique et sémantique",
-    metier: "orthophoniste",
-  },
-  {
-    id: "7",
-    type: "test",
-    title: "Test de dénomination",
-    description: "Évaluation de l'accès lexical",
-    metier: "orthophoniste",
-  },
-  {
-    id: "8",
-    type: "test",
-    title: "Échelle de dépression de Beck",
-    description: "Évaluation de l'intensité dépressive",
-    metier: "psychiatre",
-  },
-  {
-    id: "9",
-    type: "test",
-    title: "Échelle d'anxiété de Hamilton",
-    description: "Mesure de l'anxiété",
-    metier: "psychiatre",
-  },
-  {
-    id: "10",
-    type: "test",
-    title: "Test de Rorschach",
-    description: "Test projectif de personnalité",
-    metier: "psychologue",
-  },
-  {
-    id: "11",
-    type: "anamnese",
-    title: "Anamnèse personnelle",
-    description: "Histoire personnelle du patient",
-    metier: "general",
-  },
-  { id: "12", type: "anamnese", title: "Anamnèse familiale", description: "Antécédents familiaux", metier: "general" },
-  {
-    id: "13",
-    type: "anamnese",
-    title: "Anamnèse médicale",
-    description: "Historique médical et traitements",
-    metier: "general",
-  },
-  {
-    id: "14",
-    type: "anamnese",
-    title: "Anamnèse développementale",
-    description: "Développement psychomoteur et langagier",
-    metier: "orthophoniste",
-  },
-  {
-    id: "15",
-    type: "anamnese",
-    title: "Anamnèse scolaire",
-    description: "Parcours et difficultés scolaires",
-    metier: "psychologue",
-  },
-  {
-    id: "16",
-    type: "anamnese",
-    title: "Anamnèse psychiatrique",
-    description: "Antécédents psychiatriques et traitements",
-    metier: "psychiatre",
-  },
-  {
-    id: "17",
-    type: "conclusion",
-    title: "Synthèse diagnostique",
-    description: "Résumé des observations et diagnostic",
-    metier: "general",
-  },
-  {
-    id: "18",
-    type: "conclusion",
-    title: "Recommandations",
-    description: "Conseils et orientations thérapeutiques",
-    metier: "general",
-  },
-  {
-    id: "19",
-    type: "conclusion",
-    title: "Plan de suivi",
-    description: "Planification du suivi thérapeutique",
-    metier: "general",
-  },
-  {
-    id: "20",
-    type: "conclusion",
-    title: "Projet thérapeutique",
-    description: "Objectifs et modalités de prise en charge",
-    metier: "orthophoniste",
-  },
-  {
-    id: "21",
-    type: "test",
-    title: "Test de compréhension",
-    description: "Évaluation de la compréhension orale et écrite",
-    metier: "orthophoniste",
-  },
-  {
-    id: "22",
-    type: "test",
-    title: "Bilan phonologique",
-    description: "Analyse des troubles phonologiques",
-    metier: "orthophoniste",
-  },
-  {
-    id: "23",
-    type: "test",
-    title: "Test de Trail Making",
-    description: "Évaluation des fonctions exécutives",
-    metier: "neuropsychologue",
-  },
-  {
-    id: "24",
-    type: "test",
-    title: "Test de Stroop",
-    description: "Mesure de l'inhibition cognitive",
-    metier: "neuropsychologue",
-  },
-]
-
 export default function BilanTypeBuilder() {
-  const [bilanName, setBilanName] = useState("")
-  const [selectedElements, setSelectedElements] = useState<SelectedElement[]>([])
-  const [showPreview, setShowPreview] = useState(false)
-  const [draggedIndex, setDraggedIndex] = useState<number | null>(null)
+  const [bilanName, setBilanName] = useState("");
+  const [selectedElements, setSelectedElements] = useState<SelectedElement[]>([]);
+  const [showPreview, setShowPreview] = useState(false);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  const sections = useSectionStore((s) => s.items);
+  const fetchSections = useSectionStore((s) => s.fetchAll);
+  const createBilanType = useBilanTypeStore((s) => s.create);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchSections().catch(console.error);
+  }, [fetchSections]);
+
+  const availableElements = useMemo<BilanElement[]>(
+    () =>
+      sections
+        .filter((s) =>
+          ["anamnese", "conclusion", "tests_standards"].includes(s.kind as string),
+        )
+        .map((s) => ({
+          id: s.id,
+          type: (s.kind === "tests_standards" ? "test" : s.kind) as BilanElement["type"],
+          title: s.title,
+          description: s.description || "",
+          metier: "general" as const,
+        })),
+    [sections],
+  );
 
   const addElement = (element: BilanElement) => {
     const newElement: SelectedElement = {
       ...element,
       order: selectedElements.length,
-    }
-    setSelectedElements([...selectedElements, newElement])
-  }
+    };
+    setSelectedElements([...selectedElements, newElement]);
+  };
 
   const removeElement = (id: string) => {
-    setSelectedElements(selectedElements.filter((el) => el.id !== id))
-  }
+    setSelectedElements(selectedElements.filter((el) => el.id !== id));
+  };
 
   const handleDragStart = (e: React.DragEvent, index: number) => {
-    setDraggedIndex(index)
-    e.dataTransfer.effectAllowed = "move"
-  }
+    setDraggedIndex(index);
+    e.dataTransfer.effectAllowed = "move";
+  };
 
   const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = "move"
-  }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  };
 
   const handleDrop = (e: React.DragEvent, dropIndex: number) => {
-    e.preventDefault()
+    e.preventDefault();
 
     if (draggedIndex === null || draggedIndex === dropIndex) {
-      setDraggedIndex(null)
-      return
+      setDraggedIndex(null);
+      return;
     }
 
-    const items = Array.from(selectedElements)
-    const draggedItem = items[draggedIndex]
+    const items = Array.from(selectedElements);
+    const draggedItem = items[draggedIndex];
 
-    // Remove dragged item
-    items.splice(draggedIndex, 1)
+    items.splice(draggedIndex, 1);
+    const newIndex = draggedIndex < dropIndex ? dropIndex - 1 : dropIndex;
+    items.splice(newIndex, 0, draggedItem);
 
-    // Insert at new position
-    const newIndex = draggedIndex < dropIndex ? dropIndex - 1 : dropIndex
-    items.splice(newIndex, 0, draggedItem)
-
-    // Update order
     const updatedItems = items.map((item, index) => ({
       ...item,
       order: index,
-    }))
+    }));
 
-    setSelectedElements(updatedItems)
-    setDraggedIndex(null)
-  }
+    setSelectedElements(updatedItems);
+    setDraggedIndex(null);
+  };
 
   const handleDragEnd = () => {
-    setDraggedIndex(null)
-  }
+    setDraggedIndex(null);
+  };
 
-  const saveBilanType = () => {
-    console.log("Saving bilan type:", { name: bilanName, elements: selectedElements })
-    alert("Type de bilan sauvegardé avec succès!")
-  }
+  const saveBilanType = async () => {
+    await createBilanType({
+      name: bilanName,
+      layoutJson: selectedElements.map(({ id, order }) => ({
+        sectionId: id,
+        order,
+      })),
+    });
+    navigate("/bilan-types");
+  };
 
   return (
     <div className="min-h-screen bg-background p-6">
       <div className="max-w-7xl mx-auto">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-foreground mb-2">Constructeur de Type de Bilan</h1>
+          <h1 className="text-3xl font-bold text-foreground mb-2">
+            Constructeur de Type de Bilan
+          </h1>
           <p className="text-muted-foreground">
             Créez votre type de bilan personnalisé en sélectionnant et organisant les éléments
           </p>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Available Elements */}
-          <SectionDisponible availableElements={availableElements} onAddElement={addElement} />
+          <SectionDisponible
+            availableElements={availableElements}
+            onAddElement={addElement}
+          />
 
-          {/* Builder Area */}
           <BilanTypeConstruction
             bilanName={bilanName}
             setBilanName={setBilanName}
@@ -280,5 +152,5 @@ export default function BilanTypeBuilder() {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/BilanTypes.test.tsx
+++ b/frontend/src/pages/BilanTypes.test.tsx
@@ -24,5 +24,6 @@ describe('BilanTypes page', () => {
 
     expect(fetchAll).toHaveBeenCalled();
     expect(await screen.findByText('BT')).toBeInTheDocument();
+    expect(screen.getByText('Créer un Bilan Type')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/BilanTypes.tsx
+++ b/frontend/src/pages/BilanTypes.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2 } from 'lucide-react';
 import BilanTypeCard from '@/components/BilanTypeCard';
+import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -29,11 +30,16 @@ export default function BilanTypes() {
   return (
     <div className="min-h-screen bg-wood-50 p-6">
       <div className="max-w-7xl mx-auto">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Bilans types
-          </h1>
-          <p className="text-gray-600">Vos bilans préconfigurés</p>
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+              Bilans types
+            </h1>
+            <p className="text-gray-600">Vos bilans préconfigurés</p>
+          </div>
+          <Button onClick={() => navigate('/bilan-types/builder')}>
+            Créer un Bilan Type
+          </Button>
         </div>
         {isLoading ? (
           <div className="flex justify-center items-center h-40">

--- a/frontend/src/store/bilanTypes.test.ts
+++ b/frontend/src/store/bilanTypes.test.ts
@@ -1,0 +1,23 @@
+import { vi, describe, it, expect } from 'vitest';
+import { useBilanTypeStore } from './bilanTypes';
+import { useAuth, type AuthState } from './auth';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('useBilanTypeStore', () => {
+  it('adds a bilan type with create()', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    useBilanTypeStore.setState({ items: [] });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: '1', name: 'BT' }),
+    });
+    const item = await useBilanTypeStore.getState().create({ name: 'BT' });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/bilan-types',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(item.id).toBe('1');
+    expect(useBilanTypeStore.getState().items[0].id).toBe('1');
+  });
+});

--- a/frontend/src/store/bilanTypes.ts
+++ b/frontend/src/store/bilanTypes.ts
@@ -16,10 +16,13 @@ interface BilanTypeState {
   items: BilanType[];
   fetchAll: () => Promise<void>;
   fetchOne: (id: string) => Promise<BilanType>;
+  create: (data: BilanTypeInput) => Promise<BilanType>;
   remove: (id: string) => Promise<void>;
 }
 
 const endpoint = '/api/v1/bilan-types';
+
+export type BilanTypeInput = Omit<BilanType, 'id' | 'author'>;
 
 export const useBilanTypeStore = create<BilanTypeState>((set) => ({
   items: [],
@@ -44,6 +47,18 @@ export const useBilanTypeStore = create<BilanTypeState>((set) => ({
         ? state.items.map((s) => (s.id === id ? bilanType : s))
         : [...state.items, bilanType],
     }));
+    return bilanType;
+  },
+
+  async create(data) {
+    const token = useAuth.getState().token;
+    if (!token) throw new Error('Non authentifié');
+    const bilanType = await apiFetch<BilanType>(endpoint, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    set((state) => ({ items: [...state.items, bilanType] }));
     return bilanType;
   },
 


### PR DESCRIPTION
## Summary
- add button to create Bilan Type from listing
- implement Bilan Type builder with real sections and saving
- support Bilan Type creation in store with tests

## Testing
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test`


------
https://chatgpt.com/codex/tasks/task_e_68b000f95ef0832986fb0dfbf354b3c9