### PR TITLE
[frontend] Replace WizardAIBilanType event bridge with state callbacks

### DIFF
--- a/frontend/src/components/WizardAIBilanType.tsx
+++ b/frontend/src/components/WizardAIBilanType.tsx
@@ -14,7 +14,9 @@ interface WizardAIBilanTypeProps
     WizardAIRightPanelProps,
     | 'step'
     | 'onStepChange'
+    | 'activeSectionId'
     | 'onActiveSectionChange'
+    | 'excludedSectionIds'
     | 'onExcludedSectionsChange'
   > {
   mode?: 'section' | 'bilanType';
@@ -35,6 +37,11 @@ function WizardAIBilanTypeInner({
   const [localTrameId, setLocalTrameId] = useState<string | undefined>(
     rest.selectedTrame?.value,
   );
+  const [activeSectionInfo, setActiveSectionInfo] = useState<{
+    id: string | null;
+    title: string;
+  }>({ id: null, title: '' });
+  const [excludedSectionIds, setExcludedSectionIds] = useState<string[]>([]);
 
   const selectedTrame = useMemo(() => {
     const options = rest.trameOptions || [];
@@ -87,10 +94,12 @@ function WizardAIBilanTypeInner({
     id: string | null;
     title: string;
   }) => {
+    setActiveSectionInfo(info);
     onActiveSectionChangeProp?.(info);
   };
 
   const handleExcludedSectionsChange = (ids: string[]) => {
+    setExcludedSectionIds(ids);
     onExcludedSectionsChangeProp?.(ids);
   };
 
@@ -110,7 +119,13 @@ function WizardAIBilanTypeInner({
           {...rest}
           step={currentStep}
           onStepChange={handleStepChange}
+          activeSectionId={
+            mode === 'bilanType' ? activeSectionInfo.id : undefined
+          }
           onActiveSectionChange={handleActiveSectionChange}
+          excludedSectionIds={
+            mode === 'bilanType' ? excludedSectionIds : undefined
+          }
           onExcludedSectionsChange={handleExcludedSectionsChange}
           selectedTrame={
             mode === 'bilanType' ? selectedTrame : rest.selectedTrame


### PR DESCRIPTION
## Summary
- track WizardAIBilanType step, active section, and exclusions in local state and feed them into WizardAIRightPanel via the new controlled props
- refactor WizardAIRightPanel to manage controlled/uncontrolled step, active section, and exclusion updates with explicit callbacks instead of window events
- adjust WizardAIRightPanel tests to hoist the API mock and cover the new active section callback contract

## Testing
- `pnpm --filter frontend exec vitest run src/components/WizardAIRightPanel.test.tsx` *(fails: esbuild cannot parse JSX in wizard-ai/useBilanGeneration.ts when running the isolated suite)*
- `pnpm --filter frontend run lint` *(fails: pre-existing lint errors across the frontend package)*

------
https://chatgpt.com/codex/tasks/task_e_68d848e36be883299274dfb2e5739382