### PR TITLE
[backend] Link bilan type sections on creation

### DIFF
--- a/backend/__mocks__/@prisma/client.js
+++ b/backend/__mocks__/@prisma/client.js
@@ -64,6 +64,22 @@ class PrismaClient {
       updateMany: jest.fn(),
       deleteMany: jest.fn(),
     };
+    this.bilanType = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
+      deleteMany: jest.fn(),
+    };
+    this.bilanTypeSection = {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      updateMany: jest.fn(),
+      deleteMany: jest.fn(),
+    };
     this.section = {
       create: jest.fn(),
       findMany: jest.fn(),

--- a/backend/src/schemas/bilanType.schema.ts
+++ b/backend/src/schemas/bilanType.schema.ts
@@ -1,10 +1,16 @@
 import { z } from 'zod';
+import { createBilanTypeSectionSchema } from './bilanTypeSection.schema';
 
 export const createBilanTypeSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   isPublic: z.boolean().optional(),
   layoutJson: z.any().optional(),
+  sections: z
+    .array(
+      createBilanTypeSectionSchema.omit({ bilanTypeId: true })
+    )
+    .optional(),
 });
 
 export const updateBilanTypeSchema = createBilanTypeSchema.partial();

--- a/backend/tests/bilanType.routes.test.ts
+++ b/backend/tests/bilanType.routes.test.ts
@@ -26,7 +26,12 @@ describe('GET /api/v1/bilan-types', () => {
 
 describe('POST /api/v1/bilan-types', () => {
   it('creates a bilan type using the service', async () => {
-    const body = { name: 'BT' };
+    const body = {
+      name: 'BT',
+      sections: [
+        { sectionId: '11111111-1111-1111-1111-111111111111', sortOrder: 0 },
+      ],
+    };
     mockedService.create.mockResolvedValueOnce({
       id: '2',
       name: 'BT',

--- a/backend/tests/bilanType.service.test.ts
+++ b/backend/tests/bilanType.service.test.ts
@@ -1,0 +1,35 @@
+jest.mock('../src/prisma', () => {
+  const profile = { findUnique: jest.fn() };
+  const bilanType = { create: jest.fn() };
+  const bilanTypeSection = { create: jest.fn() };
+  return { prisma: { profile, bilanType, bilanTypeSection } };
+});
+
+const { prisma } = require('../src/prisma');
+const { BilanTypeService } = require('../src/services/bilanType.service');
+
+const db = prisma;
+
+describe('BilanTypeService.create', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates bilan type and related sections', async () => {
+    db.profile.findUnique.mockResolvedValueOnce({ id: 'p1' });
+    db.bilanType.create.mockResolvedValueOnce({ id: 'bt1', name: 'BT' });
+
+    const sections = [
+      { sectionId: 's1', sortOrder: 0 },
+      { sectionId: 's2', sortOrder: 1 },
+    ];
+
+    await BilanTypeService.create('user1', { name: 'BT', sections });
+
+    expect(db.bilanType.create).toHaveBeenCalled();
+    expect(db.bilanTypeSection.create).toHaveBeenCalledTimes(2);
+    expect(db.bilanTypeSection.create).toHaveBeenCalledWith({
+      data: { bilanTypeId: 'bt1', sectionId: 's1', sortOrder: 0 },
+    });
+  });
+});

--- a/frontend/src/pages/BilanTypeBuilder.tsx
+++ b/frontend/src/pages/BilanTypeBuilder.tsx
@@ -1,16 +1,16 @@
-"use client";
+'use client';
 
-import type React from "react";
-import { useState, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
-import { SectionDisponible } from "@/components/bilanType/SectionDisponible";
-import { BilanTypeConstruction } from "@/components/bilanType/BilanTypeConstruction";
-import { useSectionStore } from "@/store/sections";
-import { useBilanTypeStore } from "@/store/bilanTypes";
+import type React from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SectionDisponible } from '@/components/bilanType/SectionDisponible';
+import { BilanTypeConstruction } from '@/components/bilanType/BilanTypeConstruction';
+import { useSectionStore } from '@/store/sections';
+import { useBilanTypeStore } from '@/store/bilanTypes';
 
 // ✅ On réutilise les types existants
-import { categories, kindMap, type CategoryId } from "@/types/trame";
-import { Job } from "@/types/job";
+import { categories, kindMap, type CategoryId } from '@/types/trame';
+import { Job } from '@/types/job';
 
 // Petit type UI local basé UNIQUEMENT sur tes types de domaine
 type BilanElement = {
@@ -28,8 +28,10 @@ type SelectedElement = BilanElement & {
 };
 
 export default function BilanTypeBuilder() {
-  const [bilanName, setBilanName] = useState("");
-  const [selectedElements, setSelectedElements] = useState<SelectedElement[]>([]);
+  const [bilanName, setBilanName] = useState('');
+  const [selectedElements, setSelectedElements] = useState<SelectedElement[]>(
+    [],
+  );
   const [showPreview, setShowPreview] = useState(false);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
 
@@ -71,14 +73,14 @@ export default function BilanTypeBuilder() {
     () =>
       sections
         .map((s) => {
-          const normalized = normalizeKind((s as any).kind as string | undefined);
+          const normalized = normalizeKind(s.kind);
           if (!normalized) return null;
 
           return {
-            id: (s as any).id as string,
+            id: s.id,
             type: normalized,
-            title: (s as any).title as string,
-            description: ((s as any).description as string) || "",
+            title: s.title,
+            description: s.description ?? '',
             // pas de "general" string — on garde uniquement Job si un ciblage est utile
             metier: undefined as Job | undefined,
           } satisfies BilanElement;
@@ -101,12 +103,12 @@ export default function BilanTypeBuilder() {
 
   const handleDragStart = (e: React.DragEvent, index: number) => {
     setDraggedIndex(index);
-    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.effectAllowed = 'move';
   };
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
+    e.dataTransfer.dropEffect = 'move';
   };
 
   const handleDrop = (e: React.DragEvent, dropIndex: number) => {
@@ -140,12 +142,12 @@ export default function BilanTypeBuilder() {
   const saveBilanType = async () => {
     await createBilanType({
       name: bilanName,
-      layoutJson: selectedElements.map(({ id, order }) => ({
+      sections: selectedElements.map(({ id, order }) => ({
         sectionId: id,
-        order,
+        sortOrder: order,
       })),
     });
-    navigate("/bilan-types");
+    navigate('/bilan-types');
   };
 
   return (
@@ -156,7 +158,8 @@ export default function BilanTypeBuilder() {
             Constructeur de Type de Bilan
           </h1>
           <p className="text-muted-foreground">
-            Créez votre type de bilan personnalisé en sélectionnant et organisant les éléments
+            Créez votre type de bilan personnalisé en sélectionnant et
+            organisant les éléments
           </p>
         </div>
 

--- a/frontend/src/store/bilanTypes.test.ts
+++ b/frontend/src/store/bilanTypes.test.ts
@@ -20,4 +20,26 @@ describe('useBilanTypeStore', () => {
     expect(item.id).toBe('1');
     expect(useBilanTypeStore.getState().items[0].id).toBe('1');
   });
+
+  it('sends sections when creating a bilan type', async () => {
+    useAuth.setState((s) => ({ ...s, token: 'tok' }) as AuthState);
+    useBilanTypeStore.setState({ items: [] });
+    (fetch as unknown as vi.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ id: '1', name: 'BT' }),
+    });
+    await useBilanTypeStore.getState().create({
+      name: 'BT',
+      sections: [{ sectionId: 's1', sortOrder: 0 }],
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/bilan-types',
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: 'BT',
+          sections: [{ sectionId: 's1', sortOrder: 0 }],
+        }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- allow creating BilanType with associated sections
- wire BilanTypeBuilder to send sections
- cover BilanTypeService create behaviour

## Testing
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test`
- `pnpm --filter frontend exec eslint src/pages/BilanTypeBuilder.tsx src/store/bilanTypes.test.ts`
- `pnpm --filter frontend run test` *(fails: TypeError: el.scrollIntoView is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b009ddd5a08329b6c2b7e8303fc6b1