### PR TITLE
[shared] add BilanType and BilanTypeSection types

### DIFF
--- a/frontend/src/store/bilanTypes.ts
+++ b/frontend/src/store/bilanTypes.ts
@@ -1,16 +1,8 @@
 import { create } from 'zustand';
 import { apiFetch } from '../utils/api';
 import { useAuth } from './auth';
-
-export interface BilanType {
-  id: string;
-  name: string;
-  description?: string | null;
-  isPublic?: boolean;
-  authorId?: string | null;
-  author?: { prenom?: string | null } | null;
-  layoutJson?: unknown;
-}
+import type { BilanType } from '@monorepo/shared';
+export type { BilanType } from '@monorepo/shared';
 
 interface BilanTypeState {
   items: BilanType[];

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -19,3 +19,5 @@ export type EditGarant = Prisma.GarantUpdateInput;
 
 export * from './types/UserProfile';
 export * from './types/ApiResponse';
+export * from './types/BilanType';
+export * from './types/BilanTypeSection';

--- a/shared/src/types/BilanType.ts
+++ b/shared/src/types/BilanType.ts
@@ -1,0 +1,15 @@
+import type { BilanTypeSection } from './BilanTypeSection';
+
+export interface BilanType {
+  id: string;
+  name: string;
+  description?: string | null;
+  isPublic?: boolean;
+  authorId?: string | null;
+  createdAt?: string;
+  layoutJson?: unknown;
+  author?: { prenom?: string | null } | null;
+  sections?: BilanTypeSection[];
+}
+
+export type BilanTypes = BilanType[];

--- a/shared/src/types/BilanTypeSection.ts
+++ b/shared/src/types/BilanTypeSection.ts
@@ -1,0 +1,13 @@
+import type { BilanType } from './BilanType';
+
+export interface BilanTypeSection {
+  id: string;
+  bilanTypeId: string;
+  sectionId: string;
+  sortOrder: number;
+  settings?: unknown;
+  bilanType?: BilanType;
+  section?: unknown;
+}
+
+export type BilanTypeSections = BilanTypeSection[];


### PR DESCRIPTION
## Summary
- define global BilanType and BilanTypeSection interfaces and export them from shared package
- reuse shared BilanType type in frontend store for consistency

## Testing
- `pnpm --filter frontend run lint` *(fails: Unexpected any in many files)*
- `pnpm --filter frontend run test` *(fails: multiple test and runtime errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b0084ef3c88329ba29bf1f2fd0c42c