### PR TITLE
[frontend] Move DataEntry state into draft store

### DIFF
--- a/frontend/src/components/SectionGlimpse.tsx
+++ b/frontend/src/components/SectionGlimpse.tsx
@@ -97,6 +97,10 @@ export default function SectionGlimpse({
                 <DataEntry
                   inline
                   questions={renderQuestions}
+                  draftKey={{
+                    bilanId: 'section-glimpse',
+                    sectionId: selectedId ?? 'preview',
+                  }}
                   answers={answers}
                   onChange={setAnswers}
                 />

--- a/frontend/src/components/WizardAIRightPanel.tsx
+++ b/frontend/src/components/WizardAIRightPanel.tsx
@@ -464,6 +464,10 @@ export default function WizardAIRightPanel({
               <DataEntry
                 ref={dataEntryRef}
                 questions={activeQuestions}
+                draftKey={{
+                  bilanId,
+                  sectionId: activeBilanSectionId ?? '__bilan-type__',
+                }}
                 answers={activeAnswers}
                 onChange={(a) => {
                   if (!activeBilanSectionId) return;
@@ -507,6 +511,7 @@ export default function WizardAIRightPanel({
             <DataEntry
               ref={dataEntryRef}
               questions={questions}
+              draftKey={{ bilanId, sectionId: sectionInfo.id }}
               answers={answers}
               onChange={onAnswersChange}
               inline

--- a/frontend/src/components/bilan/DataEntry.test.tsx
+++ b/frontend/src/components/bilan/DataEntry.test.tsx
@@ -1,10 +1,36 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import * as React from 'react';
 import { DataEntry, type DataEntryHandle } from './DataEntry';
 import type { Question } from '@/types/question';
+import { resetDraftStores } from '@/store/draft';
 
 const noop = () => {};
+
+let draftCounter = 0;
+const makeDraftKey = () => {
+  draftCounter += 1;
+  return { bilanId: 'test-bilan', sectionId: `section-${draftCounter}` };
+};
+
+beforeEach(() => {
+  draftCounter = 0;
+  resetDraftStores();
+});
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
 
 const mcQuestion: Question = {
   id: '1',
@@ -138,7 +164,14 @@ const titleQuestion: Question = {
 
 describe('DataEntry', () => {
   it('renders multiple choice options as buttons', () => {
-    render(<DataEntry questions={[mcQuestion]} answers={{}} onChange={noop} />);
+    render(
+      <DataEntry
+        questions={[mcQuestion]}
+        draftKey={makeDraftKey()}
+        answers={{}}
+        onChange={noop}
+      />,
+    );
     fireEvent.click(screen.getByText(/ajouter/i));
     expect(screen.getByRole('button', { name: 'Opt1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Opt2' })).toBeInTheDocument();
@@ -148,6 +181,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[tableMultiRowQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
       />,
@@ -162,7 +196,12 @@ describe('DataEntry', () => {
 
   it('validates scale input', () => {
     render(
-      <DataEntry questions={[scaleQuestion]} answers={{}} onChange={noop} />,
+      <DataEntry
+        questions={[scaleQuestion]}
+        draftKey={makeDraftKey()}
+        answers={{}}
+        onChange={noop}
+      />,
     );
     fireEvent.click(screen.getByText(/ajouter/i));
     const input = screen.getByRole('spinbutton');
@@ -174,6 +213,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[mcQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -191,6 +231,7 @@ describe('DataEntry', () => {
       <DataEntry
         ref={ref}
         questions={[mcQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={handle}
         inline
@@ -208,6 +249,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[tableQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -220,6 +262,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[tableCommentQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -232,6 +275,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[mcQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -244,6 +288,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[tableScoreQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -256,6 +301,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[tableSelectQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -268,6 +314,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[tableMultiQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -280,6 +327,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[tableCheckQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline
@@ -292,6 +340,7 @@ describe('DataEntry', () => {
     render(
       <DataEntry
         questions={[titleQuestion]}
+        draftKey={makeDraftKey()}
         answers={{}}
         onChange={noop}
         inline

--- a/frontend/src/components/bilan/DataEntry.tsx
+++ b/frontend/src/components/bilan/DataEntry.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useImperativeHandle,
   useRef,
+  useMemo,
 } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -18,11 +19,14 @@ import { Plus } from 'lucide-react';
 import type { Question, Answers } from '@/types/question';
 import { QuestionRenderer } from './QuestionRenderer';
 import { GroupedQuestionsNav } from './GroupedQuestionsNav';
+import { getDraftStore, type DraftIdentifier } from '@/store/draft';
+import { useStore } from 'zustand';
 
 interface DataEntryProps {
   questions: Question[];
-  answers: Answers;
-  onChange: (answers: Answers) => void;
+  draftKey: DraftIdentifier;
+  answers?: Answers;
+  onChange?: (answers: Answers) => void;
   inline?: boolean;
   showGroupNav?: boolean;
   // When questions start without an explicit titre, use this as the group title instead of "Général"
@@ -43,11 +47,31 @@ type QuestionGroup = {
   items: Question[];
 };
 
+const stableStringify = (input: unknown): string =>
+  JSON.stringify(
+    input,
+    (_, value) => {
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        return Object.keys(value as Record<string, unknown>)
+          .sort()
+          .reduce<Record<string, unknown>>((acc, key) => {
+            acc[key] = (value as Record<string, unknown>)[key];
+            return acc;
+          }, {});
+      }
+      return value;
+    },
+  ) ?? '';
+
+const serializeAnswers = (value?: Answers): string =>
+  stableStringify(value ?? {});
+
 export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
   function DataEntry(
     {
       questions,
-      answers,
+      draftKey,
+      answers: initialAnswers,
       onChange,
       inline = false,
       showGroupNav = true,
@@ -56,8 +80,44 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
     ref,
   ) {
     const [open, setOpen] = useState(false);
-    const [local, setLocal] = useState<Answers>({});
     const [errors, setErrors] = useState<Record<string, string>>({});
+    const draftStore = useMemo(
+      () => getDraftStore(draftKey),
+      [draftKey.bilanId, draftKey.sectionId],
+    );
+    const answers = useStore(draftStore, (state) => state.answers);
+    const applyChange = useStore(draftStore, (state) => state.applyChange);
+    const hydrate = useStore(draftStore, (state) => state.hydrate);
+    const dirty = useStore(draftStore, (state) => state.dirty);
+    const lastHydratedRef = useRef<string | null>(null);
+
+    useEffect(() => {
+      if (initialAnswers === undefined) return;
+      const serialized = serializeAnswers(initialAnswers);
+      if (dirty && lastHydratedRef.current !== serialized) {
+        return;
+      }
+      if (lastHydratedRef.current === serialized) {
+        return;
+      }
+      hydrate({ answers: initialAnswers, dirty: false });
+      lastHydratedRef.current = serialized;
+    }, [initialAnswers, hydrate, dirty]);
+
+    const updateAnswer = (questionId: string, value: unknown) => {
+      const next: Answers = { ...answers };
+      if (value === undefined) {
+        delete next[questionId];
+      } else {
+        next[questionId] = value as
+          | string
+          | string[]
+          | number
+          | boolean
+          | Record<string, unknown>;
+      }
+      applyChange(next);
+    };
 
     const groups: QuestionGroup[] = (() => {
       const res: QuestionGroup[] = [];
@@ -129,24 +189,28 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
     const goNext = () => goTo(Math.min(activeSec + 1, groups.length - 1));
     const goPrev = () => goTo(Math.max(activeSec - 1, 0));
 
-    useEffect(() => {
-      setLocal(answers);
-    }, [answers]);
-
     const save = () => {
       if (Object.values(errors).some((e) => e)) {
         return;
       }
-      onChange(local);
+      onChange?.(answers);
       setOpen(false);
-      return local;
+      return answers;
     };
 
     useImperativeHandle(ref, () => ({
       save,
-      getAnswers: () => local,
-      load: (values: Answers) => setLocal(values ?? {}),
-      clear: () => setLocal({}),
+      getAnswers: () => draftStore.getState().answers,
+      load: (values: Answers) => {
+        const payload = values ?? {};
+        draftStore.getState().hydrate({ answers: payload, dirty: false });
+        lastHydratedRef.current = serializeAnswers(payload);
+      },
+      clear: () => {
+        const emptyAnswers = {} as Answers;
+        draftStore.getState().hydrate({ answers: emptyAnswers, dirty: false });
+        lastHydratedRef.current = serializeAnswers(emptyAnswers);
+      },
     }));
 
     const inlineForm = (
@@ -185,18 +249,8 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                 </Label>
                 <QuestionRenderer
                   question={q}
-                  value={local[q.id]}
-                  onChange={(v) =>
-                    setLocal({
-                      ...local,
-                      [q.id]: v as
-                        | string
-                        | number
-                        | boolean
-                        | string[]
-                        | Record<string, unknown>,
-                    })
-                  }
+                  value={answers[q.id]}
+                  onChange={(v) => updateAnswer(q.id, v)}
                   error={errors[q.id]}
                   setError={(msg) => setErrors((p) => ({ ...p, [q.id]: msg }))}
                 />
@@ -278,18 +332,8 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                         </Label>
                         <QuestionRenderer
                           question={q}
-                          value={local[q.id]}
-                          onChange={(v) =>
-                            setLocal({
-                              ...local,
-                              [q.id]: v as
-                                | string
-                                | number
-                                | boolean
-                                | string[]
-                                | Record<string, unknown>,
-                            })
-                          }
+                          value={answers[q.id]}
+                          onChange={(v) => updateAnswer(q.id, v)}
                           error={errors[q.id]}
                           setError={(msg) =>
                             setErrors((p) => ({ ...p, [q.id]: msg }))
@@ -352,8 +396,8 @@ export const DataEntry = forwardRef<DataEntryHandle, DataEntryProps>(
                           </Label>
                           <QuestionRenderer
                             question={q}
-                            value={local[q.id]}
-                            onChange={(v) => setLocal({ ...local, [q.id]: v })}
+                            value={answers[q.id]}
+                            onChange={(v) => updateAnswer(q.id, v)}
                             error={errors[q.id]}
                             setError={(msg) =>
                               setErrors((p) => ({ ...p, [q.id]: msg }))

--- a/frontend/src/components/bilan/SectionCard.tsx
+++ b/frontend/src/components/bilan/SectionCard.tsx
@@ -70,6 +70,7 @@ export function SectionCard({
             />
             <DataEntry
               questions={questions}
+              draftKey={{ bilanId: 'section-card', sectionId: section.id }}
               answers={answers}
               onChange={onAnswersChange}
             />

--- a/frontend/src/pages/BilanTypeBuilder.tsx
+++ b/frontend/src/pages/BilanTypeBuilder.tsx
@@ -1051,6 +1051,10 @@ export default function BilanTypeBuilder(props?: BilanTypeBuilderProps) {
                             apercuDataEntryRef as unknown as React.RefObject<DataEntryHandle>
                           }
                           questions={activeQuestions}
+                          draftKey={{
+                            bilanId: 'bilan-type-builder',
+                            sectionId: activeId ?? 'apercu',
+                          }}
                           answers={answers}
                           onChange={(a) => {
                             if (!activeId) return;

--- a/frontend/src/pages/CreationTrame.tsx
+++ b/frontend/src/pages/CreationTrame.tsx
@@ -939,6 +939,10 @@ export default function CreationTrame({
                 <DataEntry
                   inline
                   questions={questions}
+                  draftKey={{
+                    bilanId: 'creation-trame-preview',
+                    sectionId: 'preview',
+                  }}
                   answers={previewAnswers}
                   onChange={setPreviewAnswers}
                 />

--- a/frontend/src/store/draft.ts
+++ b/frontend/src/store/draft.ts
@@ -1,0 +1,117 @@
+import { useMemo } from 'react';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+import { useStore } from 'zustand';
+import type { Answers } from '@/types/question';
+
+export type DraftIdentifier = {
+  bilanId: string;
+  sectionId: string;
+};
+
+type DraftMetadata = {
+  answers: Answers;
+  dirty: boolean;
+  lastSavedHash: string | null;
+  version: number | null;
+  lastSavedAt: string | null;
+};
+
+type DraftActions = {
+  applyChange: (answers: Answers) => void;
+  hydrate: (initial: Partial<DraftMetadata>) => void;
+  markSaved: (params: { hash: string; version: number; savedAt?: string }) => void;
+};
+
+export type DraftStore = DraftMetadata & DraftActions;
+
+const stores = new Map<string, StoreApi<DraftStore>>();
+
+const emptyState: DraftMetadata = {
+  answers: {},
+  dirty: false,
+  lastSavedHash: null,
+  version: null,
+  lastSavedAt: null,
+};
+
+function createDraftStore(): StoreApi<DraftStore> {
+  return createStore<DraftStore>((set) => ({
+    ...emptyState,
+    applyChange: (answers) =>
+      set((state) => ({
+        ...state,
+        answers: { ...answers },
+        dirty: true,
+      })),
+    hydrate: (initial) =>
+      set((state) => ({
+        ...state,
+        answers:
+          initial.answers !== undefined
+            ? { ...initial.answers }
+            : state.answers,
+        dirty:
+          initial.dirty !== undefined
+            ? initial.dirty
+            : initial.answers !== undefined
+              ? false
+              : state.dirty,
+        lastSavedHash:
+          initial.lastSavedHash !== undefined
+            ? initial.lastSavedHash
+            : state.lastSavedHash,
+        version:
+          initial.version !== undefined ? initial.version : state.version,
+        lastSavedAt:
+          initial.lastSavedAt !== undefined
+            ? initial.lastSavedAt
+            : state.lastSavedAt,
+      })),
+    markSaved: ({ hash, version, savedAt }) =>
+      set((state) => ({
+        ...state,
+        dirty: false,
+        lastSavedHash: hash,
+        version,
+        lastSavedAt: savedAt ?? new Date().toISOString(),
+      })),
+  }));
+}
+
+function keyOf(identifier: DraftIdentifier): string {
+  return `${identifier.bilanId}::${identifier.sectionId}`;
+}
+
+export function getDraftStore(identifier: DraftIdentifier): StoreApi<DraftStore> {
+  const key = keyOf(identifier);
+  let store = stores.get(key);
+  if (!store) {
+    store = createDraftStore();
+    stores.set(key, store);
+  }
+  return store;
+}
+
+export function useDraftStore<T>(
+  identifier: DraftIdentifier,
+  selector: (state: DraftStore) => T,
+): T {
+  const store = useMemo(() => getDraftStore(identifier), [identifier.bilanId, identifier.sectionId]);
+  return useStore(store, selector);
+}
+
+export function resetDraftStores(): void {
+  stores.forEach((store) => {
+    const { applyChange, hydrate, markSaved } = store.getState();
+    store.setState(
+      {
+        ...emptyState,
+        applyChange,
+        hydrate,
+        markSaved,
+      },
+      true,
+    );
+  });
+  stores.clear();
+}


### PR DESCRIPTION
## Summary
- add a zustand-backed draft store to manage answers and metadata per {bilanId, sectionId}
- refactor DataEntry to use the draft store for hydration, updates, and imperative methods
- pass draft identifiers from DataEntry consumers and refresh tests with store helpers and an IntersectionObserver stub

## Testing
- `pnpm --filter frontend test -- DataEntry` *(fails: jsdom environment lacks IntersectionObserver and other app-wide stubs when running the full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d85d2fa5288329ae68599f2b3f079c