### PR TITLE
[frontend] Refactor wizard AI notes step

### DIFF
--- a/frontend/src/components/wizard-ia/BilanTypeNotesEditor.tsx
+++ b/frontend/src/components/wizard-ia/BilanTypeNotesEditor.tsx
@@ -5,6 +5,7 @@ import InlineGroupChips from '../bilan/InlineGroupChips';
 import { DataEntry, type DataEntryHandle } from '../bilan/DataEntry';
 import ImportNotes from '../ImportNotes';
 import type { Question, Answers } from '@/types/question';
+import type { DraftIdentifier } from '@/store/draft';
 
 interface NavItem {
   id: string;
@@ -27,6 +28,7 @@ interface BilanTypeNotesEditorProps {
   onNotesModeChange: (mode: 'manual' | 'import') => void;
   onRawNotesChange: (value: string) => void;
   onImageChange: (value: string | undefined) => void;
+  draftKey: DraftIdentifier;
 }
 
 export function BilanTypeNotesEditor({
@@ -42,6 +44,7 @@ export function BilanTypeNotesEditor({
   onNotesModeChange,
   onRawNotesChange,
   onImageChange,
+  draftKey,
 }: BilanTypeNotesEditorProps) {
   const activeSection = useMemo(
     () =>
@@ -118,6 +121,7 @@ export function BilanTypeNotesEditor({
           <DataEntry
             ref={dataEntryRef}
             questions={activeQuestions}
+            draftKey={draftKey}
             answers={answers}
             onChange={onAnswersChange}
             inline

--- a/frontend/src/components/wizard-ia/SectionNotesEditor.tsx
+++ b/frontend/src/components/wizard-ia/SectionNotesEditor.tsx
@@ -3,6 +3,7 @@ import { Tabs } from '@/components/ui/tabs';
 import { DataEntry, type DataEntryHandle } from '../bilan/DataEntry';
 import ImportNotes from '../ImportNotes';
 import type { Question, Answers } from '@/types/question';
+import type { DraftIdentifier } from '@/store/draft';
 
 interface SectionNotesEditorProps {
   sectionTitle: string;
@@ -14,6 +15,7 @@ interface SectionNotesEditorProps {
   onNotesModeChange: (mode: 'manual' | 'import') => void;
   onRawNotesChange: (value: string) => void;
   onImageChange: (value: string | undefined) => void;
+  draftKey: DraftIdentifier;
 }
 
 export function SectionNotesEditor({
@@ -26,6 +28,7 @@ export function SectionNotesEditor({
   onNotesModeChange,
   onRawNotesChange,
   onImageChange,
+  draftKey,
 }: SectionNotesEditorProps) {
   return (
     <div className="flex flex-1 h-full overflow-y-hidden flex-col">
@@ -50,6 +53,7 @@ export function SectionNotesEditor({
         <DataEntry
           ref={dataEntryRef}
           questions={questions}
+          draftKey={draftKey}
           answers={answers}
           onChange={onAnswersChange}
           inline


### PR DESCRIPTION
## Summary
- wire the new SectionNotesEditor and BilanTypeNotesEditor components into the wizard step 2 flow
- ensure both editors receive the draft key and callbacks they need to drive DataEntry state

## Testing
- `pnpm --filter frontend run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e1c3a2608329b7b5d4731e3c1227